### PR TITLE
Fix Clipboard format name retrieval loop

### DIFF
--- a/src/thirtytwo/Clipboard.cs
+++ b/src/thirtytwo/Clipboard.cs
@@ -92,6 +92,7 @@ public unsafe class Clipboard
                 if (count > buffer.Length - 2)
                 {
                     buffer.EnsureCapacity(buffer.Length * 2);
+                    continue;
                 }
 
                 return buffer.Slice(0, count).ToString();


### PR DESCRIPTION
Handle clipboard format name buffer resizing correctly by looping after expanding the buffer