### PR TITLE
Fix extended style retrieval

### DIFF
--- a/src/thirtytwo/WindowExtensions.cs
+++ b/src/thirtytwo/WindowExtensions.cs
@@ -598,7 +598,7 @@ public static unsafe partial class WindowExtensions
         (WindowStyles)window.GetWindowLong(WINDOW_LONG_PTR_INDEX.GWL_STYLE);
 
     public static ExtendedWindowStyles GetExtendedWindowStyle<T>(this T window) where T : IHandle<HWND> =>
-        (ExtendedWindowStyles)window.GetWindowLong(WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        (ExtendedWindowStyles)window.GetWindowLong(WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
 }
 
 /// <docs>https://learn.microsoft.com/windows/win32/api/winuser/nc-winuser-timerproc</docs>

--- a/src/thirtytwo_tests/Support/WindowExtensionTests.cs
+++ b/src/thirtytwo_tests/Support/WindowExtensionTests.cs
@@ -27,4 +27,11 @@ public class WindowExtensionTests
         window.SetWindowText("Golly");
         window.GetWindowText().Should().Be("Golly");
     }
+
+    [Fact]
+    public void GetExtendedWindowStyle_TopMost()
+    {
+        using Window window = new(Window.DefaultBounds, extendedStyle: ExtendedWindowStyles.TopMost);
+        window.GetExtendedWindowStyle().HasFlag(ExtendedWindowStyles.TopMost).Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- fix `GetExtendedWindowStyle` to use `GWL_EXSTYLE`
- add unit test for `GetExtendedWindowStyle`