### PR TITLE
Introduce GetText handling for CustomControl

### DIFF
--- a/src/thirtytwo/Controls/ActiveXControl.cs
+++ b/src/thirtytwo/Controls/ActiveXControl.cs
@@ -8,7 +8,7 @@ using Windows.Win32.System.Ole;
 
 namespace Windows;
 
-public unsafe partial class ActiveXControl : Control
+public unsafe partial class ActiveXControl : CustomControl
 {
     private static readonly WindowClass s_class = new(
         className: "ActiveXHostControlClass",

--- a/src/thirtytwo/Controls/ButtonControl.cs
+++ b/src/thirtytwo/Controls/ButtonControl.cs
@@ -5,7 +5,7 @@ using System.Drawing;
 
 namespace Windows;
 
-public partial class ButtonControl : Control
+public partial class ButtonControl : RegisteredControl
 {
     private static readonly WindowClass s_buttonClass = new(registeredClassName: "Button");
 

--- a/src/thirtytwo/Controls/CustomControl.cs
+++ b/src/thirtytwo/Controls/CustomControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Drawing;
 
 namespace Windows;
@@ -44,7 +47,7 @@ public class CustomControl : Control
         }
     }
 
-    protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    protected override unsafe LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
     {
         switch (message)
         {
@@ -68,20 +71,17 @@ public class CustomControl : Control
                 return (LRESULT)(_text?.Length ?? 0);
 
             case MessageType.GetText:
-                unsafe
+                int bufferLength = (int)(nint)wParam.Value;
+                char* buffer = (char*)lParam.Value;
+                string text = _text ?? string.Empty;
+                int copyLength = Math.Min(text.Length, Math.Max(bufferLength - 1, 0));
+                if (buffer is not null && bufferLength > 0)
                 {
-                    int bufferLength = (int)(nint)wParam.Value;
-                    char* buffer = (char*)lParam.Value;
-                    string text = _text ?? string.Empty;
-                    int copyLength = Math.Min(text.Length, Math.Max(bufferLength - 1, 0));
-                    if (buffer is not null && bufferLength > 0)
-                    {
-                        text.AsSpan(0, copyLength).CopyTo(new Span<char>(buffer, copyLength));
-                        buffer[copyLength] = '\0';
-                    }
-
-                    return (LRESULT)copyLength;
+                    text.AsSpan(0, copyLength).CopyTo(new Span<char>(buffer, copyLength));
+                    buffer[copyLength] = '\0';
                 }
+
+                return (LRESULT)copyLength;
         }
 
         return base.WindowProcedure(window, message, wParam, lParam);

--- a/src/thirtytwo/Controls/CustomControl.cs
+++ b/src/thirtytwo/Controls/CustomControl.cs
@@ -1,0 +1,89 @@
+using System.Drawing;
+
+namespace Windows;
+
+/// <summary>
+///  Base <see cref="Control"/> for custom window classes.
+/// </summary>
+public class CustomControl : Control
+{
+    private string? _text;
+
+    public CustomControl(
+        Rectangle bounds = default,
+        string? text = default,
+        WindowStyles style = WindowStyles.Overlapped | WindowStyles.Child | WindowStyles.Visible,
+        ExtendedWindowStyles extendedStyle = ExtendedWindowStyles.Default,
+        Window? parentWindow = default,
+        WindowClass? windowClass = default,
+        nint parameters = 0,
+        HMENU menuHandle = default,
+        Color backgroundColor = default,
+        Features features = default) : base(
+            bounds,
+            text,
+            style,
+            extendedStyle,
+            parentWindow,
+            windowClass,
+            parameters,
+            menuHandle,
+            backgroundColor,
+            features: features)
+    {
+        _text = text;
+    }
+
+    public string Text
+    {
+        get => _text ?? string.Empty;
+        set
+        {
+            this.SetWindowText(value);
+            _text = value;
+        }
+    }
+
+    protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    {
+        switch (message)
+        {
+            case MessageType.SetText:
+                if (lParam == 0)
+                {
+                    _text = null;
+                }
+                else
+                {
+                    Message.SetText setText = new(lParam);
+                    if (!setText.Text.Equals(_text, StringComparison.Ordinal))
+                    {
+                        _text = setText.Text.ToString();
+                    }
+                }
+
+                break;
+
+            case MessageType.GetTextLength:
+                return (LRESULT)(_text?.Length ?? 0);
+
+            case MessageType.GetText:
+                unsafe
+                {
+                    int bufferLength = (int)(nint)wParam.Value;
+                    char* buffer = (char*)lParam.Value;
+                    string text = _text ?? string.Empty;
+                    int copyLength = Math.Min(text.Length, Math.Max(bufferLength - 1, 0));
+                    if (buffer is not null && bufferLength > 0)
+                    {
+                        text.AsSpan(0, copyLength).CopyTo(new Span<char>(buffer, copyLength));
+                        buffer[copyLength] = '\0';
+                    }
+
+                    return (LRESULT)copyLength;
+                }
+        }
+
+        return base.WindowProcedure(window, message, wParam, lParam);
+    }
+}

--- a/src/thirtytwo/Controls/EditBase.cs
+++ b/src/thirtytwo/Controls/EditBase.cs
@@ -6,7 +6,7 @@ using Windows.Support;
 
 namespace Windows;
 
-public abstract class EditBase : Control
+public abstract class EditBase : CustomControl
 {
     protected EditBase(
         Rectangle bounds,

--- a/src/thirtytwo/Controls/EditControl.cs
+++ b/src/thirtytwo/Controls/EditControl.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Drawing;
+using Windows.Support;
 
 namespace Windows;
 
 /// <summary>
 ///  <see href="https://learn.microsoft.com/windows/win32/controls/edit-controls">Edit common control</see> wrapper.
 /// </summary>
-public partial class EditControl : EditBase
+public partial class EditControl : RegisteredControl
 {
     private static readonly WindowClass s_editClass = new("Edit");
 
@@ -21,12 +22,52 @@ public partial class EditControl : EditBase
         Window? parentWindow = default,
         nint parameters = default) : base(
             bounds,
-            s_editClass,
-            style |= (WindowStyles)editStyle,
             text,
+            style |= (WindowStyles)editStyle,
             extendedStyle,
             parentWindow,
+            s_editClass,
             parameters)
     {
+    }
+
+    /// <summary>
+    ///  Gets the total number of lines for the control. Never less than 1.
+    /// </summary>
+    public int LineCount => (int)this.SendMessage((MessageType)Interop.EM_GETLINECOUNT);
+
+    /// <summary>
+    ///  Gets the text for the specified <paramref name="lineNumber"/>. If the line doesn't exist, returns
+    ///  an empty <see langword="string"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   For single-line edit controls this always returns the entire text of the control. RichEdit controls
+    ///   will still listen to the <paramref name="lineNumber"/>, however.
+    ///  </para>
+    /// </remarks>
+    public unsafe string GetLine(int lineNumber)
+    {
+        int index = (int)this.SendMessage((MessageType)Interop.EM_LINEINDEX, (WPARAM)lineNumber);
+        if (index < 0)
+        {
+            return string.Empty;
+        }
+
+        int lineLength = (int)this.SendMessage((MessageType)Interop.EM_LINELENGTH, (WPARAM)index);
+
+        if (lineLength == 0)
+        {
+            return string.Empty;
+        }
+
+        using var buffer = new BufferScope<char>(stackalloc char[256], lineLength);
+
+        fixed (char* c = buffer)
+        {
+            *(ushort*)c = (ushort)buffer.Length;
+            int copied = (int)this.SendMessage((MessageType)Interop.EM_GETLINE, (WPARAM)lineNumber, (LPARAM)c);
+            return buffer[..copied].ToString();
+        }
     }
 }

--- a/src/thirtytwo/Controls/RegisteredControl.cs
+++ b/src/thirtytwo/Controls/RegisteredControl.cs
@@ -1,0 +1,39 @@
+using System.Drawing;
+
+namespace Windows;
+
+/// <summary>
+///  Base <see cref="Control"/> for controls that use registered window classes.
+/// </summary>
+public class RegisteredControl : Control
+{
+    public RegisteredControl(
+        Rectangle bounds = default,
+        string? text = default,
+        WindowStyles style = WindowStyles.Overlapped | WindowStyles.Child | WindowStyles.Visible,
+        ExtendedWindowStyles extendedStyle = ExtendedWindowStyles.Default,
+        Window? parentWindow = default,
+        WindowClass? windowClass = default,
+        nint parameters = 0,
+        HMENU menuHandle = default,
+        Color backgroundColor = default,
+        Features features = default) : base(
+            bounds,
+            text,
+            style,
+            extendedStyle,
+            parentWindow,
+            windowClass,
+            parameters,
+            menuHandle,
+            backgroundColor,
+            features: features)
+    {
+    }
+
+    public string Text
+    {
+        get => this.GetWindowText();
+        set => this.SetWindowText(value);
+    }
+}

--- a/src/thirtytwo/Controls/RegisteredControl.cs
+++ b/src/thirtytwo/Controls/RegisteredControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Drawing;
 
 namespace Windows;

--- a/src/thirtytwo/Controls/StaticControl.cs
+++ b/src/thirtytwo/Controls/StaticControl.cs
@@ -5,7 +5,7 @@ using System.Drawing;
 
 namespace Windows;
 
-public partial class StaticControl : Control
+public partial class StaticControl : RegisteredControl
 {
     private static readonly WindowClass s_buttonClass = new(registeredClassName: "Static");
 

--- a/src/thirtytwo/Controls/TextLabelControl.cs
+++ b/src/thirtytwo/Controls/TextLabelControl.cs
@@ -7,7 +7,7 @@ using Windows.Win32.Graphics.DirectWrite;
 
 namespace Windows;
 
-public class TextLabelControl : Control
+public class TextLabelControl : CustomControl
 {
     private static readonly WindowClass s_textLabelClass = new(className: "TextLabelClass");
 

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -365,7 +365,6 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
                 break;
 
-
             case MessageType.DpiChanged:
                 {
                     // Resize and reposition for the new DPI
@@ -418,8 +417,6 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             return true;
         });
     }
-
-
 
     /// <summary>
     ///  Try to get the <see cref="Window"/> from the given <paramref name="handle"/>. Walks parent windows

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -48,7 +48,6 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
     protected HwndRenderTarget RenderTarget => _renderTarget ?? throw new InvalidOperationException();
 
-    private string? _text;
     private uint _lastDpi;
     private Color _backgroundColor;
     private HBRUSH _backgroundBrush;
@@ -93,7 +92,6 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             bounds = DefaultBounds;
         }
 
-        _text = text;
         _features = features;
         _backgroundColor = backgroundColor;
 
@@ -367,24 +365,6 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
                 break;
 
-            case MessageType.SetText:
-                // Update our cached text if necessary
-
-                if (lParam == 0)
-                {
-                    _text = null;
-                }
-                else
-                {
-                    Message.SetText setText = new(lParam);
-                    if (!setText.Text.Equals(_text, StringComparison.Ordinal))
-                    {
-                        _text = setText.Text.ToString();
-                    }
-                }
-
-                // The default proc actually sets the text, so we shouldn't return from here
-                break;
 
             case MessageType.DpiChanged:
                 {
@@ -439,15 +419,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
         });
     }
 
-    public string Text
-    {
-        get => _text ?? string.Empty;
-        set
-        {
-            this.SetWindowText(value);
-            _text = value;
-        }
-    }
+
 
     /// <summary>
     ///  Try to get the <see cref="Window"/> from the given <paramref name="handle"/>. Walks parent windows

--- a/src/thirtytwo_tests/Controls/CustomControlTests.cs
+++ b/src/thirtytwo_tests/Controls/CustomControlTests.cs
@@ -1,0 +1,52 @@
+using Windows.Win32.Foundation;
+
+namespace Windows.Controls;
+
+public unsafe class CustomControlTests
+{
+    [Fact]
+    public void TextProperty_RoundTrip()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using CustomControl control = new(Window.DefaultBounds, text: "Foo", parentWindow: window);
+
+        control.Text.Should().Be("Foo");
+        control.Text = "Bar";
+        control.Text.Should().Be("Bar");
+        control.GetWindowText().Should().Be("Bar");
+    }
+
+    [Fact]
+    public unsafe void SetTextMessage_UpdatesText()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using CustomControl control = new(Window.DefaultBounds, parentWindow: window);
+
+        const string MessageText = "FromMessage";
+        fixed (char* c = MessageText)
+        {
+            control.SendMessage(MessageType.SetText, 0, (LPARAM)c);
+        }
+
+        control.Text.Should().Be(MessageText);
+        control.GetWindowText().Should().Be(MessageText);
+    }
+
+    [Fact]
+    public unsafe void GetTextMessage_ReturnsText()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using CustomControl control = new(Window.DefaultBounds, text: "Hello", parentWindow: window);
+
+        int length = (int)control.SendMessage(MessageType.GetTextLength);
+        length.Should().Be(5);
+
+        using var buffer = new BufferScope<char>(stackalloc char[length + 1]);
+        fixed (char* c = buffer)
+        {
+            int copied = (int)control.SendMessage(MessageType.GetText, (WPARAM)buffer.Length, (LPARAM)c);
+            copied.Should().Be(length);
+            buffer[..copied].ToString().Should().Be("Hello");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds hierarchy to `Control` to move text handling to `CustomControl `and avoid custom behavior for existing `Control`s via `RegisteredControl`.

- handle `WM_GETTEXT` and `WM_GETTEXTLENGTH` in `CustomControl`
- add `CustomControlTests` verifying text property and text message behaviour