### PR TITLE
Vendor shared agent skills

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -1,0 +1,73 @@
+# Agent Skills format reference
+
+This file defines the downstream conventions for `.agents/skills/`. See
+[README.md](README.md) for the installed inventory and selection boundary.
+
+## Layout
+
+```text
+.agents/skills/
+  README.md
+  FORMAT.md
+  <skill-name>/
+    SKILL.md
+    overlay.md
+    <vendored resources>
+```
+
+The directory name must match the `name` field in `SKILL.md` exactly.
+
+## Vendored cores
+
+A core installed from the commons includes source tracking in frontmatter:
+
+```yaml
+metadata:
+  github-path: skills/<skill-name>
+  github-pinned: vX.Y.Z
+  github-ref: refs/tags/vX.Y.Z
+  github-repo: https://github.com/JeremyKuhne/agent-skills
+  github-tree-sha: <tree-sha>
+```
+
+The core and its bundled siblings are immutable mirrors of that pin. Do not
+edit them directly. Reinstall from a reviewed immutable release when updating.
+
+## Local overlays
+
+Repository-specific paths, commands, examples, cross-references, and policy
+belong in `overlay.md` beside the core:
+
+```markdown
+---
+core: skill-name
+core-pin: vX.Y.Z
+---
+
+# Skill name overlay
+```
+
+The `core` value must match the directory name. Update `core-pin` only after
+reviewing the overlay against the new core.
+
+## Catalog
+
+Every installed skill must have one row in [README.md](README.md) describing
+why it applies here and what its overlay binds. Record project-gated and
+TFM-specific exclusions so future additions are deliberate.
+
+## Markdown
+
+- Use relative links for repository files.
+- Do not use HTML entities; write the character directly or use plain words.
+- Do not use tabs, trailing whitespace, or whitespace-only lines.
+- Give every fenced code block a language tag.
+- End every file with one newline.
+
+## Validation
+
+```pwsh
+pwsh -NoProfile -File .agents/skills/manage-skills/scripts/Validate-Skills.ps1 .agents/skills -RequirePortfolioMetadata
+Get-ChildItem .agents/skills -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'SKILL.md') } | ForEach-Object { npx --yes skills-ref@0.1.5 validate $_.FullName }
+git diff --check
+```

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,99 @@
+# thirtytwo agent skills
+
+This repository carries 13 portable skill cores from the
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills)
+commons, pinned to the immutable `v0.11.0` release. The installed core files
+carry `metadata.github-*` provenance injected by `gh skill install` and must
+remain exact upstream mirrors. Repository-specific paths and conventions live
+in each sibling `overlay.md`.
+
+## Inventory
+
+| Skill | Use in thirtytwo | Local binding |
+| --- | --- | --- |
+| [address-pr-feedback](address-pr-feedback/SKILL.md) | Address review comments and CI failures on an existing PR. | Uses the repository's Windows build and test gates. |
+| [agent-files-review](agent-files-review/SKILL.md) | Review skills, overlays, and other agent customization files. | Validates this catalog with the bundled strict validator. |
+| [code-comprehension](code-comprehension/SKILL.md) | Review complex Win32, COM, lifetime, and partial-type code for readability. | Treats ownership and ABI details as essential complexity. |
+| [create-pr](create-pr/SKILL.md) | Publish reviewed work as a new PR. | Targets `main` after the local build, test, and skill gates pass. |
+| [cswin32-com](cswin32-com/SKILL.md) | Work on raw struct-based COM, CCWs, vtables, and COM lifetime. | Binds to thirtytwo's `ComScope<T>`, `IID`, and `CustomComWrappers` implementations. |
+| [cswin32-interop](cswin32-interop/SKILL.md) | Work on CsWin32 projections, native signatures, ownership, and size units. | Binds to the library's `NativeMethods` configuration and public `Interop` extender. |
+| [engineering-baseline](engineering-baseline/SKILL.md) | Audit repository engineering and supply-chain practices. | Assesses the existing Windows-only repository; it does not scaffold over it. |
+| [github-actions-cost-optimization](github-actions-cost-optimization/SKILL.md) | Analyze GitHub Actions cost without weakening required checks. | Preserves the Windows runner required by product and test behavior. |
+| [il-copy-inspection](il-copy-inspection/SKILL.md) | Inspect emitted IL for copies and boxing of structs and ref structs. | Focuses on handles, COM scopes, message views, and buffer scopes. |
+| [manage-skills](manage-skills/SKILL.md) | Find, add, update, and reconcile skills. | Owns the pinned-core plus local-overlay lifecycle for this catalog. |
+| [pre-pr-self-review](pre-pr-self-review/SKILL.md) | Review the working diff before publishing. | Runs Debug and Release checks and invokes security review for unsafe changes. |
+| [scratch-buffer-strategy](scratch-buffer-strategy/SKILL.md) | Choose among stack, pooled, and heap scratch buffers. | Binds to `StackBufferScope16<T>`, `ValueBuffer<T>`, and the modern-only TFM. |
+| [security-review](security-review/SKILL.md) | Audit unsafe code, native boundaries, malformed input, and resource ownership. | Uses the mirrored product/test layout and Windows interop threat surface. |
+
+## Selection boundary
+
+The .NET Framework-only skills (`dotnet-polyfills` and
+`framework-jit-optimization`) are not installed because thirtytwo targets only
+`net10.0-windows`. `scratch-buffer-strategy` is retained despite its broader
+cross-TFM backing data because this repository directly owns stack-backed and
+pooled buffer abstractions.
+
+The project-gated `performance-testing`, `fuzz-testing`, and
+`roslyn-analyzers` skills are not installed because the repository has no perf,
+fuzz, or analyzer project. Add the corresponding project as a separate,
+reviewed prerequisite before vendoring one of those cores.
+
+## Disambiguation
+
+### CsWin32 interop and COM
+
+- Use `cswin32-interop` for generated functions, structs, constants, handles,
+  native allocation, byte/element accounting, and `NativeMethods` settings.
+- Use `cswin32-com` for COM interfaces, IIDs, vtables, activation, CCWs,
+  connection points, and reference lifetime.
+- When a change touches both, apply the general interop rules first and then
+  the COM-specific rules.
+
+### Review and publishing
+
+- Use `pre-pr-self-review` before any initial publish.
+- Use `create-pr` when no PR exists for the branch.
+- Use `address-pr-feedback` after review comments or CI results exist.
+- Run `security-review` alongside the pre-PR review for unsafe, pointer,
+  marshalling, parsing, or caller-supplied input changes.
+
+### Skill lifecycle and validation
+
+- Use `manage-skills` to discover, vendor, update, or reconcile a skill.
+- Use `agent-files-review` to validate the resulting customization files.
+
+### Repository and workflow audits
+
+- Use `engineering-baseline` for a whole-repository assessment.
+- Use `github-actions-cost-optimization` for runner time and workflow cost
+  specifically.
+
+### Struct and buffer analysis
+
+- Use `scratch-buffer-strategy` to choose the storage design.
+- Use `il-copy-inspection` to inspect what the compiler emitted.
+- Use `security-review` to verify pointer, length, ownership, and cleanup
+  preconditions.
+
+## Updating
+
+Reinstall each reviewed core from one immutable release, preserving its local
+overlay:
+
+```pwsh
+gh skill install JeremyKuhne/agent-skills skills/<name> --pin vX.Y.Z --agent github-copilot --scope project --force
+```
+
+Install `cswin32-interop` before `cswin32-com`, update every affected
+overlay's `core-pin`, and review the resulting diff. Never hand-edit a vendored
+core to resolve drift.
+
+## Validation
+
+Run the bundled strict validator and the reference specification validator:
+
+```pwsh
+pwsh -NoProfile -File .agents/skills/manage-skills/scripts/Validate-Skills.ps1 .agents/skills -RequirePortfolioMetadata
+Get-ChildItem .agents/skills -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'SKILL.md') } | ForEach-Object { npx --yes skills-ref@0.1.5 validate $_.FullName }
+git diff --check
+```

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,0 +1,133 @@
+---
+compatibility: Requires git and either a GitHub integration or authenticated gh for remote pull-request operations.
+description: Address feedback on an existing pull request - review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/address-pr-feedback
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
+    maturity: canary
+    portability: portable
+    related: create-pr, pre-pr-self-review, agent-files-review
+    requires: none
+    risk: remote-write
+name: address-pr-feedback
+---
+# Address PR feedback
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+This skill is the post-PR counterpart to the `create-pr` skill. Both share the
+**same** publish gate: neither `git commit` nor `git push` runs without an
+explicit publishing verb from the user. The difference is what each skill
+authorizes you to *edit*:
+
+- `create-pr` authorizes preparing a new PR from in-progress work -
+  branching, staging, proposing a commit message. The commit and push
+  still wait on approval.
+- This skill authorizes editing files in response to review feedback or
+  CI failures on an existing PR. Same approval gate before commit/push.
+
+Your repo's agent guidance (the "Working with the user on changes" rules in
+`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
+at the start of every invocation; this skill is the decision-point reminder, not
+a replacement.
+
+## Recognizing approval
+
+Carefully read the most recent user message and identify whether it
+contains an explicit publishing verb before you stage, commit, or push.
+Pattern-match the words, do not infer intent.
+
+**Approval** - verbs that authorize publishing the current change:
+`commit`, `push`, `update the PR`, `ship it`, `send it`, `yes push`, or
+direct synonyms when paired with a publishing intent.
+
+**Not approval** - everything else, including these phrasings that
+have repeatedly caused violations:
+
+- "Address the review comments." / "Reply to the comments on the PR." /
+  "Fix the comments / fix the CI failure."
+- "Look at Copilot's feedback / see what they said."
+- "See what you can do about this." / "Try a different approach."
+- "Do the next step" / "finish the rollout" / "go ahead to the next
+  thing" / a bare "go ahead" attached to a task description.
+- A reviewer (human or Copilot) leaving a new comment, or a failing
+  check on the PR.
+
+If you are uncertain whether a phrase is approval, **it is not approval**.
+Stop and ask one short yes/no question.
+
+## Workflow
+
+1. **Fetch the feedback.** Read review comments, PR conversation, and check-run
+   logs via the GitHub PR tools (or `Invoke-RestMethod` against
+   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`). With multiple
+   review passes, fetch the **latest** review's comments (filter by the newest
+   review id) so you act on the current round.
+
+   Automated reviewers (e.g. Copilot) post asynchronously - on open, on push, or
+   when requested - a minute or two after the trigger. If one was requested but
+   hasn't posted, say so and act when the user reports comments (or check once);
+   don't poll. Verify their comments per step 2 - they produce confident false
+   positives.
+2. **Plan, and verify each comment.** Don't fix something just because a reviewer
+   (especially a bot) flagged it: confirm the claim against the code, and prove
+   it when checkable (a REPL check, a build, a test) - a fix to a false positive
+   can introduce the bug the reviewer imagined. Classify each:
+   - **Valid** - real issue; fix it.
+   - **Nit** - minor; fix if cheap, else note it.
+   - **Out of scope** - plan a written reply.
+   - **False positive / disagree** - plan a written explanation, not a change.
+3. **Edit files.** Make the code changes. Run the build and any relevant
+   tests. The applicable validation rules are still the `pre-pr-self-review`
+   checklist - a follow-up round needs the same checks as the initial PR.
+4. **Stop. Describe.** Summarize what you changed, why, and what (if
+   anything) you chose not to act on. Do **not** run `git add`, `git
+   commit`, or `git push`.
+5. **Wait** for an explicit publishing verb (see "Recognizing approval"
+   above).
+6. **Only then** stage by path, commit with a message that summarizes the
+   round of changes, and push. The staging/commit/push mechanics are the
+   same as in the `create-pr` skill (its "Commit changes" and "Push the
+   branch" steps).
+7. **Resolve the threads, with explanations.** Replying and resolving are remote
+   actions, so they ride in the same approved publish step as the push; honor
+   explicit scoping ("push and resolve only", "don't re-request") and report
+   what you did. For each comment, reply then resolve:
+   - **Fixed** - one line on what changed (reference the commit or behavior).
+   - **False positive / won't-fix** - the rationale or the evidence. Leave a
+     thread open only to invite a human onto a contested point, and say so.
+   With the PR tool, use its resolve action; with `gh`, resolve via the GraphQL
+   `resolveReviewThread` mutation on the thread node id (not the comment id).
+8. **Re-request review when non-trivial.** After real code changes, request a
+   fresh pass from the same reviewer - also a remote action in the publish step.
+   Skip it for trivial rounds (typo, reword, one-line nit) to avoid an endless
+   trickle, and say which you did.
+
+**When to stop.** Later auto-review passes drift toward nits and false positives.
+Once comments stop being substantive, stop re-requesting, say so, and let the
+user merge.
+
+## When you've already violated the rule
+
+Acknowledge the violation directly without minimizing. Do **not** push a
+follow-up commit to "fix" the situation without explicit approval -
+that compounds the failure. The user decides whether to revert,
+force-push, or leave the commit in place.
+
+## Related
+
+- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- The `create-pr` skill - opening the initial PR (same publish gate,
+  different edit scope).
+- The `pre-pr-self-review` skill - the validation checklist that applies
+  to both initial and follow-up rounds.
+- The `agent-files-review` skill - for a CI failure from the *agent-files*
+  workflow specifically; its checklist owns the frontmatter, mirror, and
+  link rules.

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,0 +1,24 @@
+---
+core: address-pr-feedback
+core-pin: v0.11.0
+---
+
+# Address PR feedback overlay
+
+Repository-specific bindings for thirtytwo.
+
+- Read all unresolved review threads and the Windows build status before
+  editing. The workflow is
+  [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml).
+- Re-run the narrowest check that reproduces a finding, then run the Release
+  build and tests before marking the work complete:
+
+```pwsh
+dotnet build --configuration Release
+dotnet test --configuration Release --no-build --report-trx
+```
+
+- Re-run [pre-pr-self-review](../pre-pr-self-review/SKILL.md) after substantive
+  fixes and [agent-files-review](../agent-files-review/SKILL.md) after changes
+  under `.agents/`.
+- Keep edits local until the user explicitly approves commit or push actions.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -1,0 +1,156 @@
+---
+compatibility: Requires the repository's validator and relative-link check; exact commands may be supplied by an overlay.
+description: Review changes to AI-agent customization files (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, the validator, the CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from the agent-files workflow, or audit a draft of any of these files.
+license: MIT
+metadata:
+    applicability: agent-customization
+    binding: optional-overlay
+    github-path: skills/agent-files-review
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
+    maturity: canary
+    portability: portable
+    related: manage-skills
+    requires: none
+    risk: local-write
+name: agent-files-review
+---
+# Agent customization files - review checklist
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Run through every applicable item below before approving a change to an agent
+customization file. Each item below caught a real bug in PR review history.
+
+This skill assumes the repository has adopted the agent-file scaffold: an
+`AGENTS.md` single-source with a generated `.github/copilot-instructions.md`
+mirror, a validator script (conventionally `tools/Validate-AgentFiles.ps1`), a
+relative-link checker (conventionally `tools/Test-AgentFileLinks.ps1`), and a CI
+workflow (conventionally `.github/workflows/agent-files.yml`) running markdownlint
+plus an offline lychee link check. A consuming repo wires the exact paths in its
+overlay.
+
+## 1. AGENTS.md / `.github/copilot-instructions.md`
+
+- The mirror is generated. **Never edit `.github/copilot-instructions.md` by hand.**
+  Edits go in `AGENTS.md`, then regenerate the mirror with the validator's
+  fix mode.
+- Run the validator after any `AGENTS.md` edit. The agent-files CI workflow
+  enforces this; out-of-sync mirrors fail CI.
+- **Relative Markdown links must work in both `AGENTS.md` and the mirror.** The
+  generator rewrites them automatically (`.github/x` → `x`, other paths get
+  `../` prepended). Don't pre-rewrite links by hand. Don't add absolute
+  filesystem paths or `./` prefixes that would defeat the regex.
+- Don't use end-of-line comments in `AGENTS.md` examples or anywhere else; the
+  file itself bans the pattern. Same applies to YAML examples in the README
+  files for `.github/agents/`, `.github/prompts/`, etc. - put `# comment`
+  lines above the field, not after it.
+- Watch for placeholder syntax in code examples (e.g.
+  `<see langword=".."/>`). Use a recognizable ellipsis (`"..."`) or a real
+  example value.
+- Run a grammar pass: singular vs. plural ("extension methods"),
+  "for your needs" not "for your need", etc.
+
+## 2. Per-file frontmatter and naming
+
+The frontmatter and naming rules for each file type - `*.instructions.md`,
+`*.agent.md`, `SKILL.md`, and `*.prompt.md` - live in
+[frontmatter.md](frontmatter.md). Check the entry for the file type you touched.
+
+## 3. Validator and workflow
+
+- The frontmatter parser in the validator script is typically hand-rolled. A
+  hand-rolled parser supports flat scalars, inline lists, and block lists, but
+  **not** nested mappings, multi-line strings, anchors, or flow mappings. If a
+  contributor needs those, switch to a real YAML module (e.g.
+  `powershell-yaml`) rather than extending the regex.
+- The mirror generator preserves `AGENTS.md`'s on-disk line endings (LF or
+  CRLF) so `core.autocrlf=true` doesn't cause spurious diffs on Windows
+  checkouts.
+- The markdownlint config typically disables MD013 (line-length), MD022/MD032
+  (blanks-around), MD033 (inline HTML), MD041 (first-line heading), and keeps
+  MD040 (fenced-code-language), no-trailing-spaces, no-hard-tabs. Don't disable
+  MD040 - adding a `text` language tag is trivial and prevents drift.
+- The CI job typically runs on `ubuntu-latest`. PowerShell is preinstalled
+  there; no `pip` step is needed.
+- A commons repository should validate source `skills/*/SKILL.md`, not only a
+  consumer's `.agents/skills/` directory. Treat a conditional that silently
+  skips a populated source tree as a broken gate.
+- Validate agent frontmatter, plugin/marketplace/MCP manifests, relationship
+  names, and generated catalogs in addition to skill frontmatter. Then install
+  each core alone (plus declared `requires`) and resolve links inside that
+  artifact; a repo-wide link check cannot catch undeclared sibling dependencies.
+
+## 4. Relative Markdown links must resolve in this branch
+
+The CI link check is **offline lychee** - it only follows links that
+resolve to files in the current working tree. A link to a file that exists
+on the canonical repo's `main` but not in your branch will fail.
+
+- **Before opening a PR with agent-file changes, run the link checker.**
+  Without arguments, it scans every Markdown file in CI's lychee scope and
+  reports any relative link whose target doesn't exist on disk. It typically
+  auto-detects the PR base ref: `upstream/main` if a remote literally named
+  `upstream` exists (the fork-PR workflow, where `origin` is your fork and
+  `upstream` is the canonical repo), `origin/main` otherwise (working directly
+  on a clone of the canonical repo). A changed-only mode and an explicit
+  base-ref override are the usual options.
+- **If you cite files added by a different in-flight or just-merged PR,
+  rebase your branch on the canonical `main`** (`upstream/main` from a
+  fork, or `origin/main` from a direct clone) so those files exist
+  locally. A recurring review-round loss comes from exactly this scenario:
+  the branch predated a sister PR that added the referenced source files,
+  so every cross-reference to them failed lychee even though those files
+  existed on the canonical `main`.
+- The lychee check runs against the merged tree on `main` only after a
+  push, so a stale branch can still ship broken links into your PR. Treat
+  rebase-then-link-audit as a single step before pushing any agent-file
+  change that references code added elsewhere.
+- Don't downgrade a real link to backticks just to silence the checker.
+  Either fix the link or rebase. Backtick references work as a last resort
+  when the file truly does not exist in any branch yet.
+
+## 5. Whitespace (applies to every file in scope)
+
+- No trailing whitespace.
+- No whitespace-only lines (a "blank" line must be truly empty).
+- Tabs are forbidden in Markdown bodies.
+- **Files must end with a single newline character** (markdownlint MD047).
+  The validator flags a *missing* trailing newline (it checks the file ends
+  with `\n`, not that there is exactly one); markdownlint enforces the full
+  single-newline rule in CI. New files
+  created via the standard editor tooling get this for free, but
+  hand-edited or copy-pasted content sometimes loses the final `\n`.
+- These rules are enforced both by the validator and by markdownlint.
+
+## How to run the checks locally
+
+**Always run the validator before declaring a review complete or pushing
+agent-file changes.** It catches mirror drift, missing/invalid frontmatter,
+`SKILL.md` naming mistakes, missing trailing newlines, and trailing/empty-line
+whitespace - the same rules CI enforces. Run it in plain mode to validate, and
+in fix mode (`-Fix`) to regenerate the mirror after editing `AGENTS.md`.
+
+The validator does **not** reproduce markdownlint's full rule set. After it
+passes, sanity-check that your Markdown:
+
+- ends with exactly one newline (MD047);
+- has a language tag on every fenced code block, e.g. \`\`\`text or \`\`\`yaml
+  (MD040);
+- doesn't use tabs (no-hard-tabs).
+
+If CI fails after a local validator pass, the failure is almost always
+markdownlint (open the failing job's annotations) or the lychee link check
+(broken relative link - remember the mirror rewrites links, so test
+the form in `AGENTS.md`, not the rewritten copy).
+
+For a commons portfolio, use strict mode and check generated collateral:
+
+```pwsh
+./skills/manage-skills/scripts/Validate-Skills.ps1 ./skills -RequirePortfolioMetadata
+./tools/Update-SkillCatalog.ps1
+Invoke-Pester ./tests
+```

--- a/.agents/skills/agent-files-review/frontmatter.md
+++ b/.agents/skills/agent-files-review/frontmatter.md
@@ -1,0 +1,62 @@
+# Agent-file frontmatter and naming
+
+Per-file-type frontmatter and naming rules for the `agent-files-review`
+checklist. Check the entry for the file type you changed; the operational
+workflow (mirror, links, validator, whitespace) stays in [SKILL.md](SKILL.md).
+
+## `*.instructions.md` (path-specific instructions)
+
+- Frontmatter must include a non-empty `applyTo` glob.
+- Glob is comma-separated, relative to repo root. Quote the value for safety.
+- The validator only checks `applyTo`'s presence and emptiness; it does not
+  verify that the glob actually matches anything. Sanity-check by eye.
+
+## `*.agent.md` (custom agents)
+
+- Frontmatter must include `description`.
+- If `tools` is present, it must be a YAML list. Either form is accepted by
+  the validator:
+
+  ```yaml
+  tools: ['search', 'edit']
+  ```
+
+  ```yaml
+  tools:
+    - search
+    - edit
+  ```
+
+- Use VS Code's current tool names: bare tool-set names (`search`, `read`,
+  `edit`, `web`) or namespaced `<set>/<tool>` members (`read/problems`,
+  `web/fetch`, `search/usages`, `search/changes`). The legacy flat names
+  (`usages`, `problems`, `changes`, `fetch`) still resolve but raise an
+  info-level "renamed" notice in VS Code, so prefer the current form. A bare
+  tool-set name already includes its members (e.g. `search` covers
+  `search/usages` and `search/changes`).
+- The repo's authoring rules forbid end-of-line comments; document optional
+  fields with comment lines *above* them in any examples.
+
+## `SKILL.md` (`.agents/skills/<name>/SKILL.md`)
+
+- `name` is **required** and must:
+  - be 1-64 chars of lowercase letters/digits (Unicode allowed) and hyphens,
+    with no leading, trailing, or consecutive hyphen
+  - equal the parent directory name exactly
+- `description` is required; make it specific enough that another agent
+  can decide when to load it.
+- Shared portfolio cores also require string-valued `metadata.portability`,
+  `metadata.applicability`, `metadata.binding`, `metadata.risk`,
+  `metadata.maturity`, `metadata.requires`, and `metadata.related`. Use the
+  repository's `FORMAT.md` vocabulary; relationship names must resolve and the
+  required graph must remain acyclic.
+- For `optional-overlay` or `required-overlay`, keep the standard loader sentence
+  in the core. An `overlay.md` starts with `core` and `core-pin`; `core` matches
+  the directory, and a required overlay must exist.
+- A name/dir mismatch causes the skill to silently fail to load. Always
+  verify by running both the strict bundled validator and `skills-ref`.
+
+## `*.prompt.md` (reusable prompts)
+
+- No required frontmatter, but `description` is recommended for the slash
+  menu UX.

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,0 +1,26 @@
+---
+core: agent-files-review
+core-pin: v0.11.0
+---
+
+# Agent files review overlay
+
+Repository-specific bindings for thirtytwo.
+
+The current agent surface is `.agents/skills/`. This repository has not adopted
+an `AGENTS.md` plus `.github/copilot-instructions.md` mirror or a dedicated
+agent-files workflow, so do not claim those gates exist. If that scaffold is
+added later, update this overlay with its exact commands.
+
+Validate the installed portfolio with:
+
+```pwsh
+pwsh -NoProfile -File .agents/skills/manage-skills/scripts/Validate-Skills.ps1 .agents/skills -RequirePortfolioMetadata
+Get-ChildItem .agents/skills -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'SKILL.md') } | ForEach-Object { npx --yes skills-ref@0.1.5 validate $_.FullName }
+git diff --check
+```
+
+Review local files against the [format contract](../FORMAT.md) and keep the
+[catalog](../README.md) synchronized with the skill directories. Vendored core
+files must match their `metadata.github-*` provenance; local changes belong in
+overlays.

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -1,0 +1,89 @@
+---
+description: Evidence-based readability and cognitive-load review of code. Use when asked to "review this for readability", "is this too complex", "reduce nesting or cognitive load", "what is a reasonable method length / parameter count / nesting depth", or when judging whether code will be hard to understand. Screens code against research-backed thresholds and prioritizes the factors that actually drive comprehension - naming first, then structure that loads working memory.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/code-comprehension
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review
+    requires: none
+    risk: advisory
+name: code-comprehension
+---
+# Code comprehension review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+A research-backed screen for how hard code is to *understand* (not how hard it is
+to test). Four decades of studies - including recent eye-tracking, EEG, and fMRI
+work - converge on a few high-confidence rules. Lead with those; treat the
+threshold numbers as **screening heuristics, not hard limits**, and let a
+consuming repo's own style guide or `.editorconfig` win on any conflict.
+
+## The high-confidence rules (apply these first)
+
+1. **Naming is the #1 factor.** Across 40 years of studies, identifier quality
+   beats every structural metric. **Misleading names are worse than meaningless
+   ones.** Fix misleading or cryptic names before touching anything else; prefer
+   full words over abbreviations.
+2. **Cognitive load comes from working memory, not path count.** Deep nesting,
+   long parameter lists, and dense data-flow (many live variables a reader must
+   track) strain comprehension. McCabe's cyclomatic complexity is a weak proxy
+   for human effort - use it for testing, not readability.
+3. **Indentation and layout matter a lot.** Consistent indentation roughly
+   *halves* reading time versus unindented control flow; blank lines between
+   logical chunks help.
+4. **Complexity perception saturates.** Past a point (around cognitive complexity
+   15) more complexity barely changes perceived difficulty - so spend effort
+   *avoiding the extremes*, not micro-optimizing already-simple code.
+5. **Small reviews work.** Review effectiveness drops faster than linearly with
+   size; keep a change under roughly 200 lines so a reviewer can read it linearly.
+
+## Screening thresholds
+
+Flag for review at "Review", refactor at "Refactor". Values between "Low" and "Review" are "moderate" — usually acceptable, but worth a quick "why" check.
+Numbers aggregate research and industry-tool convergence; adjust to the team and language.
+
+| Factor | Low | Review | Refactor | Measure |
+| --- | --- | --- | --- | --- |
+| Nesting depth | 1-2 | 4-5 | >=6 | max nested control blocks |
+| Cognitive complexity (Sonar) | <=5 | 11-15 | >=16 | rule-based, penalizes nesting |
+| Method length | <=20 | 51-100 | >100 | SLOC (no blanks/comments) |
+| Parameter count | <=3 | 6-8 | >=9 | params per method |
+| Boolean terms in an expression | <=2 | 5-6 | >=7 | operands / sub-expressions |
+| Line length | <=80 | 101-120 | >=121 | columns |
+| Data-flow (DepDegree) | few | many | dense, long-range | live def-use links |
+| Coupling (CBO) | <=5 | 10-14 | >=15 | classes a class depends on |
+| Cohesion (LCOM4) | 1 | 3-4 | >=5 | connected components in a class |
+
+Cyclomatic complexity (McCabe) <=10 is the universal *testing* threshold - keep
+it, but don't use it to argue about readability.
+
+## Review priority order
+
+1. **Names** - scan for misleading identifiers first, then cryptic abbreviations;
+   ensure consistent vocabulary.
+2. **Working-memory load** - nesting depth, parameter count, and data-flow
+   (variable lifespans, cross-branch sharing). Extract methods, introduce
+   well-named temporaries, or use a parameter object.
+3. **Size** - over-long methods and over-large changesets; decompose.
+4. **Layout** - consistent indentation, blank lines between chunks, line length.
+5. **Stop at the extremes** - don't churn already-simple code to shave a metric.
+
+Tailor to the audience: novices are hit hardest by nesting, recursion, and poor
+names; default a mixed team to the novice-friendly choice.
+
+## Evidence
+
+The factor-by-factor research, the metric glossary, industry-tool thresholds, and
+the full citation list are in [references/research.md](references/research.md).
+The threshold numbers above are screening heuristics drawn from that evidence; the
+high-confidence rules at the top are the parts to rely on. A consuming repository
+binds its own style guide and any house thresholds in its overlay.

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,0 +1,22 @@
+---
+core: code-comprehension
+core-pin: v0.11.0
+---
+
+# Code comprehension overlay
+
+Repository-specific bindings for thirtytwo.
+
+- Product code lives under [src/thirtytwo](../../../src/thirtytwo); tests live
+  under [src/thirtytwo_tests](../../../src/thirtytwo_tests), and samples live
+  under [src/samples](../../../src/samples).
+- Read all files of a partial type together before judging method or type
+  complexity. Window, control, dialog, and COM behavior is intentionally split
+  by responsibility.
+- Treat explicit native ownership, HRESULT handling, ABI types, and lifetime
+  scopes as essential complexity. A readability refactor must not hide who
+  owns a handle, pointer, COM reference, or native allocation.
+- Prefer the established `Windows` and `Windows.Win32` object model over a new
+  wrapper layer introduced only to shorten a method.
+- Pair readability review with [pre-pr-self-review](../pre-pr-self-review/SKILL.md)
+  when changes are proposed.

--- a/.agents/skills/code-comprehension/references/research.md
+++ b/.agents/skills/code-comprehension/references/research.md
@@ -1,0 +1,131 @@
+# Code comprehension - the evidence
+
+Backing detail for the [code-comprehension](../SKILL.md) skill: the factor-by-factor
+research, the metric glossary, industry-tool thresholds, and the citation list.
+The skill core distills the high-confidence parts; this page is the evidence and
+the lower-confidence frontier, so you can judge how hard to lean on any one number.
+
+> **How to read the thresholds.** They are *screening heuristics* aggregated from
+> empirical studies and widely used industry tools, not hard limits. Several
+> factors (naming, expression clarity, recursion style) are categorical, so their
+> "ranges" describe typical states, not numeric cut-offs.
+
+## Threshold table
+
+| Factor | Low | Moderate | High | Very high | Metric |
+| --- | --- | --- | --- | --- | --- |
+| Nesting depth | 1-2 | 3 | 4-5 | >=6 | max nested control blocks |
+| Cyclomatic complexity (McCabe) | <=5 | 6-10 | 11-20 | >=21 | independent paths (testing proxy) |
+| Cognitive complexity (Sonar) | <=5 | 6-10 | 11-15 | >=16 | rule-based understandability |
+| Method length | <=20 | 21-50 | 51-100 | >100 | SLOC, no blanks/comments |
+| Parameter count | <=3 | 4-5 | 6-8 | >=9 | params per method |
+| Line length | <=80 | 81-100 | 101-120 | >=121 | columns |
+| Identifier naming | descriptive, consistent | short / abbreviations | single letters in locals | misleading / inconsistent | qualitative |
+| Boolean / expression terms | <=2 | 3-4 | 5-6 | >=7 | operands / sub-expressions |
+| Recursion | tail / simple | single + obvious base case | mutual / non-obvious termination | deep, intertwined | presence and depth |
+| Data-flow (DepDegree) | few def-use links | moderate | many interdependent vars | dense, long-range | live def-use edges |
+| Layout / whitespace | consistent indent, blank lines | minor inconsistency | irregular indent, dense | no indent / hard wraps | indent consistency |
+| Coupling (CBO) | <=5 | 6-9 | 10-14 | >=15 | classes a class depends on |
+| Cohesion (LCOM4) | 1 | 2 | 3-4 | >=5 | connected components in a class |
+| Inheritance depth (DIT) | <=2 | 3-4 | 5-6 | >=7 | depth of inheritance tree |
+
+## Metric glossary
+
+- **Cyclomatic complexity (McCabe).** Independent paths through a method (decision
+  points plus one). Useful for *testing* effort; a weak proxy for human
+  comprehension - a 2023 neuroscience study (222 developers) confirmed poor
+  correlation with measured cognitive load.
+- **Cognitive complexity (Sonar).** Rule-based score built to mirror human
+  understandability: adds for flow breaks, adds *extra* for nesting, ignores
+  structures perceived as simple. Validated to correlate with comprehension time.
+- **DepDegree (data-flow).** Counts definition-use edges - how many variable
+  relationships a reader must track. Relates to brain-measured load more strongly
+  than control-flow-only metrics.
+- **Coupling Between Objects (CBO).** Classes a class depends on directly; high
+  values track with defect density and comprehension difficulty.
+- **Lack of Cohesion of Methods (LCOM4).** Connected components in a class's
+  method graph; 1 = single responsibility, higher = split candidate.
+
+## Factor details (what / why / guardrail)
+
+1. **Nesting depth and indentation.** Each level adds a simultaneously-active
+   condition; indentation is the visual scaffold. Indented code is read materially
+   faster (RCTs find unindented control flow roughly doubles reading time). Prefer
+   <=2-3 levels; refactor >=4 by extracting methods or flattening.
+2. **Cyclomatic vs cognitive complexity.** McCabe for testing; cognitive
+   complexity for readability (its nesting penalty is the point). Keep methods at
+   <=10 cognitive where feasible.
+3. **Method length.** Larger units combine more decisions, names, and data-flow.
+   Aim <=20 SLOC, review at 50+, refactor above 100.
+4. **Parameter count.** Parameters are vocabulary a reader holds in mind; count
+   correlates with working-memory brain activation. Prefer <=3; 4-5 = "explain
+   why"; 6+ = parameter object.
+5. **Line length and whitespace.** Long lines reduce scan anchors. <=100 columns
+   for code (<=80 for prose); add blank lines between logical chunks.
+6. **Identifier naming.** The primary carrier of meaning and the #1 factor in a
+   40-year review (named in 16 studies, ahead of every complexity metric).
+   Full-word names sped professionals ~19% in one study; misleading names are
+   worse than meaningless. Rename misleading identifiers first.
+7. **Expression complexity and explaining variables.** For experts, flat vs nested
+   boolean forms are often equivalent; well-named intermediate variables help when
+   an expression is genuinely hard. Prefer <=4 boolean terms; avoid long fluent
+   chains without breaks.
+8. **Recursion.** Readers must simulate the call stack and termination. Prefer
+   tail/simple recursion; make the base case and state explicit; consider an
+   iterative form when depth or state is non-obvious.
+9. **Data-flow dependencies.** Interleaved definitions and uses force
+   back-referencing. Keep variable lifespans short; reduce cross-branch sharing;
+   one purpose per variable per block.
+10. **Regularity / repetition.** Readers invest most in the first occurrence of a
+    pattern; later repeats cost less. Prefer consistent idioms; avoid needless
+    irregularity.
+11. **Coupling and cohesion.** Keep CBO <=9; LCOM4 = 1 ideal, refactor at >=3.
+    High coupling and low cohesion both track with maintenance and comprehension
+    problems.
+
+## Industry-tool convergence
+
+- Cyclomatic complexity: **10** (near-universal).
+- Method length: **~25 lines** (tools vary 20-30).
+- Parameter count: **4**.
+- Nesting depth: **4** (SonarQube, ESLint).
+- File length: **250-500 lines** (wide variation).
+
+Defaults by tool: SonarQube (cognitive 15, method 50), CodeClimate (method
+complexity 5, file 250), ESLint (complexity 20, max-depth 4), Visual Studio
+maintainability index (green 20-100, red 0-9).
+
+## Process factors (well-supported)
+
+- **Review size.** Effectiveness drops faster than linearly with changeset size;
+  under ~200 lines enables linear reading. Tool-assisted review yields about 2x
+  the accepted comments of over-the-shoulder review.
+- **Audience.** Novices are hit hardest by nesting, recursion, and weak names and
+  benefit most from consistent indentation; default mixed teams to the
+  novice-friendly choice.
+
+## Frontier (interesting, lower confidence)
+
+Treat these as directional, not as guardrails - small samples, single studies, or
+hard-to-reproduce instrumentation:
+
+- **Physiological measures.** Eye-tracking shows non-linear read patterns; EEG
+  theta rises and alpha falls with effort; fNIRS detects prefrontal load. Reported
+  accuracies (e.g. ~89% load detection, ~97% expertise prediction) come from small
+  lab studies.
+- **Paradigm effects.** Reported comprehension deltas - reactive vs OOP (~15-25%),
+  async/await debugging (~30%), static vs dynamic typing trade-offs - are single
+  studies with modest cohorts.
+- **ML smell detection.** Transformer models report 90%+ precision but 50-60%
+  recall; many flagged issues are never refactored (the actionability gap).
+
+## Citations
+
+The claims above trace to (among others): Sonar Cognitive Complexity whitepaper;
+Munoz Baron et al. 2020 (cognitive-complexity meta-analysis); Peitek et al. 2021
+(fMRI); Beyer et al. 2014 (DepDegree); Hofmeister et al. 2017 and Avidan &
+Feitelson 2017 (naming); the 40-year naming review (2022); Hanenberg et al. 2024
+and Miara et al. 1983 (indentation); Buse & Weimer 2010 (readability model);
+Jbara & Feitelson 2017 (regularity); Stoeckert et al. 2024 (recursion); and ICPC
+2025 review-strategy work. Each entry is searchable by author and year for the
+full source.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,209 @@
+---
+compatibility: Requires git; remote creation uses an available GitHub integration or authenticated gh, with a browser fallback.
+description: Create a pull request for the current changes. Use when asked to "make a PR", "open a pull request", "push and PR", or otherwise publish in-progress work for review. Ensures changes are on a non-`main` branch, commits are made and pushed, and the PR targets `upstream/main` when an `upstream` remote exists, otherwise `origin/main`.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/create-pr
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review, address-pr-feedback
+    requires: none
+    risk: remote-write
+name: create-pr
+---
+# Create a pull request
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Follow these steps in order. Stop and ask the user if any check is ambiguous;
+do not force-push, rewrite history, or delete branches without explicit
+confirmation.
+
+**Approval scope.** A request to "open / make / create a PR" authorizes the
+*work* of preparing one. It does **not** authorize the commit or the push.
+The **Approval checkpoint** inside step 3 (Commit changes) is the gate:
+staging happens before it, `git commit` and everything after happen only
+once the user supplies an explicit publishing verb - `commit`, `push`,
+`ship it`, or equivalent. See your repo's agent guidance (the "Working with
+the user on changes" rules in `AGENTS.md`) for the canonical rule and the
+recurring not-approval phrasings.
+
+Before running this workflow, walk through the `pre-pr-self-review` checklist -
+it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
+that repeatedly cost a review round-trip. If the change polyfills a .NET API for
+.NET Framework, a `polyfill-dotnet-api` skill (where the repo provides one)
+defines the design rules the self-review then validates against.
+
+## 1. Inspect repository state
+
+Run these (read-only) checks first:
+
+- `git remote -v` - determine whether an `upstream` remote exists.
+- `git rev-parse --abbrev-ref HEAD` - current branch name.
+- `git status --porcelain` - uncommitted changes.
+- `git log --oneline @{u}.. 2>$null` (if upstream is set) - unpushed commits.
+
+Decide the PR base:
+
+- If a remote literally named `upstream` exists, the PR base is
+  `upstream/main` (i.e. `--repo` points at the upstream repo, base branch
+  `main`).
+- Otherwise the PR base is `origin/main` (the fork itself, base `main`).
+
+## 2. Ensure work is on a feature branch
+
+- If the current branch is `main`, **do not commit on `main`**. Create a new
+  branch from the current `HEAD` with a short, descriptive, kebab-case name
+  derived from the change (e.g. `fix-span-enumerate-lines`,
+  `add-create-pr-skill`).
+- Confirm the branch name with an available structured-question capability
+  before creating it. Offer the suggested kebab-case name and a way to enter a
+  different name. If the host has no structured question tool, ask in chat.
+  Known client adapters are in [host-adapters.md](host-adapters.md).
+- Use `git switch -c <branch>` to move uncommitted changes onto the new
+  branch.
+- If already on a non-`main` branch, keep using it.
+
+## 3. Commit changes
+
+- If `git status` shows uncommitted changes that belong in the PR, stage them
+  with `git add` (prefer explicit paths over `git add -A` unless the user
+  asked for everything).
+- Write a concise commit message: short imperative subject (≤ 72 chars), and
+  a body only if the change needs explanation. Match the style of recent
+  commits (`git log --oneline -20`).
+- Do not amend or rebase published commits without explicit user approval.
+- Do not pass `--no-verify`; let hooks run.
+
+### Approval checkpoint
+
+**Stop here.** Show the user the staged diff (or summarize it) and the
+proposed commit message. Wait for the user to explicitly say `commit`,
+`push`, or `ship it` (or one of the other verbs listed in your repo's
+agent guidance "Working with the user on changes" rules) before running
+`git commit`. If the user already used one of those verbs in the message
+that triggered this skill, proceed without asking again. Do not infer
+approval from the original "open a PR" request.
+
+## 4. Push the branch
+
+### Pre-push conflict check
+
+Before pushing (or re-pushing), confirm the branch still merges cleanly into
+its base (`<base>` = `origin/main`, or `upstream/main` when that remote exists)
+so conflicts surface locally instead of on the PR:
+
+- `git fetch <remote> main`, then `git rev-list --left-right --count <base>...HEAD`.
+  Left count `0` means up to date - skip to push.
+- If behind, dry-run the merge without touching the tree:
+
+  ```pwsh
+  git merge-tree $(git merge-base HEAD <base>) HEAD <base> | Select-String 'CONFLICT|<<<<<<<'
+  ```
+
+- **Clean:** prefer rebasing onto `<base>` so the PR diff is current.
+- **Conflicts:** rebase (`git rebase <base>`, `$env:GIT_EDITOR='true'`), resolve,
+  `git add` by path, `git rebase --continue`, then re-run the build and the
+  test suite in Release (base may have moved/renamed code you depend on).
+- A rebase rewrites commits, so the next push needs `--force-with-lease` - a
+  force-push that **requires explicit user approval** per the publish-boundary rule.
+
+### Push
+
+- Fresh branch (no rebase): `git push -u origin <branch>`.
+- After rebasing an already-pushed branch (explicit approval only):
+  `git push --force-with-lease origin <branch>`.
+- Never `git push --force` or `--force-with-lease` without explicit user
+  confirmation.
+
+## 5. Open the PR
+
+**Prefer an available GitHub integration** that can create a pull request and
+return its number/URL. Fall back to the GitHub CLI (`gh`) when no integration is
+available, and only fall back to a browser compare URL if neither is available.
+Known client adapters are in [host-adapters.md](host-adapters.md).
+
+Determine the target with the rule from step 1.
+
+### Option A - GitHub integration (preferred)
+
+Call the host's pull-request creation capability with:
+
+- `title`, `body` (see PR title/body guidance below),
+- `head` = the feature branch name (no owner prefix),
+- `base` = `main`,
+- For an upstream-targeted PR, set `repo` to `{ owner: <upstreamOwner>, name: <repo> }` and `headOwner` to the fork owner.
+- For an origin-only PR, omit `repo` and `headOwner` (they default correctly).
+
+### Option B - GitHub CLI fallback
+
+- **Upstream exists**:
+
+  ```pwsh
+  gh pr create --repo <upstreamOwner>/<repo> --base main --head <forkOwner>:<branch> --title "<title>" --body "<body>"
+  ```
+
+- **No upstream**:
+
+  ```pwsh
+  gh pr create --base main --head <branch> --title "<title>" --body "<body>"
+  ```
+
+### PR title and body
+
+- Title: same style as the commit subject; reference the area touched.
+- Body: brief summary of what changed and why, bullet list of notable
+  changes, and any test/validation notes (e.g. "ran the test suite"). Link
+  related issues with `Fixes #N` when appropriate.
+- If the user has not supplied a title/body, propose one and confirm before
+  creating.
+
+### Option C - Browser fallback
+
+If neither the VS Code tool nor `gh` is available, print the compare URL:
+
+- Upstream: `https://github.com/<upstreamOwner>/<repo>/compare/main...<forkOwner>:<branch>?expand=1`
+- Origin only: `https://github.com/<originOwner>/<repo>/compare/main...<branch>?expand=1`
+
+## 6. Report back
+
+Tell the user:
+
+- The branch name and where it was pushed.
+- The base the PR targets (`upstream/main` or `origin/main`).
+- The PR URL (from `gh pr create` output) or the compare URL fallback.
+
+## 7. Watch for an automated reviewer
+
+Some repos auto-review PRs (e.g. GitHub Copilot), posting a review a minute or
+two after the PR opens or after each push; others let you request one.
+
+- Tell the user a review may land shortly; offer to fetch and investigate it
+  when it does. Don't poll - act when the user reports comments, or check once.
+- If nothing auto-reviews, offer to request a reviewer - a remote action, only
+  with the user's go-ahead.
+
+Opening the PR ends this skill. Handling whatever the reviewer posts - resolving
+threads, re-requesting review - is the `address-pr-feedback` workflow, under the
+same commit/push publish gate.
+
+## Guardrails
+
+- Never commit directly to `main`, even if the user is currently on it -
+  always branch first.
+- Never delete branches, force-push, or rewrite history as part of this
+  workflow.
+- If the working tree has unrelated changes, ask the user which files belong
+  in the PR before staging.
+
+## Host adapters
+
+- [host-adapters.md](host-adapters.md) - exact structured-question and GitHub
+  integration names for tested clients, plus the host-neutral fallbacks.

--- a/.agents/skills/create-pr/host-adapters.md
+++ b/.agents/skills/create-pr/host-adapters.md
@@ -1,0 +1,25 @@
+# Create-PR host adapters
+
+The [create-pr core](SKILL.md) is capability-based. Use this page only to map
+those capabilities to exact client tool names; the workflow and approval gates
+remain in the core.
+
+## GitHub Copilot in VS Code
+
+- Structured question: `vscode_askQuestions`. Supply two options - the suggested
+  branch name and `Use a different name` - and leave free-form input enabled.
+- Pull-request creation: `github-pull-request_create_pull_request`. Supply
+  `title`, `body`, `head`, and `base`. For an upstream-targeted PR, also supply
+  the upstream `repo` and the fork `headOwner`.
+
+## GitHub Copilot CLI
+
+The CLI has no built-in pull-request creation capability in the portable tool
+set. Ask the branch-name question in chat, then use authenticated `gh pr create`.
+The core contains the upstream and origin command forms.
+
+## Other Agent Skills hosts
+
+Use a host-native structured question or GitHub integration when one exists.
+Otherwise ask in chat and use `gh`. If `gh` is unavailable, emit the compare URL
+from the core and stop; do not invent a host tool name or silently install one.

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,0 +1,24 @@
+---
+core: create-pr
+core-pin: v0.11.0
+---
+
+# Create PR overlay
+
+Repository-specific bindings for thirtytwo.
+
+- The canonical repository is `JeremyKuhne/thirtytwo`; PRs target `main`.
+- Run [pre-pr-self-review](../pre-pr-self-review/SKILL.md) before publishing.
+- The required product gate is the Windows workflow in
+  [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml).
+- Before publishing, build and test the current tree in Release:
+
+```pwsh
+dotnet restore
+dotnet build --configuration Release --no-restore
+dotnet test --configuration Release --no-build --report-trx
+```
+
+- When `.agents/` changes, also run the commands in
+  [agent-files-review](../agent-files-review/SKILL.md).
+- Stage by path and do not publish unrelated working-tree changes.

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -1,0 +1,119 @@
+---
+compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; Windows COM APIs across .NET 10 and .NET Framework. Cross-assembly extension-block examples require C# 14.
+description: Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across .NET 10 and .NET Framework, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces absent from Win32 metadata, COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Not for ordinary RCW-based COM consumption with no raw struct pointers or CCW bridge. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/cswin32-com
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 16f0e262ed5b4a11f90a91b70cb4b9ab473a3d1a
+    maturity: canary
+    portability: portable
+    related: security-review, il-copy-inspection
+    requires: cswin32-interop
+    risk: local-write
+name: cswin32-com
+---
+# CsWin32 struct-based COM interop
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Struct-based COM interop on top of CsWin32: raw `delegate*` vtable calls and no
+built-in CLR marshalling on the native pointer surface, so it is AOT- and
+trimming-friendly. A managed `[ComImport]` mirror is allowed only as a narrow
+CCW bridge; runtime calls still use the generated struct. This skill covers the
+COM-specific layer; the general P/Invoke layer and the blittable-signature rules
+that vtable methods also follow live in the paired **cswin32-interop** skill.
+
+## Helper conventions
+
+Examples use `ComScope<T>` for a disposable scope that owns one AddRef'd COM
+reference and `IID.Get<T>()` for a support helper that returns a `Guid*` to
+`T`'s `IComIID.Guid`. CsWin32 generates `IComIID`, but these two helpers come
+from a support library. The overlay names their concrete implementations. If a
+repository does not provide them, use an equivalent owned-pointer scope and a
+stable IID pointer; keep the same ownership and ABI contracts.
+
+`AcquireOwnedCcwPointer<T>()` in examples is pseudocode for a repository helper
+that returns one AddRef'd, caller-owned interface pointer for a managed object.
+Its implementation determines compatibility: classic
+`Marshal.GetComInterfaceForObject` uses built-in COM interop and is not a
+NativeAOT path, while a `ComWrappers` implementation can be AOT-compatible.
+
+## Workflow
+
+1. **In Win32 metadata?** If yes, add the interface name to `NativeMethods.txt`
+  and CsWin32 generates it. If not (for example, Setup Configuration or a
+  private / third-party interface), define a manual struct in its own file - see
+   [manual-structs.md](manual-structs.md).
+2. **Lifetime:** `using ComScope<T> scope = new();` for every transient **owned**
+   COM reference, and free every owned COM `BSTR` out-param (`SysFreeString` /
+   `FreeBSTR`, or a repo-provided scoped `BSTR` wrapper). A correct
+   `try` / `finally` also releases on early return, but an owned-pointer scope
+   centralizes initialization, release, and ownership transfer. Never release a
+   borrowed pointer unless the caller first acquires a reference. See
+   [lifetime.md](lifetime.md).
+3. **Activate** via a class-factory helper or `CoCreateInstance` with
+   the exact interface IID; prefer `IID.Get<T>()` when the support helper is
+   available. See [Activation](#activation).
+4. **Call** via `scope.Pointer->Method(...)`. Pass `ComScope<T>` directly where
+   the API expects `T**` / `void**` when the concrete scope provides those
+   conversions.
+5. **Match the caller's error contract.** If the top-level consumer treats COM
+  failure as a documented "absent" result, helpers may return `default` /
+  `false`; otherwise call `.ThrowOnFailure()`. Do not change a shared helper's
+  contract merely because one caller catches `COMException`. See the parity
+  table in
+   [migration-and-testing.md](migration-and-testing.md).
+6. **Gate .NET 10-only COM features with `#if NET`.** `ComWrappers`-based CCW
+  support is unavailable on .NET Framework. Generated `IComIID` works on both
+  supported runtime families with CsWin32 0.3.287 or later; see
+  [comiid-and-cls.md](comiid-and-cls.md).
+7. **Compose across packages** at the owner boundary. The owner implements
+   generated partial hooks and publishes shared COM structs; extenders add
+   behavior with extension blocks or uniquely named CCW providers. See
+   [ccw-composition.md](ccw-composition.md).
+
+## Activation
+
+```csharp
+// Via CoCreateInstance and the repository's IID support helper.
+Guid clsid = SomeCoClass.CLSID;
+using ComScope<ISomething> instance = new();
+PInvoke.CoCreateInstance(
+    &clsid, null, CLSCTX.CLSCTX_INPROC_SERVER, IID.Get<ISomething>(), instance)
+    .ThrowOnFailure();
+instance.Pointer->DoThing(...);
+```
+
+- Prefer `IID.Get<T>()` when available; it returns a `Guid*` to the type's
+  `IComIID.Guid` without a per-call copy. Otherwise pass a pointer to a stable
+  `Guid` containing the exact IID. A local `Guid` is valid for the duration of
+  the native call; the problem is an incorrect or ad hoc IID, not local storage.
+- Initialize `ComScope<T>` with `new()`; it implicitly converts to the `T**` /
+  `void**` output parameter when the concrete support type supplies those
+  conversions.
+- A repo may also ship a class-factory helper (activate via `CoGetClassObject`
+  then `CreateInstance`), the AOT-friendly path when a CLSID is registered - see
+  the overlay.
+
+## Sibling pages
+
+- [lifetime.md](lifetime.md) - `ComScope<T>`, `BSTR`, owned and borrowed
+  references, field-lifetime strategies, and ownership transfer out of a helper.
+- [manual-structs.md](manual-structs.md) - defining an interface not in Win32
+  metadata: `delegate* unmanaged[Stdcall]` vtables, exact slot indices, the
+  dual-target `IComIID` member, and strongly-typed handle/token wrappers.
+- [comiid-and-cls.md](comiid-and-cls.md) - `IComIID` across .NET 10 and
+  .NET Framework (both-family auto-emit versus the older Framework per-struct
+  polyfill) and CLS compliance.
+- [migration-and-testing.md](migration-and-testing.md) - the error-handling
+  parity table when migrating off `[ComImport]`, and mocking struct-based COM in
+  tests via a CCW bridge.
+- [ccw-composition.md](ccw-composition.md) - owner-side `IUnknown` vtable
+  initialization, extending imported COM structs across assemblies, and local
+  CCW provider types.

--- a/.agents/skills/cswin32-com/ccw-composition.md
+++ b/.agents/skills/cswin32-com/ccw-composition.md
@@ -1,0 +1,143 @@
+# Cross-assembly CCW composition
+
+Detail for [cswin32-com](SKILL.md). The paired interop skill owns the general
+owner/extender package model; this page covers the COM-specific boundary when
+one package owns generated COM structs and another adds COM-callable wrappers or
+helper behavior.
+
+## The owner owns generated partial hooks
+
+CsWin32's generated `IVTable<TComInterface, TVTable>` support initializes the
+three `IUnknown` slots by calling `Windows.Win32.ComHelpers.PopulateIUnknown<T>()`.
+That method delegates to a generated partial method named
+`PopulateIUnknownImpl<T>()`. A partial implementation must be in the **same
+assembly and compilation** as its declaration; an extender package cannot
+implement the owner's hook.
+
+If an owner publishes CCW-capable generated types, implement the hook in the
+owner. On the .NET 10 leg, a `ComWrappers` provider can copy the runtime's
+canonical `IUnknown` entry points into the generated vtable:
+
+```csharp
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace Windows.Win32;
+
+public static unsafe partial class ComHelpers
+{
+    static partial void PopulateIUnknownImpl<TComInterface>(
+        System.Com.IUnknown.Vtbl* vtable)
+        where TComInterface : unmanaged
+        => IUnknownVtableProvider.Populate(vtable);
+
+    private sealed class IUnknownVtableProvider : ComWrappers
+    {
+        public static void Populate(System.Com.IUnknown.Vtbl* vtable)
+        {
+            GetIUnknownImpl(out nint queryInterface, out nint addRef, out nint release);
+            vtable->QueryInterface_1 =
+                (delegate* unmanaged[Stdcall]<System.Com.IUnknown*, Guid*, void**, Foundation.HRESULT>)queryInterface;
+            vtable->AddRef_2 =
+                (delegate* unmanaged[Stdcall]<System.Com.IUnknown*, uint>)addRef;
+            vtable->Release_3 =
+                (delegate* unmanaged[Stdcall]<System.Com.IUnknown*, uint>)release;
+        }
+
+        protected override ComInterfaceEntry* ComputeVtables(
+            object obj,
+            CreateComInterfaceFlags flags,
+            out int count)
+            => throw new NotSupportedException();
+
+        protected override object CreateObject(
+            nint externalComObject,
+            CreateObjectFlags flags)
+            => throw new NotSupportedException();
+
+        protected override void ReleaseObjects(IEnumerable objects)
+            => throw new NotSupportedException();
+    }
+}
+```
+
+Gate this implementation with `#if NET`; .NET Framework does not provide the
+real `ComWrappers` support needed to populate the vtable. Without the hook,
+generated vtable creation throws `NotImplementedException` when it sees an
+uninitialized `QueryInterface` slot; moving the same partial declaration into
+an extender does not fix it.
+
+## Extend owner types; do not redeclare them
+
+A `partial struct` cannot span assemblies. When the owner already publishes
+`IDispatch`, `IUnknown`, or another generated COM struct:
+
+- add convenience behavior with a C# 14 extension block, using a `ref` receiver
+  when the method needs the struct address;
+- keep runtime pointers typed as the owner's imported struct;
+- do not publish another struct with the same fully qualified name;
+- put behavior shared by all extenders in the owner rather than duplicating it.
+
+For example:
+
+```csharp
+public static unsafe class IDispatchExtensions
+{
+    extension(ref IDispatch dispatch)
+    {
+        public HRESULT InvokeMember(/* blittable parameters */)
+        {
+            fixed (IDispatch* pointer = &dispatch)
+            {
+                return pointer->Invoke(/* ... */);
+            }
+        }
+    }
+}
+```
+
+## Use a uniquely named CCW provider when necessary
+
+An extender may need a writable vtable provider even though runtime calls use the
+owner's imported interface. If the owner type cannot serve that role, define a
+uniquely named implementation-only provider such as `IDispatchCcw` that
+implements `IComIID` and `IVTable<TComInterface, TVTable>`. Its vtable contains
+the interface-specific slots; the owner hook supplies the inherited `IUnknown`
+slots.
+
+A nested managed `[ComImport]` interface is acceptable when it exists solely to
+ask the classic COM marshaller for a CCW or to describe the managed callback
+contract. It is not the runtime pointer surface: native calls still go through
+the owner-generated struct and raw vtable. This is the same narrow exception used
+by the test bridge in [migration-and-testing.md](migration-and-testing.md). A
+path that calls `Marshal.GetComInterfaceForObject` depends on built-in COM
+interop and is not a NativeAOT path; use `ComWrappers` for the AOT-capable CCW
+implementation.
+
+When a manual lifetime wrapper is generic on its vtable type, use that **exact
+same vtable type** in allocation and every callback that recovers the object or
+updates its reference count. Do not substitute a layout-compatible generated
+vtable type in `GetObject`, `AddRef`, or `Release`; generic type identity is part
+of the wrapper contract even when the current native layouts happen to match.
+
+Every AddRef'd pointer returned by a CCW helper is caller-owned. Scope it when
+passing it to `Advise` or another retaining API, and pair successful connection
+cookies with `Unadvise`; see [lifetime.md](lifetime.md).
+
+## Validation
+
+Test more than compilation:
+
+1. construct the extender's COM interface table so the owner-side
+   `PopulateIUnknownImpl` hook executes;
+2. obtain a CCW pointer for a managed implementation and query the expected
+   interface;
+3. call through the owner-generated pointer struct and verify HRESULT behavior;
+4. build all .NET 10 and .NET Framework TFMs so `ComWrappers`-dependent code is
+    absent or explicitly unsupported on .NET Framework;
+5. pack the owner and extender and compile a consumer that references only the
+   extender package.
+
+These checks catch the failure mode where project references compile but the
+owner omitted its partial hook, the extender accidentally redeclared an imported
+COM type, or the packaged dependency graph exposes two incompatible projections.

--- a/.agents/skills/cswin32-com/comiid-and-cls.md
+++ b/.agents/skills/cswin32-com/comiid-and-cls.md
@@ -1,0 +1,79 @@
+# IComIID across target frameworks, and CLS compliance
+
+Detail for [cswin32-com](SKILL.md). `IComIID` is the interface CsWin32 uses to
+recover a COM type's IID generically. A support helper such as `IID.Get<T>()`
+can expose a `Guid*` to the type's `IComIID.Guid`. Its shape differs by target
+framework, and how much you author by hand depends on the CsWin32 version.
+
+## CsWin32 0.3.287 and later
+
+The generator emits `IComIID` and attaches it to **every** generated COM struct
+on both supported runtime families - a static-abstract
+`static ref readonly Guid Guid` on the .NET 10 leg, and an instance
+`ref readonly Guid Guid` on .NET Framework. Nothing to hand-author: adding a
+generated COM type to `NativeMethods.txt` carries `IComIID` through an
+`IComIID`-constrained scope automatically on both legs. A support helper reads
+it via `T.Guid` on .NET 10 and `default(T).Guid` on .NET Framework.
+
+Only **manual** structs implement `IComIID` by hand, matching the per-TFM shape
+(see [manual-structs.md](manual-structs.md)).
+
+This both-family generation was added by
+[microsoft/CsWin32#1705](https://github.com/microsoft/CsWin32/pull/1705).
+
+## Older CsWin32 (before 0.3.287)
+
+Within this skill's .NET 10 / .NET Framework target pair, older generators emit
+the static-abstract `IComIID` and attach it to generated structs only on the
+.NET 10 leg. On .NET Framework you supply the missing pieces by hand, included
+only for that target with a Framework-only source folder or `#if NETFRAMEWORK`:
+
+- The `IComIID` interface itself (an instance-based `ref readonly Guid Guid`).
+- One `partial struct` per generated COM type used through `ComScope<T>`, adding
+  `IComIID` to its base list and returning the CsWin32-emitted `IID_Guid` field:
+
+```csharp
+namespace Windows.Win32.System.Com;
+
+internal partial struct IRunningObjectTable : IComIID
+{
+    readonly ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      get => ref Unsafe.AsRef(in IID_Guid);
+    }
+}
+```
+
+`IID_Guid` is the generator-emitted static field and is present on these older
+versions even when `IComIID` is not.
+
+Add a partial for each new generated COM type you scope. A **manual** struct is
+not given the instance polyfill (it would force an interface dispatch on a hot
+path); a manual struct that must work on .NET Framework spells out the instance
+member itself, as in [manual-structs.md](manual-structs.md). Whether a repo uses
+the 0.3.287+ both-family generation or the older Framework polyfill - and where
+those polyfill files live - is repository-specific; **see the overlay.**
+Upgrading the generator to 0.3.287 or later lets you delete the whole polyfill.
+
+## CLS compliance
+
+A CLS-compliant assembly (`[assembly: CLSCompliant(true)]`) trips `CS3016` on
+generated COM wrappers that carry CCW thunks (the `[UnmanagedCallersOnly(...)]`
+array argument). CsWin32 0.3.287+ auto-emits `[CLSCompliant(false)]` only on
+**internal** wrappers that carry those thunks and adds `CS3019` / `CS3021` to
+its generated-file `#pragma warning disable` list. Internal projections therefore
+need no consumer workaround. The .NET Framework target does not emit the thunks
+and receives no annotation.
+
+CsWin32 deliberately does not annotate **public** wrappers: the consuming
+library owns its public CLS contract. In a CLS-compliant assembly with a public
+projection, decide whether each wrapper belongs in the public surface. Mark an
+intentionally non-CLS wrapper with a hand-authored `[CLSCompliant(false)]`
+partial, reduce its visibility, or otherwise address the public contract rather
+than applying a blanket suppression. Before 0.3.287, internal CCW-bearing
+wrappers also need the hand-authored partials and may need narrowly scoped
+`CS3019` / `CS3021` suppression. See the overlay and
+[microsoft/CsWin32#1706](https://github.com/microsoft/CsWin32/pull/1706).
+The underlying array-argument diagnostic is tracked by
+[dotnet/roslyn#68526](https://github.com/dotnet/roslyn/issues/68526).

--- a/.agents/skills/cswin32-com/lifetime.md
+++ b/.agents/skills/cswin32-com/lifetime.md
@@ -1,0 +1,138 @@
+# Lifetime and access
+
+Detail for [cswin32-com](SKILL.md). Struct-based COM has no runtime to release
+references for you. Release every reference the caller owns, and never release a
+borrowed pointer without first acquiring a reference.
+
+## Where a COM pointer may live
+
+A raw `T*` (a CsWin32 COM struct pointer) is simplest as a local in an `unsafe`
+method, a parameter, or a field of a `ref struct`. Avoid storing one directly in
+a class or non-`ref` struct by default: the owner must track whether the pointer
+is owned or borrowed, enforce the interface's apartment and thread contract,
+release an owned reference on the correct apartment, and prevent access after
+disposal. A finalizer on an arbitrary thread is not a substitute for releasing
+an apartment-affine pointer on its owning apartment. Use a field-lifetime
+strategy below unless the type explicitly enforces all of those invariants.
+
+## ComScope<T> - transient pointers
+
+The examples use a support-library `ref struct` that owns one AddRef'd reference
+and calls `Release` on dispose. Always use it in a `using` declaration. It is the
+default for an **owned** pointer that does not outlive the current method. The
+conventional type implicitly converts to `T**` and `void**`, so an out-param
+writes straight into the scope:
+
+```csharp
+using ComScope<ISomething> scope = new();
+factory.Pointer->QueryInterface(IID.Get<ISomething>(), scope).ThrowOnFailure();
+scope.Pointer->DoThing(...);
+```
+
+- Access methods via `scope.Pointer->Method(...)`; null-check with
+  `scope.IsNull`.
+- Applies to every COM out-param whose contract returns an owned reference -
+    `CoCreateInstance`, `QueryInterface`, many `IEnumXxx::Next` and factory
+    methods, and app-local `STDAPI Get*` functions. Read the contract before
+    scoping an unusual borrowed output. Declare raw outputs with `T**` when the
+    scope's implicit pointer-to-pointer conversion should bind.
+
+## Passing pointers to retaining APIs
+
+A helper that creates a CCW or queries an interface normally returns one owned,
+AddRef'd pointer. Passing that pointer to `Advise`, `SetClientSite`, or another
+API that retains it does **not** transfer the caller's reference. When the call
+succeeds and its contract retains the pointer, the callee acquires its own
+reference; scope and release the caller's reference after the call:
+
+```csharp
+using ComScope<IEventSink> sink = new(AcquireOwnedCcwPointer<IEventSink>(managedSink));
+source.Pointer->Advise(sink.Pointer, &cookie).ThrowOnFailure();
+```
+
+The same scope is appropriate when an **owned** pointer is passed to a
+non-retaining call such as a verb or callback: the scope releases the caller's
+reference afterward. A pointer that is itself borrowed is different. Do not put
+it in a releasing scope; keep its owner alive for the call, or call `AddRef`
+before creating an owned scope.
+
+A successful cookie-producing subscription is a second lifetime edge. Store the
+cookie and call `Unadvise(cookie)` before releasing the source object. Use a
+`try`/`finally` in disposal so failure to disconnect cannot prevent releasing the
+source pointer. If subscription failure is deliberately non-fatal, initialize
+the cookie to zero and skip disconnect when no cookie was issued.
+
+## Ownership transfer out of a helper
+
+A helper that acquires a pointer can return `ComScope<T>` directly; intermediate
+pointers stay in their own `using` scopes and release on the helper's `return`. A
+`default` `ComScope<T>` is null and its `Dispose` is a no-op, so callers need no
+extra null guard:
+
+```csharp
+private static ComScope<ISomething> Acquire()
+{
+    ComScope<ISomething> result = new();
+    Guid clsid = SomeCoClass.CLSID;
+    HRESULT createResult = PInvoke.CoCreateInstance(
+        &clsid, null, CLSCTX.CLSCTX_INPROC_SERVER, IID.Get<ISomething>(), result);
+    if (createResult.Failed)
+    {
+        result.Dispose();
+        return default;
+    }
+
+    return result;
+}
+```
+
+Disposing the scope on failure covers APIs that leave a non-null output despite
+failing. On success, returning the scope transfers that one owned reference to
+the caller. The concrete support type must make `default` null and disposal a
+no-op for this shape to be valid.
+
+## BSTR - COM strings
+
+A COM `BSTR` out-param is owned by the caller and must be freed with
+`SysFreeString` (equivalently `Marshal.FreeBSTR`). CsWin32 generates `BSTR` as a
+plain value - it does **not** implement `IDisposable` - so free it explicitly:
+
+```csharp
+BSTR version = default;
+try
+{
+    instance.Pointer->GetVersion(&version).ThrowOnFailure();
+    string managed = version.ToString();
+}
+finally
+{
+    Marshal.FreeBSTR((nint)version.Value);
+}
+```
+
+A repo may extend `BSTR` with `IDisposable` (a `Dispose` that calls
+`SysFreeString` / `FreeBSTR` and clears the field), enabling the same scoped
+shape as `ComScope<T>` - `using BSTR version = default;` - the recommended
+convenience where available. Because such a `Dispose` writes through the storage
+in place, the `using` must be on the storage location, not a method-returned
+copy.
+
+## A COM pointer that outlives a method
+
+Choose a holder that matches the interface's apartment contract:
+
+- A same-apartment owner may keep an owned pointer only when it enforces access
+    and deterministic disposal on that apartment.
+- For cross-apartment access, marshal the interface. A Global Interface Table
+    holder stores one registered reference and retrieves an apartment-appropriate
+    proxy into a short-lived owned scope for each call. The GIT does not make the
+    underlying object agile.
+- For an interface documented as agile, a holder may use an agile-reference or
+    equivalent strategy, but it must still own and release the correct reference.
+
+When the source pointer is already owned by a `ComScope<T>` that will release,
+register without taking that caller reference; the GIT acquires its own. Take
+ownership only when no other code path will release the source reference. Every
+holder needs deterministic disposal, and any finalizer fallback must be valid
+for the chosen marshalling strategy. The concrete holder type is
+repository-specific - see the overlay.

--- a/.agents/skills/cswin32-com/manual-structs.md
+++ b/.agents/skills/cswin32-com/manual-structs.md
@@ -1,0 +1,89 @@
+# Manual COM structs
+
+Detail for [cswin32-com](SKILL.md). For an interface not in Win32 metadata, such
+as Setup Configuration or a private / third-party interface, hand-write a struct
+that lays out the vtable yourself. Put each interface in its own file. Include
+or exclude that file using the same platform and target-framework decisions as
+the paired interop skill; a cross-platform assembly may compile the declaration
+as long as reachable calls remain Windows-only.
+
+## Shape
+
+Replace the placeholder with the interface's exact IID.
+
+```csharp
+internal unsafe struct IPrivateService : IComIID
+{
+  public static readonly Guid IID_IPrivateService = new("...");
+
+#if NET
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref Unsafe.AsRef(in IID_IPrivateService);
+    }
+#else
+    readonly ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref Unsafe.AsRef(in IID_IPrivateService);
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+          fixed (IPrivateService* pThis = &this)
+              return ((delegate* unmanaged[Stdcall]<IPrivateService*, Guid*, void**, HRESULT>)
+                _lpVtbl[0])(pThis, riid, ppvObject);
+    }
+    // AddRef @1, Release @2, then interface methods at their slot indices.
+}
+```
+
+## Rules
+
+- **`delegate* unmanaged[Stdcall]`** for the function-pointer cast. IDL
+  `STDMETHODCALLTYPE` is `__stdcall` on Win32; the wrong convention silently
+  corrupts the stack. This works on .NET Framework too (it lowers to an IL
+  `calli`).
+- **Vtable slots are exact and IUnknown-relative:** slot 0 = `QueryInterface`,
+  1 = `AddRef`, 2 = `Release`, 3+ = interface methods in IDL order. When the
+  interface derives from another, **add the parent's method count** first (e.g. a
+  `v2` method after three `IUnknown` and three `v1` methods is at slot 6). Unused
+  slots may be omitted as long as the ones you call have the correct index.
+- **`IComIID` has two shapes** - a static-abstract `static ref readonly Guid
+  IComIID.Guid` on the .NET 10 leg, and an instance
+  `readonly ref readonly Guid IComIID.Guid` on .NET Framework. A dual-target
+  manual struct spells out **both** arms (`#if NET` / `#else`). A .NET 10-only
+  struct needs no conditional; a Framework-only struct uses only the
+  instance form. CsWin32 handles this automatically for *generated* structs -
+  see [comiid-and-cls.md](comiid-and-cls.md).
+- **Use the generated `PCWSTR` / `PWSTR`** for wide-string parameters (add them
+  to `NativeMethods.txt`); raw `char*` with `fixed` only where no typed
+  equivalent exists.
+- **Vtable methods are blittable** - the same rules as any `[DllImport]`; see the
+  blittable-signatures page of the paired cswin32-interop skill (`HRESULT`
+  return, raw `T**` pointer outputs, `void*`, typed enum parameters).
+- **Platform annotations may be type- or member-level.**
+  `[SupportedOSPlatform]` is valid on structs. Apply it to the whole interface
+  struct when every member has the same Windows contract, or to individual
+  methods when versions differ. In dual-target source, place the attribute under
+  `#if NET` unless the .NET Framework target provides a compatible source
+  polyfill; .NET Framework reference assemblies do not define it.
+
+## Strongly-typed handle and token wrappers
+
+When the native side `typedef`s a primitive into a family of "same shape,
+different meaning" aliases (e.g. `typedef ULONG32 mdToken; typedef mdToken
+mdAssembly; ...`), mirror the hierarchy with distinct `readonly struct` wrappers,
+each holding the single underlying primitive - the same pattern as CsWin32's
+`HANDLE` / `HWND` / `HMODULE`. It stays blittable, so `delegate*` casts and arrays
+cost nothing at the boundary. Conversions follow the typedef hierarchy:
+**implicit** widening to the base (always safe), **explicit** narrowing (opt-in,
+because the C side cannot enforce the kind at the cast site). Check the native
+header for the canonical validation primitives before writing `IsNil` / `IsValid`
+- the encoding often hides in macros (for `mdToken`, `IsNilToken` tests the rid
+half, `RidFromToken(tk) == 0`, not the whole value, and a per-type nil such as
+`mdAssemblyNil = 0x20000000` is the table tag, not `0`).

--- a/.agents/skills/cswin32-com/migration-and-testing.md
+++ b/.agents/skills/cswin32-com/migration-and-testing.md
@@ -1,0 +1,71 @@
+# Migration parity and testing
+
+Detail for [cswin32-com](SKILL.md). Two things bite when moving off `[ComImport]`
+and RCWs: preserving the old throw-versus-return behavior, and mocking a
+struct-based interface in tests.
+
+## Error-handling parity when migrating
+
+Struct-based COM returns a raw `HRESULT`; `[ComImport]` and built-in activation
+threw automatically. Preserve the old throw-versus-return at each call site:
+
+| Old shape | Threw via | Migrated shape |
+| --- | --- | --- |
+| `new SomeCoClass()` | built-in activation | `CoCreateInstance(...).ThrowOnFailure()` |
+| `(IFoo)rcw` cast | `InvalidCastException` on QI | `QueryInterface(&iid, scope).ThrowOnFailure()` |
+| `[ComImport]` method, default `PreserveSig=false` | marshaller throws on `FAILED(hr)` | `.ThrowOnFailure()` at the call site |
+| `[ComImport]` method with `[PreserveSig]` | caller inspects the return | mirror the existing `hr` branch - do not start throwing |
+
+**Factory exception:** when the old contract returned `null` for legitimate
+rejection (e.g. `Create(path)` on bad input), keep the null-return only for that
+path; activation and QI failures still throw.
+
+**A swallowing caller does not define a shared helper's contract.** If the
+operation documents an expected "absent" result, an exception-free
+`Try*` / `false` / `default` path can avoid allocation and preserve the raw
+`HRESULT`. Otherwise retain `.ThrowOnFailure()` even when one top-level caller
+catches `COMException`. Change a shared helper only after auditing every caller
+and preserving its public failure contract.
+
+## Mocking struct-based COM in tests
+
+Struct-based calls go through raw vtable pointers, so a managed mock cannot be
+passed where a `T*` is expected. Bridge with the built-in COM marshaller: the mock
+implements the *managed* interface (a BCL
+`System.Runtime.InteropServices.ComTypes.*` interface when ABI-compatible - true
+for `ITypeLib` / `ITypeInfo` - otherwise CsWin32's nested `[ComImport] internal
+interface Interface`), and the test passes a **CCW** pointer to the code under
+test:
+
+```csharp
+// MockTypeLib : ComTypes.ITypeLib  (a normal managed class)
+nint ccw = Marshal.GetComInterfaceForObject(mock, typeof(ComTypes.ITypeLib));
+try
+{
+    walker.Analyze((ITypeLib*)ccw);
+}
+finally
+{
+    Marshal.Release(ccw);
+}
+```
+
+The CCW exposes a real vtable, so no hand-rolled native vtable is needed. But the
+mock must now behave like real COM:
+
+- **Every `[out]` param is written**, even ones the caller ignores - passing
+  `null` for a trailing out-param faults the marshaller.
+- **Exception identity is lost.** An HRESULT-returning method resurfaces a thrown
+  exception as a *new* `COMException` (HRESULT preserved, instance not); a `uint`
+  / `void` method with no HRESULT channel swallows it. Assert on type or count,
+  not the injected instance.
+- **Throw `COMException` on bad input; do not `Assert`** inside the mock - an
+  assertion exception escapes the code-under-test's `catch (COMException)`, while
+  a `COMException` becomes a failing HRESULT it handles normally.
+
+The managed `[ComImport]` interface in this bridge is deliberately not the
+runtime pointer API. Keep native calls on the generated struct. This classic
+marshaller bridge is for tests or other built-in-COM paths, not NativeAOT. In an
+owner/extender package design, the owner must also provide the generated
+`PopulateIUnknownImpl` partial hook before an extender's `IVTable` provider can
+construct a CCW; see [ccw-composition.md](ccw-composition.md).

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -1,0 +1,42 @@
+---
+core: cswin32-com
+core-pin: v0.11.0
+---
+
+# CsWin32 COM overlay
+
+Repository-specific bindings for thirtytwo.
+
+## Concrete helpers
+
+- Owned transient COM references use
+  [ComScope](../../../src/thirtytwo/Win32/System/Com/ComScope.cs) and its generic
+  companion.
+- Stable interface IDs use
+  [IID.Get<T>()](../../../src/thirtytwo/Win32/Foundation/IID.cs).
+- Managed CCWs are implemented by
+  [CustomComWrappers](../../../src/thirtytwo/Win32/System/Com/CustomComWrappers.cs)
+  and the `IManagedWrapper<T>`/vtable infrastructure in the same directory.
+- Long-lived ownership helpers include
+  [Lifetime<TVTable, TObject>](../../../src/thirtytwo/Win32/System/Com/Lifetime.cs).
+- COM tests live under
+  [src/thirtytwo_tests/Win32/System/Com](../../../src/thirtytwo_tests/Win32/System/Com).
+
+## Local rules
+
+- This repository targets only `net10.0-windows`; the portable core's .NET
+  Framework branches do not apply.
+- Preserve `ComScope<T>`'s owned-reference contract and readonly/no-copy design.
+  Pair changes with [il-copy-inspection](../il-copy-inspection/SKILL.md) when a
+  ref struct or by-value call shape changes.
+- Use [cswin32-interop](../cswin32-interop/SKILL.md) first for generated types,
+  blittable signatures, P/Invoke, and byte/element accounting.
+- Run [security-review](../security-review/SKILL.md) for vtable, pointer,
+  marshalling, or ownership changes.
+
+## Validation
+
+```pwsh
+dotnet build src/thirtytwo/thirtytwo.csproj --configuration Release
+dotnet test src/thirtytwo_tests/thirtytwo_tests.csproj --configuration Release --no-build --report-trx
+```

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -1,0 +1,127 @@
+---
+compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs across .NET 10 and .NET Framework. Owner/extender composition requires C# 14.
+description: Guides CsWin32 P/Invoke interop in a multi-targeted .NET 10 and .NET Framework library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, selecting compile-time / runtime / analyzer guards for Windows-only code, or choosing between CsWin32 and [LibraryImport]. Not for managed-only changes with no native boundary. Paired with the cswin32-com skill for the struct-based COM layer.
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/cswin32-interop
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 14960bec081ff29eaa9bf5593b7a6ca9d5201ae8
+    maturity: canary
+    portability: portable
+    related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy, security-review
+    requires: none
+    risk: local-write
+name: cswin32-interop
+---
+# CsWin32 P/Invoke interop
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+[CsWin32](https://github.com/microsoft/CsWin32) is a source generator that
+replaces hand-written `[DllImport]` declarations with generated `PInvoke.*`
+calls and strongly-typed projections of Win32 handles, structs, enums, and
+constants. You list the API, type, or constant names you need in
+`NativeMethods.txt`; the generator emits them and pulls in their dependencies.
+
+This skill is the general P/Invoke layer. The struct-based COM layer builds on
+it - see the paired **cswin32-com** skill, whose vtable methods follow the same
+[blittable-signatures](blittable-signatures.md) rules.
+
+## Rules
+
+1. **Replace a hand-written `[DllImport]` with `PInvoke.*` when CsWin32 can
+  project the API.** After verifying the generated declaration and supporting
+  types, delete their hand-written equivalents. Keep a source-generated
+  `[LibraryImport]` on .NET 10 and `[DllImport]` on .NET Framework for an
+  export absent from the available Win32 metadata. See
+  [types-and-constants.md](types-and-constants.md).
+2. **Use the generated types directly** (`HANDLE`, `HMODULE`, `HRESULT.S_OK`,
+   `FILE_FLAGS_AND_ATTRIBUTES`, ...). Never keep a parallel local copy of a
+   Win32 enum or struct CsWin32 already projects.
+3. **Call the generated method directly** - no thin wrapper. Within one
+   ownership layer, generate once and share internal types with friend
+   assemblies. When a downstream package intentionally extends a public owner,
+   use the [owner/extender composition](composition.md) model instead.
+4. **Prefer CsWin32 for Windows APIs present in its metadata.** Use
+  `[LibraryImport]` (or `[DllImport]` on .NET Framework) for private, custom,
+  or otherwise unprojectable Windows exports and for non-Windows native calls
+  such as `libc`. Keep those signatures blittable under the same rules.
+5. **Preserve the original error-handling contract when migrating.** Check the
+   old declaration for `PreserveSig` / `SetLastError` / `BOOL` / `HRESULT`
+   semantics and reproduce them: `PreserveSig=false` becomes
+   `.ThrowOnFailure()`; `SetLastError=true` plus a failed `BOOL` becomes
+   `throw new Win32Exception()`. Silently returning where the old code threw is
+   a behavior change. The paired cswin32-com skill has the COM-side parity
+   table.
+6. **Keep signatures blittable.** CsWin32 is configured `allowMarshaling: false`,
+   so every `[DllImport]` and every COM vtable method must be blittable. The
+   full rule set is in [blittable-signatures.md](blittable-signatures.md).
+7. **Audit ownership and size units.** Generated wrappers do not decide which
+   allocator frees an output, whether a COM reference remains caller-owned, or
+   whether a length is bytes or elements. Record and test those contracts using
+   [ownership-and-units.md](ownership-and-units.md).
+
+## Platform and target-framework guards
+
+CsWin32 projects Windows APIs, but compile inclusion, runtime reachability, and
+the public platform contract are separate decisions. Generated declarations can
+live in a cross-platform assembly; reachable calls still need a recognized
+Windows runtime guard or a Windows-only API context. Exclude source at compile
+time only when a target intentionally omits that interop surface or one of its
+dependencies. In the .NET 10 / .NET Framework target model, use `NET` for the
+.NET 10 leg and `NETFRAMEWORK` for the Framework leg. See
+[gating.md](gating.md) for the decision table, `CA1416`, and guarded-build
+verification. An overlay records the concrete TFMs and any repository-specific
+compile symbol or source-item condition.
+
+## Configuration
+
+- **`NativeMethods.txt`** - one API / type / constant name per line; the
+  generator projects each and pulls in its dependencies.
+- **`NativeMethods.json`** - generator options. `allowMarshaling: false` (raw
+  blittable signatures, no marshaller) and `useSafeHandles: false` are the
+  interop-friendly defaults these skills assume.
+- Run the generator in a single project within an ownership layer and share via
+  `InternalsVisibleTo` rather than adding CsWin32 to every implementation
+  project. A package that extends another package's public projection is a
+  separate layer: configure `className` / `extensionReceiver` as described in
+  [composition.md](composition.md).
+
+### Source generator versus build task
+
+The Roslyn source generator is the default. Setting
+`CsWin32RunAsBuildTask=true` replaces it with an MSBuild task that writes `.cs`
+files under the intermediate output directory and adds them to `Compile`; the
+source generator stands down. Treat this as an opt-in for a specific build
+ordering, generated-file, or tooling requirement, not as a general upgrade.
+
+Before keeping build-task mode, clean and build all .NET 10 and .NET Framework
+TFMs, compare the emitted public API, and measure clean-build time. It can be
+materially slower. It also does not make an `allowMarshaling: false` project
+more AOT-safe by itself, so do not enable `DisableRuntimeMarshalling` merely
+because generation moved to the task.
+
+## Sibling pages
+
+- [blittable-signatures.md](blittable-signatures.md) - the signature rules
+  shared by `[DllImport]` and COM vtables (`HRESULT`, `T**` vs `out T*`,
+  `void*`, `nint`, `PCWSTR` / `PWSTR`, typed enum parameters).
+- [types-and-constants.md](types-and-constants.md) - using the generated
+  handle / enum / constant projections, "grep the metadata before redefining",
+  type conversions, FILETIME, and native integers.
+- [composition.md](composition.md) - composing one public `PInvoke` across an
+  owner package and downstream extender, including constants, XML docs, and
+  package verification.
+- [library-layering.md](library-layering.md) - placing generic utilities,
+  shared Win32 support, domain extensions, and applications in a directed
+  package stack, with migration and release ordering.
+- [ownership-and-units.md](ownership-and-units.md) - matching native allocators
+  and deallocators, caller-owned COM references, failure cleanup, and
+  byte-versus-element conversions.
+- [gating.md](gating.md) - source inclusion, runtime and TFM guards, `CA1416`, a
+  stack-first scratch-buffer strategy, and guarded-build verification.

--- a/.agents/skills/cswin32-interop/blittable-signatures.md
+++ b/.agents/skills/cswin32-interop/blittable-signatures.md
@@ -1,0 +1,47 @@
+# Blittable signatures
+
+Detail for [cswin32-interop](SKILL.md). CsWin32 is configured
+`allowMarshaling: false`, so every `[DllImport]` and every manual COM vtable
+method must be **blittable** - the runtime does no marshalling at the boundary.
+These rules apply to both surfaces.
+
+- **Return `HRESULT`, not `int`,** from HRESULT-returning APIs. `HRESULT` is
+  blittable (a single `int` field) and exposes `.Succeeded` / `.Failed` /
+  `.Value` / `.ThrowOnFailure()`. Use `HRESULT.S_OK` instead of `0`; cast
+  `e.HResult` to `(HRESULT)` when wrapping. `AddRef` / `Release` return `uint`
+  (the `IUnknown` contract).
+- **Throw with `hr.ThrowOnFailure()`** rather than
+  `if (hr.Failed) Marshal.ThrowExceptionForHR(hr)`. It is the idiomatic helper,
+  produces the same `IErrorInfo`-enriched exception, and reads cleanly at the
+  call site: `iface->Method(...).ThrowOnFailure();`. Branch on the raw `hr` only
+  when you handle a specific code (e.g. `ERROR_INSUFFICIENT_BUFFER`) before
+  throwing.
+- **Prefer `T**` for raw pointer outputs and vtable signatures.** `out T*` is
+  also blittable and represents the same native indirection, but it introduces
+  managed by-reference syntax and cannot bind to helpers that expose `T**` or
+  `void**`. Keep `out T*` only when the hand-written declaration intentionally
+  wants C# definite-assignment semantics; match the raw ABI with `T**` by
+  default.
+- **Use `void*` for opaque / reserved parameters** and pass `null` literally -
+  never round-trip through `IntPtr.Zero` inside `unsafe`.
+- **Prefer `nint` / `nuint` for new native-sized values.** Keep
+  `IntPtr` / `UIntPtr` only where an existing public contract or managed API
+  requires those names (`Marshal.*`, `SafeHandle.DangerousGetHandle`, or a
+  compatibility-sensitive public API), and convert once at that boundary.
+- **Use the generated `PCWSTR` / `PWSTR` for wide strings,** never a managed
+  `string`. The caller pins with `fixed (char* p = managedString)` (implicit on
+  most overloads). Add the type to `NativeMethods.txt` if not yet generated.
+- **No managed reference types** (`string`, `StringBuilder`, arrays) in a
+  blittable signature.
+- **Do not set `PreserveSig = true` on `[DllImport]`** - it is the default. Use
+  `PreserveSig = false` only to force the marshaller to throw on failure
+  HRESULTs (rare; prefer returning `HRESULT` and calling `.ThrowOnFailure()`).
+  Note `[ComImport]` defaults the opposite way, but struct-based COM uses raw
+  `delegate*` invocation and is unaffected.
+- **Constrain flag / option parameters to a typed `enum`.** When a native
+  `DWORD` / `ULONG` / `int` is documented as a `typedef enum` or a `#define`
+  set, declare a matching C# `[Flags] enum Foo : uint` (same underlying type)
+  and use it in the signature (and in the `delegate*` cast for a COM method).
+  Mirror the constraint even when the native side has no named enum:
+  `OpenScope(path, CorOpenFlags.ofRead, ...)` self-documents where
+  `OpenScope(path, 0, ...)` does not. Co-locate the enum with its consumer.

--- a/.agents/skills/cswin32-interop/composition.md
+++ b/.agents/skills/cswin32-interop/composition.md
@@ -1,0 +1,101 @@
+# Layered owner/extender composition
+
+Detail for [cswin32-interop](SKILL.md). Use this model when one package owns the
+public CsWin32 projection and another package adds APIs to that same callable
+surface. This is different from sharing one internal projection with friend
+assemblies: each layer runs CsWin32, but only one layer owns the receiver type.
+For the broader managed-foundation / Win32-owner / domain-extender package
+stack and release order, see [library-layering.md](library-layering.md).
+
+## Choose the ownership boundary first
+
+| Layer | Responsibility |
+| --- | --- |
+| Owner | Publishes the canonical `Windows.Win32.PInvoke` and shared projected or hand-authored Win32 types. |
+| Extender | References the owner and projects additional APIs as C# 14 extension members on the owner's `PInvoke`. |
+| Consumer | References the extender and calls owner and extender APIs through one `PInvoke` surface. |
+
+The owner configuration names and publishes the receiver:
+
+```json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvoke",
+  "public": true,
+  "allowMarshaling": false,
+  "useSafeHandles": false
+}
+```
+
+The extender uses a different host name and points `extensionReceiver` at the
+owner type:
+
+```json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "Interop",
+  "extensionReceiver": "PInvoke",
+  "public": true,
+  "allowMarshaling": false,
+  "useSafeHandles": false
+}
+```
+
+The extender project must reference the owner assembly at compile time and use a
+C# version that supports extension blocks. Keep the CsWin32 package private in a
+library package unless consumers need it directly; generated source is compiled
+into the extender assembly.
+
+## What composes, and what does not
+
+- Call generated methods and read generated values through `PInvoke` in normal
+  runtime code. The extender's `Interop` type is the generated implementation
+  host, not a second public facade for ordinary calls.
+- A generated constant remains a real `const` on the extender host, while its
+  `PInvoke` projection is an extension property. Extension properties are not
+  compile-time constants. Enum initializers, `case` labels, constant patterns,
+  attributes, and optional-parameter defaults therefore use
+  `Interop.CONSTANT`; runtime expressions use `PInvoke.CONSTANT`.
+- Composition is receiver- and namespace-specific. A second projection root
+  such as `Windows.Wdk.Interop` does not automatically appear on
+  `Windows.Win32.PInvoke`; keep it separate or design another explicit receiver.
+- `partial` does not cross assembly boundaries. Do not try to augment an
+  owner-generated struct or `PInvoke` with a downstream `partial` declaration.
+  Put shared public types in the owner and add downstream behavior with C# 14
+  extension blocks. Give implementation-only provider types unique names so a
+  consumer never sees two public types with the same fully qualified name.
+- Read the generated extender output when overload resolution changes. A
+  friendly generated overload can become ambiguous with a downstream helper;
+  call the raw pointer overload explicitly or rename the helper rather than
+  introducing another facade.
+- Re-audit native ownership whenever a helper or call shape moves between
+  layers. Generated overloads do not preserve allocator, COM reference, or
+  byte/element obligations by themselves; use
+  [ownership-and-units.md](ownership-and-units.md).
+
+## Generated XML documentation diagnostics
+
+Some CsWin32 versions emit cross-assembly XML `cref` values for
+`extensionReceiver` members that Roslyn cannot resolve, producing `CS1574` or
+`CS1580` from generated code. First verify the diagnostics originate only in
+CsWin32 output and that the referenced API compiles. If so, suppress exactly
+those two diagnostics in the extender project and record why. A project-level
+suppression also applies to hand-authored source, so keep normal documentation
+review in the validation path rather than disabling XML warnings broadly.
+
+## Verify the packaged composition
+
+A same-solution build is necessary but not sufficient. Pack both layers, then
+build a scratch consumer that references **only the extender package** and
+compiles at least:
+
+1. one owner-provided `PInvoke` call;
+2. one extender-provided `PInvoke` call;
+3. any public extension member added to an owner-provided generated type.
+
+Restore into a clean package cache when reusing a local version number. This
+catches missing transitive dependencies, stale packages, duplicate generated
+types, inaccessible receivers, and composition that worked only through project
+references. Inspect the packed dependency graph too: an extender that directly
+uses a foundation library should declare it directly, even when the owner also
+depends on it.

--- a/.agents/skills/cswin32-interop/gating.md
+++ b/.agents/skills/cswin32-interop/gating.md
@@ -1,0 +1,93 @@
+# Platform and target-framework guards
+
+Detail for [cswin32-interop](SKILL.md). CsWin32 projects Windows APIs. Decide
+source inclusion, runtime reachability, and the platform contract independently;
+one guard does not automatically satisfy all three.
+
+## Choose the guard from the constraint
+
+| Constraint | Compile-time action | Runtime action |
+| --- | --- | --- |
+| Windows-specific TFM or assembly | Usually none; the assembly already carries the platform context. | None unless the API requires a newer Windows version than the assembly contract. |
+| Cross-platform assembly; declarations compile on both runtime families | None. | Guard every reachable call with a recognized Windows check, or annotate the containing API as Windows-only. |
+| A target intentionally omits the interop source or one of its dependencies | Exclude whole files with conditional `Compile` items, or use a documented project symbol for smaller regions. | Still guard calls on any included target that can run cross-platform. |
+| A member exists only on the .NET 10 leg | Use `#if NET`. | Independent of the platform guard. |
+| A member or polyfill exists only on .NET Framework | Use a Framework-only source folder or `#if NETFRAMEWORK`. | Independent of the platform guard. |
+
+Generated P/Invoke declarations are not themselves a reason to remove source
+from non-Windows builds. Use compile-time exclusion only when the project has a
+real source or dependency constraint. When a whole file is conditional, prefer
+an MSBuild item condition over a whole-file `#if`. Namespace `using` directives
+and private helpers referenced only by a conditional region must use the same
+condition. The overlay names any custom symbol or item condition.
+
+For a cross-platform binary, use a guard recognized by the platform analyzer:
+
+```csharp
+#if NET
+if (OperatingSystem.IsWindows())
+#else
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
+{
+    _ = PInvoke.GetCurrentProcessId();
+}
+else
+{
+    // Cross-platform fallback.
+}
+```
+
+Use `OperatingSystem.IsWindows()` on .NET 10 and
+`RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` on .NET Framework. If the
+interop call is also conditionally compiled, keep the compile condition outside
+the runtime branch so the fallback remains complete when that source is absent.
+
+## CA1416 platform compatibility
+
+For a cross-platform assembly, satisfy the analyzer semantically rather than
+suppressing it:
+
+- Use `OperatingSystem.IsWindows()` or
+  `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`. Annotate a custom
+  boolean field, property, or method with
+  `[SupportedOSPlatformGuard("windows")]` before relying on it as a guard.
+- Apply `[SupportedOSPlatform("windows")]` to an assembly, type, or member when
+  its contract is Windows-only. The attribute is valid on structs. Include a
+  version only when the API has that real minimum, and match the documented
+  version instead of applying one baseline to every CsWin32 call.
+- Use `#pragma warning disable CA1416` only as a narrow, justified last resort
+  when a recognized guard or platform annotation cannot express the contract.
+
+The platform attributes are available on modern .NET but not in .NET Framework
+reference assemblies. In dual-target source, place them under `#if NET` unless
+the Framework target provides a compatible source polyfill.
+
+## A stack-first scratch buffer
+
+Win32 string and buffer APIs often want caller-allocated storage followed by a
+length retry. Check for a CsWin32 `Span<T>` convenience overload before writing
+a `fixed` block. For a bounded common case, start with a small stack span and
+rent from `ArrayPool<T>` when the required length exceeds it. Choose the stack
+size from element size, call depth, measured workloads, and the repository's
+stack budget; there is no universal byte cutoff.
+
+A repository may provide a disposable `ref struct` that combines the stack and
+pool paths. Always dispose that scope so a rented array is returned. The
+`scratch-buffer-strategy` skill covers the choice when installed, and the
+overlay names any concrete helper. On retry, preserve the native API's exact
+length semantics: bytes versus elements, and whether the required count includes
+a terminator or header.
+
+## Verify the guarded build
+
+Anything referenced **only** inside a compile condition must itself be inside
+that condition, or the excluded build can fail under warnings-as-errors. Watch
+for `IDE0005` (unused `using`), `IDE0051` / `IDE0052` (unused private members),
+`CA1823` (an unused private field), and `CS1587` (an XML doc comment left before
+a conditional member).
+
+Build all .NET 10 and .NET Framework TFMs and every custom-symbol state that
+changes source inclusion. For a cross-platform binary, also execute an
+unsupported-OS path and verify it takes the fallback without loading or calling
+the Windows API.

--- a/.agents/skills/cswin32-interop/library-layering.md
+++ b/.agents/skills/cswin32-interop/library-layering.md
@@ -1,0 +1,91 @@
+# Support-library layering
+
+Detail for [cswin32-interop](SKILL.md). A public CsWin32 composition surface works
+best as one layer in a directed package stack, not as the place where every
+shared helper accumulates.
+
+## The four layers
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Managed foundation | Cross-domain buffers, pooling, collections, enum helpers, compiler/runtime polyfills, and other utilities that remain useful without a public Win32 API. | The canonical public `Windows.Win32.PInvoke` or public Win32 type identity. |
+| Win32 composition owner | The public `PInvoke`, shared generated Win32 types, Windows-specific lifetime/ownership helpers, common COM wrappers, and owner-only generated hooks. | Product- or domain-specific UI and workflow behavior. |
+| Domain extender | Additional generated APIs projected through `extensionReceiver`, domain wrappers, and extension members on owner-provided types. | Duplicate owner types, cross-assembly partial declarations, or a competing public `PInvoke`. |
+| Consumer | Application behavior that calls the composed surface. | Another generated projection unless it is intentionally a separate namespace/ABI domain. |
+
+The conceptual layer order is foundation -> owner -> extender -> consumer;
+package references point back down that stack. An extender may also reference
+the foundation directly when its source uses that surface. Declare that
+dependency explicitly rather than relying on the owner's transitive dependency.
+
+A foundation package may use platform interop internally. The boundary is its
+**public ownership contract**: an internal generated `PInvoke` does not compete
+with the composition owner, while a public `Windows.Win32.PInvoke` does.
+
+## Decide where a helper belongs
+
+Move a helper toward the lowest reusable layer that can own it without importing
+higher-level policy:
+
+- A pooled scratch buffer, allocation-free flag operation, or .NET Framework
+   BCL polyfill belongs in the managed foundation.
+- A `HANDLE` close helper, `HRESULT` mapping, `PWSTR` ownership operation,
+   owned COM-pointer scope, `SAFEARRAY`/`VARIANT` support, or owner-side CCW hook
+   belongs in the Win32 owner when multiple extenders can use it.
+- A windowing framework, accessibility model, dialog abstraction, or
+  domain-specific COM adapter belongs in the extender.
+- An implementation-only vtable provider needed by one extender stays there
+  under a unique name; it does not justify a duplicate imported interface.
+
+Before promoting code, remove dependencies on the higher layer and ask whether
+its public namespace and exception/ownership contract make sense for every
+consumer of the lower layer. "Used by two projects" is not enough if both uses
+carry the same product policy.
+
+## API identity and compatibility
+
+Moving a public type from an extender assembly into the owner is not merely a
+source relocation. Even with the same namespace and type name, its assembly
+identity changes. Treat the move as a binary and often source breaking change
+unless the old assembly provides type forwarding and compatible facade members.
+Also call out removed static facades, renamed nested types, and changed extension
+lookup in release notes.
+
+Do not leave both definitions public during migration. Two assemblies exporting
+the same fully qualified type create ambiguity instead of compatibility.
+
+## Release order and package metadata
+
+Publish from the bottom up:
+
+1. publish the managed foundation when its required surface changed;
+2. publish the Win32 owner against that foundation;
+3. restore the owner from the real feed into the extender, then publish the
+   extender;
+4. validate an application that references only the top-level package.
+
+Keep the owner and extender on compatible CsWin32 versions and language levels.
+If the owner is prerelease, the extender package must also be prerelease; NuGet
+warns when a stable package depends on a prerelease package. Inspect the packed
+extender nuspec to confirm the owner and foundation dependency versions before
+publishing.
+
+## Migration sequence
+
+For an existing library that duplicates owner candidates:
+
+1. inventory generated types, hand-authored partials, helpers, and static
+   facades; classify each into the four layers;
+2. add the shared public surface and generated hooks to the owner, with direct
+   tests, and publish it first;
+3. restore that published owner into an empty package root using normal feeds;
+4. configure `extensionReceiver`, remove duplicate types, and convert downstream
+   augmentation to extension blocks or uniquely named provider types;
+5. audit every raw pointer and native buffer while changing call shapes; moving
+   ownership does not preserve caller obligations automatically;
+6. pack the extender and build a clean-cache consumer that references only the
+   extender package.
+
+For the final restore, use `--no-cache` and a fresh `--packages` directory. Check
+`project.assets.json`, the package's `.nupkg.metadata` source, and the nuspec so a
+locally cached rehearsal package cannot masquerade as the published dependency.

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -1,0 +1,47 @@
+---
+core: cswin32-interop
+core-pin: v0.11.0
+---
+
+# CsWin32 interop overlay
+
+Repository-specific bindings for thirtytwo.
+
+## Surface
+
+- The owning project is
+  [src/thirtytwo/thirtytwo.csproj](../../../src/thirtytwo/thirtytwo.csproj),
+  targeting `net10.0-windows` with C# 14.
+- CsWin32 inputs are
+  [NativeMethods.txt](../../../src/thirtytwo/NativeMethods.txt) and
+  [NativeMethods.json](../../../src/thirtytwo/NativeMethods.json).
+- The generator emits a public `Interop` class whose methods are also
+  accessible on `PInvoke` as extension methods, with `allowMarshaling: false`,
+  `useSafeHandles: false`, and preserved COM signatures. Keep native
+  signatures blittable.
+- Generated and hand-authored projections use the `Windows.Win32` namespace.
+  Search the existing generated input and partial types before adding a local
+  duplicate.
+- The repository is modern-only and Windows-only. Framework TFM branches and
+  cross-platform runtime guards in the portable core do not apply unless the
+  project targets change.
+
+## Ownership and exceptions
+
+- Preserve explicit handle, allocator, pointer, and byte-versus-element
+  contracts. Pair changes involving unsafe preconditions with
+  [security-review](../security-review/SKILL.md).
+- The hand-written `NtQueryKey` declaration in
+  [Interop.NtQueryKey.cs](../../../src/thirtytwo/Wdk/Interop.NtQueryKey.cs)
+  covers a metadata gap. Do not replace it without verifying the available
+  Win32 metadata and the existing analyzer suppression rationale in
+  [AssemblyAttributes.cs](../../../src/thirtytwo/AssemblyAttributes.cs).
+- Use [cswin32-com](../cswin32-com/SKILL.md) for COM vtables, activation,
+  CCWs, and reference lifetime.
+
+## Validation
+
+```pwsh
+dotnet build src/thirtytwo/thirtytwo.csproj --configuration Release
+dotnet test src/thirtytwo_tests/thirtytwo_tests.csproj --configuration Release --no-build --report-trx
+```

--- a/.agents/skills/cswin32-interop/ownership-and-units.md
+++ b/.agents/skills/cswin32-interop/ownership-and-units.md
@@ -1,0 +1,133 @@
+# Native ownership and size units
+
+Detail for [cswin32-interop](SKILL.md). Generated signatures make calls easier to
+write; they do not infer who owns an output or whether a length is bytes,
+characters, or elements. Read the native contract before choosing a wrapper.
+
+## Record the ownership contract before calling
+
+For every pointer or handle output, identify all four facts:
+
+1. who allocates or increments the reference;
+2. whether the result is owned or borrowed;
+3. which operation releases it;
+4. whether failure guarantees the output is initialized.
+
+Common pairs include:
+
+| Acquired value | Release operation |
+| --- | --- |
+| AddRef'd COM interface | `IUnknown::Release` (prefer a repository-provided owned-pointer scope) |
+| COM task allocator memory, including many Shell PIDLs | `CoTaskMemFree` |
+| `LocalAlloc` memory | `LocalFree` |
+| `BSTR` | `SysFreeString` / `Marshal.FreeBSTR` |
+| Owned Win32 handle | The API-specific close function, such as `CloseHandle` |
+| Borrowed pointer/handle | No release; keep the owner alive for the whole use |
+
+Do not infer the deallocator from the projected pointer type. Two `PWSTR` values
+can have different allocators depending on the API that returned them.
+
+## Cleanup must cover failure paths
+
+A native API may leave an output untouched when it fails. If cleanup runs in a
+`finally`, initialize the actual native output storage to null and prefer the raw
+pointer overload so that initialization cannot be hidden by a convenience
+wrapper:
+
+```csharp
+ITEMIDLIST* itemIdList = null;
+HRESULT result;
+fixed (char* pathPointer = path)
+{
+    result = PInvoke.SHParseDisplayName(
+        pathPointer,
+        null,
+        &itemIdList,
+        0,
+        null);
+}
+
+try
+{
+    result.ThrowOnFailure();
+    // Consume itemIdList.
+}
+finally
+{
+    PInvoke.CoTaskMemFree(itemIdList);
+}
+```
+
+Freeing null is safe for the matching Windows allocators. Inspect generated
+convenience-overload source before relying on its failure initialization or
+ownership behavior.
+
+## A retained COM pointer is still caller-owned
+
+A helper that returns an AddRef'd COM pointer gives the caller one reference.
+Passing it to a method such as `Advise`, `SetClientSite`, or another retaining
+API does not transfer that caller reference. The callee adds its own reference
+when its contract retains the pointer; the caller still releases its reference.
+In the example, `AcquireOwnedCcwPointer<T>()` is pseudocode for a repository
+helper that returns one caller-owned CCW interface pointer. Its implementation
+may use classic COM marshalling or `ComWrappers`; only the latter can support a
+NativeAOT path. Use the repository's owned-pointer scope when available;
+otherwise make the release explicit:
+
+```csharp
+IEventSink* sink = AcquireOwnedCcwPointer<IEventSink>(managedSink);
+try
+{
+    source->Advise(sink, &cookie).ThrowOnFailure();
+}
+finally
+{
+    if (sink is not null)
+    {
+        sink->Release();
+    }
+}
+```
+
+Pair every successful cookie-producing `Advise` with `Unadvise(cookie)` before
+releasing the source object. Do not confuse a non-retaining parameter with a
+borrowed pointer: an owned pointer passed to a non-retaining call still needs its
+caller reference released, while a pointer that is itself borrowed must not be
+released. Keep the borrowed pointer's owner alive for the whole call, or call
+`AddRef` first when an owned scope is required.
+
+## Length parameters: bytes are not elements
+
+Read each length parameter's native documentation. A managed buffer abstraction
+usually reports **elements**, while many NT and Win32 APIs accept and return
+**bytes**. Convert explicitly with checked arithmetic:
+
+```csharp
+uint capacityInBytes = checked((uint)buffer.Length * sizeof(char));
+
+// Native call writes requiredBytes.
+int requiredElements = checked(
+    (int)(((ulong)requiredBytes + sizeof(char) - 1) / sizeof(char)));
+buffer.EnsureCapacity(requiredElements);
+```
+
+Use ceiling division for a required **capacity** because an odd byte count still
+needs another element. For a payload length that must contain whole elements,
+validate divisibility when malformed native data is possible, then divide
+exactly. Also distinguish whether a returned byte count includes a header,
+terminator, or only payload; size the whole native buffer but slice only the
+payload field.
+
+## Review and test shapes
+
+When adding or migrating an interop call, cover the branches that expose the
+contract:
+
+- success and native failure, including cleanup after each;
+- null/default output and double-dispose or repeated cleanup when supported;
+- a result large enough to force buffer growth;
+- a malformed or odd-sized payload when the input is not trusted;
+- a retaining COM call followed by explicit disconnect and owner disposal.
+
+A happy-path build cannot detect a leaked reference, the wrong allocator, or a
+byte/element mismatch that only appears beyond the initial buffer.

--- a/.agents/skills/cswin32-interop/types-and-constants.md
+++ b/.agents/skills/cswin32-interop/types-and-constants.md
@@ -1,0 +1,96 @@
+# Types and constants
+
+Detail for [cswin32-interop](SKILL.md). Prefer the CsWin32 projection over any
+hand-written copy, and let the typed value flow as far as possible before
+casting.
+
+## Prefer the generated projection - grep the metadata first
+
+Before defining a `private const int ERROR_*` or a `private enum FooFlags`,
+search the generated metadata; CsWin32 almost certainly already projects it:
+
+- `ERROR_*` (Win32 error codes) -> `WIN32_ERROR.ERROR_*` (a `uint` enum)
+- `HRESULT` codes -> `HRESULT.S_OK`, etc.
+- File flags -> `FILE_FLAGS_AND_ATTRIBUTES`, `FILE_ACCESS_RIGHTS`,
+  `FILE_SHARE_MODE`, `FILE_CREATION_DISPOSITION`
+- Process flags -> `PROCESS_CREATION_FLAGS`, `STARTUPINFOW_FLAGS`,
+  `PROCESS_ACCESS_RIGHTS`
+- Memory mapping -> `PAGE_PROTECTION_FLAGS`, `FILE_MAP`
+- Standard handles / known folders -> `STD_HANDLE`, `KNOWN_FOLDER_FLAG`
+
+Add the name to `NativeMethods.txt` if not yet generated, then read the emitted
+`Windows.Win32.<Name>.g.cs` under the generator's output for the exact shape.
+
+In a layered `extensionReceiver` project, the real `const` remains on the
+extender's generated host (for example, `Interop.VALUE`); the member projected
+onto the owner's `PInvoke` is an extension property. Use the host in enum
+initializers, `case` labels, constant patterns, attributes, and optional defaults,
+because an extension property is not a compile-time constant. Use the unified
+`PInvoke.VALUE` surface in runtime expressions. See
+[composition.md](composition.md).
+
+## Some flags are standalone constants, not enum members
+
+A Win32 `#define` that sits outside a `typedef enum` generates as a `const` on
+the configured generated host, not as an enum member. Its visibility follows
+the CsWin32 `public` setting. Add the **constant name** to `NativeMethods.txt`
+like any API, then OR it onto an enum of matching width and cast back where
+needed. Do not reintroduce a local `const` the generator already emits.
+
+## Match local types to the generated type
+
+Declare the CsWin32 type and let it flow, instead of casting to `int` / `uint`
+at every use:
+
+```csharp
+// Keep the generated type rather than storing the result as int.
+WIN32_ERROR result = PInvoke.RmStartSession(...);
+
+// Cast only at a non-CsWin32 boundary.
+Win32Exception exception = new((int)result, ...);
+```
+
+The same applies to `HRESULT`, `BOOL`, `HANDLE`, and every flag enum. **Delete
+local mirror enums** that exist only to duplicate a Win32 one - the generated
+type is the source of truth.
+
+## Type conversions
+
+- `HANDLE` <-> `nint`: `(HANDLE)ptr` / `(nint)h.Value`. Sentinels:
+  `HANDLE.Null`, `HANDLE.INVALID_HANDLE_VALUE`.
+- `BOOL` is a struct - use its implicit conversion to `bool`, never a raw
+  `int` / `uint`.
+- `HRESULT` - check `.Succeeded` / `.Failed`; cast to `int` only at a boundary
+  with a non-CsWin32 API.
+- Nullable value-type parameters: `(SECURITY_ATTRIBUTES?)null`.
+- **Anonymous unions** surface as nested `Anonymous` members
+  (`info.Anonymous.Anonymous.wProcessorArchitecture`) - read the generated
+  `*.g.cs` for the exact path.
+- **Enum flags:** test with bitwise `&`. `Enum.HasFlag` boxes on .NET Framework;
+  avoid it on hot paths. A repo may ship allocation-free flag extensions - see
+  the overlay.
+
+## FILETIME
+
+`FILETIME` is a split 32/32 value; convert with a helper, never hand-roll
+`DateTime.FromFileTime((long)hi << 32 | lo)`. Note CsWin32 uses
+`ComTypes.FILETIME` (int fields) for COM members and
+`Windows.Win32.Foundation.FILETIME` (uint fields) for kernel ones; a shared
+extension usually targets `ComTypes.FILETIME`. Read the producing API's time
+contract and choose the desired managed result deliberately. `GetFileTime` and
+the creation / exit outputs from `GetProcessTimes` are UTC-based timestamps: use
+`FromFileTimeUtc` to preserve UTC, or `FromFileTime` only when intentionally
+converting the result to local time. The kernel / user outputs from
+`GetProcessTimes` are elapsed 100-nanosecond durations, not dates; combine their
+64-bit values and convert them to `TimeSpan` ticks. Do not infer time-zone or
+duration semantics from the projected struct shape.
+
+## Native integers
+
+Prefer `nint` / `nuint` for new native-sized values. Preserve
+`IntPtr` / `UIntPtr` where an existing public contract or managed API requires
+those names, and convert at that boundary rather than carrying both forms
+through the implementation. Note that `nint` does not implement
+`IEquatable<nint>` on .NET Framework, so a generic method constrained
+`where T : unmanaged, IEquatable<T>` cannot be instantiated with `nint` for a
+cross-target call site - pick a concrete value type or split the path by TFM.

--- a/.agents/skills/engineering-baseline/SKILL.md
+++ b/.agents/skills/engineering-baseline/SKILL.md
@@ -1,0 +1,127 @@
+---
+compatibility: Requires PowerShell 7.2, git, and the .NET SDK; remote setup additionally uses authenticated gh.
+description: Create a new .NET repository fully wired for building, testing, and publishing with OSS best practices, or bring an existing repository up to a documented engineering baseline. Use when asked to "create a new repository" / "scaffold a new project" (a CLI tool, a class library / NuGet package, or a multi-target library) with CI, packaging, branch protection, and governance files, or to "ensure this repo follows modern engineering best practices" / "audit this repository" / "bring this repo up to standard". Scores a repository across nine domains - foundation, build, test, publish, versioning, CI, supply-chain security, OSS governance, and agent enablement - against an industry-cited baseline, then reports gaps and remediates. Irreversible or remote actions (repository creation, branch protection, release settings, publishing) are proposed for explicit approval, never run silently.
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/engineering-baseline
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: b0e52e484192142c2b3083ee181b4f7a5b61b0d6
+    maturity: canary
+    portability: portable
+    related: manage-skills, security-review, create-pr, github-actions-cost-optimization
+    requires: none
+    risk: remote-write
+name: engineering-baseline
+---
+# Engineering baseline
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+The repository-lifecycle skill: stand up a new repository wired for the full
+build / test / publish path with open-source best practices, or measure an
+existing repository against the same standard and close the gaps. Both verbs
+share one normative definition of "good" - the **baseline** - and one record of
+the choices behind it, each traced to an authoritative industry source.
+
+The standard in one paragraph: a high-quality .NET repository is **buildable**
+(centralized, deterministic, analyzer-enforced), **tested** (with coverage and,
+where it applies, perf and fuzz surfaces), **publishable** (signed, SourceLinked,
+validated packages with rich metadata), **released** deterministically from tags,
+**gated** by cost-aware CI with least-privilege tokens and pinned actions,
+**secured** by branch protection, dependency updates, and scanning,
+**governed** by the OSS community files, and **agent-enabled** with vendored
+skills and the agent-file gates. The [baseline](baseline.md) is that standard as
+a checklist; the [citation catalog](references/best-practices.md) is the *why*
+behind every line.
+
+## When to use
+
+- "Create a new repository for a command-line tool", "scaffold a new library",
+  "set up a new project with CI and publishing" - the greenfield path.
+- "Ensure this repository follows modern engineering best practices", "audit
+  this repo", "bring this repo up to standard", "what is missing for engineering
+  fundamentals here" - the brownfield path.
+- Before making a repository public, or onboarding it into a shared fleet, to
+  confirm the governance and supply-chain gates are in place.
+
+Not for vendoring or syncing the agent skills themselves - that is the
+skill-lifecycle skill (a consuming repository names it in its overlay). This
+skill *consumes* that one as the agent-enablement domain of the baseline.
+
+## The two verbs
+
+| Ask | Do | Detail |
+| --- | --- | ------ |
+| "audit this repo", "bring it up to standard" | Inventory the repo, score it by domain against the baseline, report gaps highest-risk-first, then remediate in safe-to-risky order. | [assess.md](assess.md) |
+| "create a new repo", "scaffold a CLI tool / library" | Pick the archetype, lay down the standard structure, build/test/publish wiring, CI, governance files, and the agent gates, then propose the remote setup. | [scaffold.md](scaffold.md) |
+
+Both measure against the same [baseline.md](baseline.md), and both end at the
+same remote-setup boundary (below). Scaffold is "build to the baseline from
+nothing"; assess is "diff an existing repo against the baseline and converge."
+
+## The baseline domains
+
+The baseline groups every check into nine domains, used identically by both
+verbs and by the scoring report:
+
+1. Repository foundation and licensing
+2. Build configuration
+3. Testing and coverage
+4. Packaging and publishing
+5. Versioning and releases
+6. CI/CD
+7. Supply-chain and security
+8. OSS governance and community
+9. Agent enablement
+
+Each domain's concrete checks, the recommended choice, and the one-line rationale
+live in [baseline.md](baseline.md). The external authority for each choice - and
+the notes on where reasonable setups diverge - live in the
+[citation catalog](references/best-practices.md).
+
+## Guardrails: the remote boundary
+
+Most of the baseline is local, reversible, and safe to apply directly: writing
+`Directory.Build.props`, adding a workflow file, creating a `SECURITY.md`. Apply
+those directly.
+
+A few actions are remote or hard to reverse. **Never run these silently.**
+Propose the exact command or setting, show it, and wait for an explicit
+publishing verb before executing:
+
+- Creating or renaming the remote repository (`gh repo create`).
+- Branch protection or repository rulesets (`gh api`, ruleset JSON).
+- Release, tag, and publishing settings, including trusted-publishing policies
+  and the first package push.
+- Anything that pushes commits, opens a PR, or cuts a release.
+
+This mirrors the publish boundary in the repository's own agent guidance: the
+work of preparing a change is authorized by the request; the publish is not.
+When in doubt, stop and ask one yes/no question.
+
+## Related skills
+
+Run a security review over any code the scaffold generates or the assessment
+adds, and use the repository's PR skills to publish the result. Hand detailed
+workflow usage, billing, and matrix analysis to the GitHub Actions cost
+optimization skill. The agent-enablement domain hands off to the skill-lifecycle
+skill and the fleet onboarding runbook for vendoring the skill tier and wiring
+the agent-file gates. A consuming repository wires these concrete
+cross-references in its overlay.
+
+## Sub-pages
+
+- [baseline.md](baseline.md) - the nine-domain gold-standard checklist with the
+  recommended choice and rationale for each item.
+- [assess.md](assess.md) - the brownfield procedure: inventory, score, gap
+  report, and safe-order remediation.
+- [scaffold.md](scaffold.md) - the greenfield procedure: archetype selection and
+  the build-to-baseline sequence for a CLI tool, library, or multi-target library.
+- [references/best-practices.md](references/best-practices.md) - the citation
+  catalog: every baseline choice traced to its industry source, with the
+  rationale and the divergence notes.

--- a/.agents/skills/engineering-baseline/assess.md
+++ b/.agents/skills/engineering-baseline/assess.md
@@ -1,0 +1,150 @@
+# Assess an existing repository
+
+The brownfield verb: measure a repository against [baseline.md](baseline.md),
+report the gaps by risk, and converge - applying safe fixes directly and
+proposing the rest. Triggered by "ensure this repo follows modern engineering
+best practices", "audit this repository", or "bring this repo up to standard".
+
+The output is a **scored gap report plus an applied set of safe fixes**, never a
+silent rewrite. Stop at the remote boundary (see the core's guardrails) and at
+anything that needs a judgment call.
+
+## 1. Inventory
+
+Read the repository's actual state before judging it. Gather, read-only:
+
+- Root files: `LICENSE`, `README.md`, `SECURITY.md`, `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `CHANGELOG.md`, `.editorconfig`, `.gitignore`,
+  `.gitattributes`, `global.json`, `Directory.Build.props` / `.targets`,
+  `Directory.Packages.props`.
+- The project graph: which projects exist, their target frameworks, which is the
+  shippable one, whether test / perf / fuzz / analyzer projects are present.
+- `.github/`: workflows, `dependabot.yml`, `CODEOWNERS`, issue/PR templates,
+  rulesets, `copilot-instructions.md`.
+- CI topology: triggers, matrices, runners, required status names, repeated
+  setup, caches/artifacts, and whether one merged change causes duplicate runs.
+- Agent wiring: `AGENTS.md`, the skills location, the agent-file validator and
+  its CI gate.
+- Remote settings you can read without admin: read them from the repository's
+  own files rather than the GitHub API - the workflow YAML shows whether publish
+  uses OIDC (`id-token: write` plus a trusted-publishing login step) or a stored
+  key. Toggles that need an admin token (branch protection / rulesets, secret
+  scanning, push protection) cannot be read from the tree; mark them
+  **unverified - admin required** rather than guessing.
+
+Record two things that drive applicability: the primary **archetype** (tool,
+library, multi-target library, or app), which selects the archetype tags, and
+the **release status** (pre-release, stable, or end-of-life). Determine release
+status from the tag list (read-only `git tag` or `.git/refs/tags`) and the
+package gallery; if there are no tags and no published package, treat the repo as
+**pre-release**, corroborated by README markers like "coming soon". Release
+status decides whether the temporal items (package validation, release record,
+immutability, signing) apply yet or score N/A.
+
+## 2. Score by domain
+
+For each of the nine [baseline.md](baseline.md) domains, mark every applicable
+item (by its archetype tag) as one of:
+
+- **Met** - present and correct.
+- **Partial** - present but weaker than the baseline (for example actions pinned
+  by a mutable tag/major version instead of a SHA, or coverage collected but not
+  gated).
+- **Missing** - absent and applicable now.
+- **N/A** - does not apply: the archetype tag excludes it, or a **temporal**
+  item's milestone has not been reached (record why, for example "N/A until the
+  first stable release").
+
+Two scoring rules the cold cases need:
+
+- **Temporal items** (marked temporal in the baseline, for example
+  `EnablePackageValidation` "once a stable release exists") score **N/A with a
+  note** before the milestone, not **Missing** - a pre-release library is not
+  failing a post-release check.
+- **Pick-one items** (a release record: `CHANGELOG.md` *or* curated GitHub
+  Releases) score **Met** if either is present, **Partial** if neither is present
+  yet but the repo must eventually choose - flag the pending choice in the report.
+
+Produce a compact table, one row per domain, plus an itemized list of every
+Partial and Missing finding. Keep it factual - cite the file and the line, not
+an opinion.
+
+## 3. Report gaps, highest-risk first
+
+Order findings so the report leads with what matters. Use this risk order, which
+follows the OpenSSF Scorecard risk levels in the
+[citation catalog](references/best-practices.md):
+
+1. **Critical / High** - no branch protection, a stored long-lived publishing
+   key, no static analysis, missing license, a workflow that checks out and runs
+   untrusted PR code with write scope, or actions referenced by a **floating
+   ref** (a branch or `@latest`, which can change under you).
+2. **Medium** - no dependency-update tool, no SECURITY.md, no package validation,
+   missing SourceLink, no coverage gate, or actions pinned by a **mutable
+   tag/major version** without a stated policy (weaker than a SHA, but not a
+   floating ref - score Partial).
+3. **Low** - missing community files (code of conduct, templates), no CHANGELOG,
+   stylistic analyzer gaps.
+
+Action pinning has a deliberate gray zone: a SHA pin is the recommended choice, a
+floating branch ref is High, and a tag/major-version pin sits in between -
+**Partial**, and an **accepted divergence** when the repo states it as policy
+(see the catalog's divergence notes). Do not score a tag/major pin as Critical.
+
+For each finding give: the gap, the baseline item it fails, the cited reason,
+and the concrete remediation. Where the repository made a **deliberate** contrary
+choice (GitHub Releases instead of a `CHANGELOG.md`; major-version action pins as
+a stated policy), record it as an accepted divergence, not a defect - the
+catalog's divergence notes describe the common ones. If the repo documents its
+engineering choices (in `AGENTS.md`, a `docs/` philosophy page, or the README),
+read that first - a mature repo's conscious omission is an accepted divergence,
+not a gap.
+
+## 4. Remediate in safe-to-risky order
+
+Apply fixes in this order, so the reversible work lands first and the report
+stays ahead of the risky steps:
+
+1. **Local, additive, inert (apply directly).** Files that neither execute nor
+   change build behavior on merge, and opt-in metadata: `.editorconfig`,
+   `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue/PR templates,
+   SourceLink and package-metadata properties, `ContinuousIntegrationBuild`,
+   coverage collection. Validate after each (build, and the repo's agent-file
+   gates for agent files).
+2. **Local but behavior-changing (apply, then call out).** Anything that runs or
+   changes behavior on merge, even though the file itself is reversible: a new
+   workflow (a CodeQL or other CI job executes on the next push), a
+   `dependabot.yml` (it opens PRs on its own), turning on `TreatWarningsAsErrors`,
+   raising `AnalysisLevel`, pinning actions to SHAs, adding a coverage gate. These
+   can break the build or CI or generate activity; do them in a reviewable commit
+   and say so. Re-pin actions to SHAs using the version the repo already trusts,
+   recording the version in a trailing comment.
+3. **Remote or irreversible (propose, then run only on approval).** Branch
+   protection / rulesets, secret-scanning and push-protection toggles, the
+   trusted-publishing policy and the switch off a stored API key, the default
+   branch, repository visibility. Emit the exact `gh` / API command or the ruleset
+   JSON, show it, and wait for an explicit publishing verb. Never run these
+   silently.
+
+Batch related local fixes into coherent commits with clear messages. Do not
+commit or push unless the user asks - preparing the changes is authorized;
+publishing them is not.
+
+## 5. Hand off specialized domains
+
+- For domain 7 findings on code that handles untrusted input, run the security
+  review skill rather than judging vulnerability shapes here.
+- For domain 6 findings about runner choice, matrices, duplicate triggers,
+  storage, or estimated spend, run the GitHub Actions cost optimization skill.
+  This baseline establishes the required shape; that skill measures and tunes it.
+- For domain 9 (vendoring the skill tier, wiring the validator and link checker,
+  the drift loop), hand off to the skill-lifecycle skill and the fleet
+  onboarding runbook - this skill confirms the gate exists; those own the how.
+
+A consuming repository names both skills in its overlay.
+
+## 6. Report back
+
+Summarize: the per-domain score before and after, the fixes applied, the
+behavior-changing commits to review, and the remote actions awaiting approval
+with their exact commands. End with the single highest-value next step.

--- a/.agents/skills/engineering-baseline/baseline.md
+++ b/.agents/skills/engineering-baseline/baseline.md
@@ -1,0 +1,271 @@
+# The baseline
+
+The normative gold standard, grouped into nine domains. Each item states the
+**recommended choice** and a one-line **why**; the external authority and the
+divergence notes are in the [citation catalog](references/best-practices.md),
+keyed by the same domain numbers.
+
+Each item is tagged:
+
+- **(core)** - every repository should satisfy it.
+- **(library)** - applies when the repo ships a NuGet package.
+- **(tool)** - applies when the repo ships an executable / `dotnet` tool.
+- **(conditional: <condition>)** - applies only when the named condition holds;
+  the parenthetical states the trigger so applicability is mechanical (for
+  example *(conditional: untrusted input)*).
+- **(deferred)** - in scope, but the actual judgment is owned by another skill;
+  confirm the check is wired, do not perform it here.
+
+Scoring and remediation read these tags to decide applicability; see
+[assess.md](assess.md). An item marked **temporal** applies only after a
+milestone ("once a stable release exists"); before that milestone it scores
+**N/A** with a note, not **Missing**. Concrete file names below
+(`Directory.Build.props`, `global.json`, ...) are .NET ecosystem conventions,
+not repo-specific paths. A repository's own layout, target frameworks, and
+project names are bound in its overlay - this core states the *shape*, not the
+literals.
+
+## 1. Repository foundation and licensing
+
+- **(core)** A top-level `LICENSE` file with an [SPDX](https://spdx.org/licenses/)-identified
+  open-source license (MIT is the fleet default). Why: without a license the
+  project defaults to exclusive copyright and cannot be used or reviewed.
+- **(core)** A `README.md` that states what the project is, how to install it,
+  and where to find docs. Why: it is the first and most-read artifact, and it
+  doubles as the package landing page.
+- **(core)** A `.gitignore` scoped to the toolchain (build output, `obj/`,
+  `bin/`, IDE state) and a `.gitattributes` that normalizes line endings
+  (`* text=auto`). Why: keeps generated and machine-specific files out of history
+  and avoids cross-platform diff churn.
+- **(core)** An `.editorconfig` that sets indentation, encoding, naming rules,
+  and analyzer severities. Why: makes style machine-enforceable instead of a
+  review topic.
+- **(core)** A license header on every source file, enforced
+  (`file_header_template` + `IDE0073`). Why: each file states its license and
+  copyright with a machine-readable SPDX id. Omit a per-file year (maintenance
+  churn, no legal benefit) and credit "<owner> and contributors" rather than a
+  roster.
+- **(conditional: redistributes third-party code)** A `NOTICE` /
+  `THIRD-PARTY-NOTICES` file when third-party code is redistributed. Why:
+  satisfies attribution obligations of bundled licenses.
+
+## 2. Build configuration
+
+- **(core)** SDK-style projects; framework and package metadata in the project
+  file. Why: the supported, tooling-friendly project format.
+- **(core)** Central build properties in `Directory.Build.props` /
+  `Directory.Build.targets`. Why: one source of truth for language version,
+  nullability, and analysis settings across every project.
+- **(core)** Route build output and intermediates to a top-level `artifacts/`
+  tree (for example `artifacts/bin/` and `artifacts/obj/` via
+  `BaseOutputPath` / `BaseIntermediateOutputPath`). Why: keeps repository roots
+  clean, makes cleanup deterministic, and standardizes paths for CI artifacts.
+- **(core)** Central Package Management via `Directory.Packages.props`
+  (`ManagePackageVersionsCentrally=true`). Why: one pinned version per package,
+  repo-wide, removing version drift between projects.
+- **(core)** Commit a lock file (`packages.lock.json` via
+  `RestorePackagesWithLockFile`) and enable NuGet audit (`NuGetAudit` with
+  `NuGetAuditMode=all`); CI restores with `--locked-mode`. Why: pins the full
+  dependency graph including transitives, fails on drift, and flags advisories on
+  direct and transitive packages every restore.
+- **(core)** A pinned SDK in `global.json` with a `rollForward` policy. Why:
+  reproducible builds across machines and CI; no silent SDK drift.
+- **(core)** `Nullable=enable` globally (in `Directory.Build.props`), plus a
+  current `LangVersion` and a deliberate `ImplicitUsings` setting. Why: every
+  project opts into the compiler's null-safety analysis by default.
+- **(core)** Keep the shippable project AOT/trim clean on its modern target
+  (`IsAotCompatible=true`), which turns on the trim, AOT, and single-file
+  analyzers. Why: the code composes into trimmed/AOT apps and avoids expensive
+  runtime reflection - worth keeping clean even if you never publish AOT, and
+  with warnings-as-errors a regression fails the build.
+- **(core)** `TreatWarningsAsErrors=true` (with a short, documented
+  `WarningsNotAsErrors` escape list) and `EnableNETAnalyzers` with a chosen
+  `AnalysisLevel` / `AnalysisMode`. Why: keeps warnings from accumulating and
+  turns the analyzers on by default.
+- **(core)** `EnforceCodeStyleInBuild=true`. Why: surfaces the `.editorconfig`
+  IDE rules as build diagnostics so style is enforced headlessly in CI.
+- **(library)** `GenerateDocumentationFile=true`. Why: ships XML docs and flags
+  undocumented public surface.
+- **(core)** Deterministic build, with `ContinuousIntegrationBuild=true` set
+  under the CI environment. Why: reproducible, path-independent outputs and PDBs.
+
+## 3. Testing and coverage
+
+- **(core)** A dedicated test project on the
+  [Microsoft Testing Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro)
+  (MTP): the test project is an executable (`OutputType=Exe`) with an MTP runner
+  (`EnableMSTestRunner` for MSTest, `UseMicrosoftTestingPlatformRunner` for
+  xunit.v3), selected in `global.json` (`"test": { "runner":
+  "Microsoft.Testing.Platform" }`). Why: MTP is the supported, self-contained,
+  faster successor to the VSTest host and the direction for every .NET test
+  framework.
+- **(core)** Default to MSTest; when using xunit, use v3 - both are first-class
+  on MTP. Why: a current, MTP-native framework; the fleet defaults away from
+  xunit's contribution policy on AI-assisted changes. This is a fleet choice, not
+  a hard rule - an overlay may pick another MTP-capable framework.
+- **(core)** Run at the fullest concurrency the framework allows by default
+  (MSTest `[assembly: Parallelize(Workers = 0, Scope = MethodLevel)]`; xunit.v3
+  unlimited parallel threads). Why: fast feedback, and it surfaces hidden test
+  ordering or shared-state bugs early.
+- **(core)** Tests run in Release on every merge candidate. Run them again on a
+  default-branch push only when a direct or bypass update can avoid equivalent
+  pre-merge validation; a pull request with strict up-to-date checks or a merge
+  queue should not pay for an identical post-merge run. Why: Release codegen and
+  timing differ from Debug; gate what ships without duplicating the same
+  candidate.
+- **(core)** Code coverage collected and reported, with a gate on patch
+  coverage (new/changed lines). Why: a patch gate holds new code to a bar
+  without fighting noise in the whole-project number.
+- **(conditional: perf claim or hot path)** A perf project (for example
+  BenchmarkDotNet) where a performance claim or hot path exists - a hot path is
+  code on a measured critical path or tight loop (parsing, encoding, crypto,
+  byte/image processing), or any explicit performance claim in the README. Why:
+  perf assertions need measurement, not intuition.
+- **(conditional: untrusted input)** A fuzz project (for example SharpFuzz) for
+  any parser, decoder, or buffer surface that takes untrusted input. Why:
+  coverage-guided fuzzing finds the malformed-input bugs unit tests miss.
+
+## 4. Packaging and publishing
+
+- **(library)** Complete package metadata: `PackageId`, `Description`,
+  `Authors`, `PackageLicenseExpression`, `PackageProjectUrl`, `RepositoryUrl`,
+  `RepositoryType`, `PackageReadmeFile`, and `PackageTags`. Why: metadata drives
+  discoverability and trust on the gallery.
+- **(library)** [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink)
+  enabled (`PublishRepositoryUrl`, the Source Link package, `EmbedUntrackedSources`)
+  with symbols published (embedded PDBs or a `.snupkg`). Why: lets consumers
+  step into library source while debugging.
+- **(library, temporal)** Package validation (`EnablePackageValidation`, with a
+  baseline version once a stable release exists). Temporal: score N/A until the
+  first stable release, then required. Why: catches accidental breaking API and
+  cross-framework surface gaps at pack time.
+- **(library)** A README packed into the package (`PackageReadmeFile`). Why: the
+  README renders on the gallery package page.
+- **(library)** Strong-named assemblies for identity (not as a security
+  boundary), shipped consistently. Why: required by some consumers; do not ship
+  both signed and unsigned variants of the same library.
+- **(tool)** `PackAsTool=true` with a `ToolCommandName`, packaged for
+  `dotnet tool` install. Why: the supported distribution path for a CLI tool.
+
+## 5. Versioning and releases
+
+- **(core)** [SemVer](https://semver.org/) version numbers. Why: communicates
+  compatibility expectations to consumers.
+- **(library)** Tag-driven, deterministic versioning from git history
+  (for example MinVer or Nerdbank.GitVersioning) rather than a hand-edited
+  version. Why: the released version is a function of the tag, not a manual edit
+  that can drift.
+- **(core)** A release record per version - a `CHANGELOG.md`
+  ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)) or curated GitHub
+  Releases notes. Why: consumers need to know what changed and whether it breaks.
+- **(library)** Releases are immutable once published, and the package is
+  published only from a tagged commit. Why: a pinned version must never change
+  underneath a consumer.
+- **(library)** Releases are signed or carry build provenance / attestation.
+  Why: lets consumers verify an artifact came from the expected build.
+
+## 6. CI/CD
+
+- **(core)** A build-and-test workflow triggered for every merge candidate and
+  available for manual diagnosis. Add a default-branch push trigger only when
+  branch rules permit an update that bypasses equivalent pre-merge validation;
+  include `merge_group` when a merge queue is available. Why: gate every path to
+  the default branch without automatically testing the same change twice.
+- **(core)** A least-privilege token: top-level `permissions: contents: read`,
+  with any write scope granted per-job. Why: limits blast radius if a workflow
+  step is compromised.
+- **(core)** Third-party actions pinned by full commit SHA (with the version in
+  a trailing comment). Why: a tag or branch is mutable and can be repointed at
+  malicious code; a SHA cannot.
+- **(core)** Concurrency control that cancels superseded in-flight runs for a
+  pull request. Why: saves runner time and surfaces only the latest result.
+- **(core)** The automatic matrix contains the minimum load-bearing Release
+  gates; Debug and expensive platform/architecture breadth run through a named
+  manual, scheduled, or release workflow with a named owner and occasion or
+  cadence when delayed detection is acceptable. Why: preserve the support
+  contract without charging every pull request for every dimension.
+- **(core)** Each job uses the least expensive runner that is proven compatible;
+  native behavior still executes on its required operating system and
+  architecture. Why: lightweight scripts do not need premium runners, while
+  cross-compilation does not replace native execution.
+- **(conditional: restorable dependencies)** Dependency caching keyed on the
+  lock/props files and pointed at the directory the tool actually uses. Why:
+  cuts CI time without staleness or a cache that never captures restored data.
+- **(core)** A stable aggregate status-check name that branch protection can
+  require, even when the matrix underneath changes. Why: keeps the required
+  check name from breaking when the build matrix is edited.
+- **(library)** Publishing via OIDC
+  [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+  (short-lived key, `id-token: write`) rather than a stored long-lived API key.
+  Why: removes the standing secret that is the usual supply-chain leak.
+
+## 7. Supply-chain and security
+
+- **(core)** A `SECURITY.md` with a private reporting channel and a disclosure
+  expectation. Why: gives reporters a safe path and is an
+  [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
+  Security-Policy signal.
+- **(core)** A dependency-update tool (Dependabot or Renovate) configured. Why:
+  out-of-date dependencies accrue known-vulnerable flaws; automate the bumps.
+- **(core)** Restore from a single trusted feed with package source mapping (a
+  `nuget.config` that clears inherited sources and maps every package to one
+  feed). Why: blocks dependency-confusion, where a package is silently served
+  from an unexpected source.
+- **(core)** Adopt only vetted, quarantined dependency versions - pin a
+  known-good floor and bump deliberately (a minimum release age, advisory,
+  deprecation, and listing checks, and a license allowlist) rather than tracking
+  latest. Why: a freshly published version is the least-vetted and the usual
+  vector for a compromised release.
+- **(core)** Static analysis / code scanning (for example CodeQL) on pull
+  requests (and `merge_group` when used) and on a schedule, with code-scanning
+  results required by merge protection at documented thresholds. Moving it to
+  schedule-only is an accepted divergence only after documenting the
+  delayed-detection security tradeoff, cadence, and alert owner. Why: catches
+  injectable and memory-safety bug classes before merge by default.
+- **(core)** Secret scanning and push protection enabled. Why: stops credentials
+  from entering history.
+- **(core)** Branch protection or a repository ruleset on the default branch:
+  require the status and code-scanning checks, require pull requests with no
+  bypass, require branches up to date or a merge queue, and block force-push and
+  deletion. Why: prevents direct, unreviewed, stale-base, or history-rewriting
+  changes to main.
+- **(conditional: untrusted input) (deferred)** Address the
+  [OWASP Top Ten](https://owasp.org/www-project-top-ten/) classes for any code
+  that handles untrusted input or runs as a service - the security-review skill
+  owns the actual review; here, only confirm it has been run. Why: the consensus
+  baseline for application-level vulnerability review.
+
+## 8. OSS governance and community
+
+- **(core)** A `CODE_OF_CONDUCT.md` (the
+  [Contributor Covenant](https://www.contributor-covenant.org/) is the default).
+  Why: sets behavioral expectations and is a GitHub community-standards signal.
+- **(core)** A `CONTRIBUTING.md` covering how to build, test, and submit
+  changes, and the contribution license terms. Why: lowers the barrier to a
+  correct first contribution.
+- **(conditional: multiple maintainers)** A `CODEOWNERS` file once more than one
+  maintainer or area exists. Why: routes review to the right owners automatically.
+- **(core)** Issue and pull-request templates. Why: makes reports and proposals
+  actionable by default.
+- **(conditional: defined support channel)** A `SUPPORT.md` when there is a
+  defined support channel. Why: directs help requests away from the issue tracker.
+
+## 9. Agent enablement
+
+- **(core)** An `AGENTS.md` as the single source of agent guidance, with the
+  tool-specific mirror (for example `.github/copilot-instructions.md`) generated
+  from it, not hand-edited. Why: one canonical instruction set, many consumers.
+- **(core)** Vendored agent skills under the host-read skills location, each
+  pinned and provenance-stamped, with the repo-specific overlay. Why: the
+  reviewed, version-controlled skill set instead of ad-hoc prompting.
+- **(core)** An agent-file gate in CI: frontmatter validation, the mirror check,
+  markdown lint, and an offline link check over the agent files. Why: keeps the
+  instruction set valid and its internal links resolvable.
+- **(conditional: distinct domains)** Path-specific instructions and reviewer
+  agent personas where the repo has distinct domains. Why: focuses guidance and
+  review on the area being changed.
+
+The mechanics of *vendoring* the skill tier, wiring the validator and link
+checker, and the drift loop are owned by the skill-lifecycle skill and the fleet
+onboarding runbook; this domain confirms they are present, and defers the how to
+them. A consuming repository names both in its overlay.

--- a/.agents/skills/engineering-baseline/overlay.md
+++ b/.agents/skills/engineering-baseline/overlay.md
@@ -1,0 +1,25 @@
+---
+core: engineering-baseline
+core-pin: v0.11.0
+---
+
+# Engineering baseline overlay
+
+Repository-specific bindings for thirtytwo.
+
+Assess the existing repository; do not run the greenfield scaffold over it.
+Primary anchors are:
+
+- [README.md](../../../README.md) and [LICENSE](../../../LICENSE);
+- [Directory.Build.props](../../../Directory.Build.props) and
+  [Directory.Packages.props](../../../Directory.Packages.props);
+- [global.json](../../../global.json) and [nuget.config](../../../nuget.config);
+- [thirtytwo.slnx](../../../thirtytwo.slnx);
+- [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml).
+
+The product is a Windows-only .NET 10 library and its tests exercise Win32,
+COM, controls, and native resources. Keep platform-specific build and test
+requirements explicit in any recommendation. Treat missing governance,
+publishing, supply-chain, or agent-file gates as findings to discuss, not as
+permission to add them automatically. Remote settings and GitHub changes still
+require explicit user approval.

--- a/.agents/skills/engineering-baseline/references/best-practices.md
+++ b/.agents/skills/engineering-baseline/references/best-practices.md
@@ -1,0 +1,173 @@
+# Citation catalog
+
+The authority behind every [baseline.md](../baseline.md) choice. Each domain
+table lists the **choice**, the **industry source** that backs it, and the
+**rationale**. The closing [divergence notes](#divergence-notes) record where
+reasonable, vetted setups legitimately differ - the places to "consult where
+they collide" rather than treat as defects.
+
+External links here are not network-checked by the offline link gate; keep them
+correct by hand. Sources are canonical standards bodies and vendor docs, not
+blog posts, so they age slowly.
+
+## Umbrella frameworks
+
+The cross-cutting standards the domain checks draw from.
+
+| Framework | Source | What it anchors |
+| --------- | ------ | --------------- |
+| OpenSSF Scorecard | [scorecard checks](https://github.com/ossf/scorecard/blob/main/docs/checks.md) | The supply-chain checks and their risk levels (branch protection, pinned deps, token permissions, SAST, ...) |
+| OpenSSF Best Practices Badge | [bestpractices.dev](https://www.bestpractices.dev/) | The passing/silver/gold criteria for OSS process health |
+| OpenSSF Concise Guide | [secure-software guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md) | A short, prioritized secure-development checklist |
+| SLSA | [slsa.dev](https://slsa.dev/) | Build provenance and supply-chain integrity levels |
+| OWASP Top Ten | [owasp.org/Top10](https://owasp.org/www-project-top-ten/) | The application-level vulnerability classes |
+| Reproducible Builds | [reproducible-builds.org](https://reproducible-builds.org/) | Why deterministic, verifiable builds matter |
+| .NET library guidance | [learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/) | The official "what and why" for high-quality .NET libraries |
+| NuGet authoring best practices | [learn.microsoft.com](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices) | Package metadata and packing recommendations |
+
+## 1. Repository foundation and licensing
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SPDX-identified open-source license | [SPDX license list](https://spdx.org/licenses/), [choosealicense.com](https://choosealicense.com/) | No license means exclusive copyright; an SPDX id is machine-readable on the gallery and by Scorecard |
+| Pick the license deliberately | [GitHub: licensing a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) | The license governs all downstream use; default to MIT for permissive reuse |
+| `.editorconfig` for style and severities | [EditorConfig](https://editorconfig.org/), [.NET code-style options](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options) | Makes style machine-enforceable instead of a review topic |
+| `.gitattributes` line-ending normalization | [GitHub: configuring line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) | Prevents cross-platform diff churn |
+| Redistribution notices when bundling code | [REUSE](https://reuse.software/) | Satisfies attribution obligations of bundled licenses |
+
+## 2. Build configuration
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SDK-style projects | [NuGet: project format](https://learn.microsoft.com/en-us/nuget/resources/check-project-format) | The supported, metadata-in-project format |
+| Central Package Management | [NuGet: central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) | One pinned version per package repo-wide; no inter-project drift |
+| Lock file + restore audit | [Lock files](https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#locking-dependencies), [NuGet audit](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) | Pins the full transitive graph (`--locked-mode` in CI) and flags advisories every restore |
+| Pinned SDK in `global.json` | [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) | Reproducible builds across machines and CI |
+| Nullable reference types on | [Nullable references](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) | Opts into compiler null-safety |
+| Analyzers on, warnings as errors | [.NET code analysis overview](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) | Stops warnings accumulating; turns analyzers on by default |
+| Deterministic build / `ContinuousIntegrationBuild` | [.NET reproducible builds](https://github.com/dotnet/reproducible-builds), [MSBuild props](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild) | Path-independent, reproducible outputs and PDBs |
+| Nullable reference types enabled repo-wide | [Nullable references](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) | Every project opts into compiler null-safety by default |
+| AOT/trim-clean shippable project | [Prepare libraries for trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming), [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) | `IsAotCompatible` runs the trim/AOT analyzers so code composes into AOT apps and avoids runtime reflection |
+
+## 3. Testing and coverage
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| A real test project and suite | [.NET unit-testing best practices](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices) | A repo without runnable tests cannot gate regressions; OpenSSF CI-Tests check |
+| Microsoft Testing Platform (MTP) | [MTP overview](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro), [MTP + dotnet test](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test) | The supported, self-contained successor to the VSTest host; the direction for all .NET test frameworks |
+| Coverage collected and gated | [.NET code coverage](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage) | A patch-coverage gate holds new code to a bar without whole-project noise |
+| Perf project where a hot path exists | [BenchmarkDotNet](https://benchmarkdotnet.org/) | Perf claims need measurement, not intuition |
+| Fuzz untrusted-input surfaces | [OWASP: fuzzing](https://owasp.org/www-community/Fuzzing), [Scorecard: Fuzzing](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing) | Coverage-guided fuzzing finds malformed-input bugs unit tests miss |
+
+## 4. Packaging and publishing
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Complete package metadata | [NuGet authoring best practices](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices) | Metadata drives discoverability and trust |
+| Source Link + symbols | [Source Link guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink), [symbol packages](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) | Lets consumers step into library source while debugging |
+| Package validation | [Package validation overview](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview) | Catches accidental breaking API and cross-framework gaps at pack time |
+| README packed into the package | [PackageReadmeFile](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile) | The README renders on the gallery package page |
+| Strong naming for identity, applied consistently | [Strong naming guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming) | Some consumers require it; never ship signed and unsigned variants |
+| CLI tool packaged as a `dotnet` tool | [Create a dotnet tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create) | The supported distribution path for a command-line tool |
+
+## 5. Versioning and releases
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SemVer | [semver.org](https://semver.org/), [.NET versioning](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/versioning) | Communicates compatibility expectations |
+| Tag-driven deterministic versioning | [MinVer](https://github.com/adamralph/minver), [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) | The version is a function of the tag, not a hand-edit that drifts |
+| A release record per version | [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), [GitHub releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) | Consumers need to know what changed and whether it breaks |
+| Optional commit convention | [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) | Enables automated changelog and version inference |
+| Build provenance / attestation | [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), [SLSA](https://slsa.dev/) | Lets consumers verify an artifact came from the expected build |
+
+## 6. CI/CD
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Harden the workflows | [GitHub: security hardening for Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) | The canonical list of Actions-specific risks and mitigations |
+| Least-privilege `GITHUB_TOKEN` | [Automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication), [Scorecard: Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) | Limits blast radius if a step is compromised; default to `contents: read` |
+| Pin actions by full commit SHA | [Scorecard: Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies), [StepSecurity](https://github.com/step-security/harden-runner) | A tag is mutable and can be repointed at malicious code; a SHA cannot |
+| OIDC trusted publishing | [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing), [GitHub OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) | Removes the standing long-lived secret that is the usual leak |
+| Concurrency and caching | [Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency), [Caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) | Cancels superseded runs and cuts CI time |
+| Cost-aware topology and runner selection | [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing), [Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions), [hosted-runner specifications](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) | Each job has independent setup and billing granularity; current rates and visibility-specific hardware make runner and matrix choices materially different even when public-repository allowances hide invoice cost |
+| Measure workflow and job usage | [Actions usage metrics](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-usage-metrics-for-github-actions) | Job runtime, runner type, queue time, and failure rate distinguish actual hot spots from guesses |
+| Manual extended validation | [Manually running workflows](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow) | Expensive breadth can remain available without charging every change, provided it has an explicit trigger and owner |
+| Test the merge candidate | [Required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-status-checks-to-pass-before-merging), [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) | Strict up-to-date checks or a merge queue prevent a green stale branch from merging as an untested combination |
+
+## 7. Supply-chain and security
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Branch protection / rulesets on the default branch | [GitHub: about rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [Scorecard: Branch-Protection](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection) | Prevents direct, unreviewed, or history-rewriting changes to main |
+| A dependency-update tool | [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), [Renovate](https://docs.renovatebot.com/) | Out-of-date dependencies accrue known-vulnerable flaws |
+| Single trusted feed (source mapping) | [Package source mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping) | Blocks dependency-confusion across configured feeds |
+| Adopt only vetted, quarantined versions | [Renovate: minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage), [OpenSSF Concise Guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md) | A freshly published version is least-vetted and the usual compromised-release vector |
+| Static analysis / code scanning | [CodeQL code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql), [code-scanning merge protection](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/set-code-scanning-merge-protection), [Scorecard: SAST](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast) | Catches injectable and memory-safety bug classes and blocks the merge while required analysis is absent, pending, or over threshold |
+| Secret scanning + push protection | [About secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning), [About push protection](https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection) | Stops credentials from entering history |
+| `SECURITY.md` with private reporting | [GitHub: adding a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository), [Scorecard: Security-Policy](https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy) | Gives reporters a safe path; a Scorecard signal |
+| Dependency vulnerability auditing | [NuGet audit](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) | Surfaces advisories against the restored graph at build time |
+| Review untrusted-input code against OWASP | [OWASP Top Ten](https://owasp.org/www-project-top-ten/) | The consensus application-vulnerability baseline |
+
+## 8. OSS governance and community
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Set up healthy-contribution files | [GitHub community standards](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions) | The community-profile checklist GitHub surfaces |
+| `CODE_OF_CONDUCT.md` | [Contributor Covenant](https://www.contributor-covenant.org/) | Sets behavioral expectations; a community-standards signal |
+| `CONTRIBUTING.md` | [Setting contribution guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) | Lowers the barrier to a correct first contribution |
+| `CODEOWNERS` | [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) | Routes review to the right owners automatically |
+| Issue / PR templates | [About issue and PR templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) | Makes reports and proposals actionable by default |
+| `SUPPORT.md` | [Adding support resources](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project) | Directs help requests away from the issue tracker |
+
+## 9. Agent enablement
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Vendor-neutral agent skills | [agentskills.io](https://agentskills.io/) | The discovered skills format across Copilot and Claude |
+| `AGENTS.md` single source | [agents.md](https://agents.md/) | One canonical instruction set, many consumers |
+| Generated tool mirror | [Copilot repository instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot), [VS Code customization](https://code.visualstudio.com/docs/copilot/copilot-customization) | Tool-specific files are mirrors of the canonical `AGENTS.md`, not hand-edited |
+
+The mechanics of vendoring the skill tier and wiring the agent-file gates are
+owned by the skill-lifecycle skill and the fleet onboarding runbook, which a
+consuming repository names in its overlay.
+
+## Divergence notes
+
+Where vetted setups legitimately differ. Treat these as choices to record, not
+defects to flag.
+
+- **Action pinning: SHA vs major version.** The
+  [Scorecard Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+  best practice is a full commit SHA (with the version in a trailing comment),
+  and a dependency-update tool keeps the SHA fresh. Some repositories pin by
+  major version instead, trading supply-chain strictness for lower maintenance
+  and automatic patch uptake. The baseline recommends SHA pinning; a major-version
+  policy is an accepted, stated divergence - record it rather than silently
+  "fixing" it.
+- **Changelog: a file vs GitHub Releases.** [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  favors an in-repo `CHANGELOG.md`; tag-driven repos often curate
+  [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+  notes instead. Either satisfies the baseline - pick one and state it in the
+  README; do not require both.
+- **Strong naming.** [Guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming)
+  treats it as identity, not a security boundary, and it is genuinely optional.
+  The rule that is not optional: never ship both a signed and an unsigned variant
+  of the same library.
+- **Coverage thresholds.** A strict whole-project gate is noisy on small or
+  fast-moving repos; a patch gate on changed lines is the pragmatic default. The
+  baseline requires *a* gate, not a specific number.
+- **Default-branch push validation.** A pull request with strict up-to-date
+  checks or a merge-queue ruleset with no bypass path validates the merge
+  candidate; repeating identical build/test work after merge is optional
+  confirmation. Keep the push trigger when administrators, automation, or direct
+  pushes can bypass equivalent pre-merge checks. Record the ruleset assumption
+  next to the workflow decision.
+- **Automatic matrix breadth.** Operating systems, architectures, target
+  frameworks, Debug builds, and Native AOT legs belong on every merge only when
+  they protect a merge-blocking invariant. It is reasonable to move lower-risk
+  breadth to a scheduled/manual or release workflow, but document the resulting
+  detection delay, cadence, and owner.
+- **Branch protection as code vs UI.** Classic branch protection is configured in
+  the UI; [repository rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+  can be exported and version-controlled as JSON. Prefer as-code for
+  reproducibility, but UI-configured protection still satisfies the baseline.

--- a/.agents/skills/engineering-baseline/scaffold.md
+++ b/.agents/skills/engineering-baseline/scaffold.md
@@ -1,0 +1,183 @@
+# Scaffold a new repository
+
+The greenfield verb: stand up a new repository built to [baseline.md](baseline.md)
+from nothing. Triggered by "create a new repository for a command-line tool",
+"scaffold a new library", or "set up a new project with CI and publishing".
+
+The primary mechanism is the scaffold script ([scripts/New-DotnetRepo.ps1](scripts/New-DotnetRepo.ps1)),
+which uses `dotnet new` for the project skeleton and then applies the hardening
+layer (centralized build, CI workflows, governance files, agent stubs). Running
+the script produces an immediately buildable, testable, and packable tree. Stop
+at the remote boundary and propose those steps for explicit approval.
+
+## 1. Confirm the archetype and identity
+
+Pick the archetype - it selects which baseline items and script parameters apply:
+
+| Archetype | Ships | Key script parameters |
+| --------- | ----- | --------------------- |
+| **tool** | A `dotnet` tool executable | `-Archetype tool -ToolCommandName <cmd>` |
+| **library** | A single-TFM NuGet library | `-Archetype library` |
+| **multi-target** | A library across a modern + legacy TFM | `-Archetype multi-target -Framework net10.0 -FrameworkLegacy net481` |
+
+Confirm, before running the script, with one short prompt: the repository name,
+the target framework(s), the package id and one-line description, the license
+(default MIT), and the owner. Do not invent these - if the user did not supply
+them, ask once. These are the literals the script takes as parameters, and what
+a brownfield repo would keep in its overlay.
+
+## 2. Run the scaffold script
+
+Invoke `New-DotnetRepo.ps1` from the skill's `scripts/` directory (or a
+vendored copy in the consuming repo). Use an empty directory outside any
+existing repository as the root - the script refuses to run in a non-empty
+directory.
+
+The static file bodies it lays down are real files under `scripts/template/`
+(rendered with simple `{{TOKEN}}` substitution); the `.ps1` is the orchestration
+layer that runs `dotnet new`, renders the template, and applies project-file
+hardening. To change what a scaffolded repo contains, edit the template files,
+not here-strings.
+
+```pwsh
+# Example: scaffold a dotnet tool
+pwsh /path/to/New-DotnetRepo.ps1 `
+    -Root   C:\src\widgettool `
+    -Name   widgettool `
+    -Archetype tool `
+    -PackageId     WidgetTool `
+    -ToolCommandName widgettool `
+    -Description   "A sample command-line tool." `
+    -Owner  YourGitHubHandle
+```
+
+The script produces: `global.json`, `Directory.Build.props/.targets`,
+`Directory.Packages.props` (CPM on), a `dotnet new`-generated project and test
+project, `.gitignore`/`.gitattributes`/`.editorconfig`, `README.md`, `LICENSE`,
+`.github/workflows/` (automatic CI, manual Full CI, publish, CodeQL, and the
+agent mirror), `dependabot.yml`, `SECURITY.md`, `CODE_OF_CONDUCT.md`,
+`CONTRIBUTING.md`, issue/PR templates, and `AGENTS.md` with its generated Copilot
+mirror.
+
+The workflow defaults are cost-aware without weakening the merge gate. A pull
+request or merge group gets one Release build/test job: standard Linux for
+modern-only projects and Windows when a legacy target framework must compile
+there. Maintainers run the manually dispatched Full CI workflow before every
+release and after SDK or build-tool changes; it covers Debug and Release in one
+job. CodeQL runs on pull requests, merge groups, and a weekly schedule. For a
+private repository with GitHub Code Security, enable it before the first pull
+request and require CodeQL results in the ruleset. Without that entitlement,
+replace CodeQL with a supported scanner and require its status check instead.
+None of these workflows repeats automatically after a strictly protected merge.
+If the remote ruleset later permits direct or bypass pushes, restore
+default-branch push triggers in CI, CodeQL (or its replacement), and the agent
+mirror before relying on that path.
+
+It also standardizes output paths to a top-level `artifacts/` tree:
+
+- `artifacts/bin/` - build outputs
+- `artifacts/obj/` - intermediates
+- `artifacts/packages/` - packed `.nupkg` output
+
+The scaffold is **born safe** on the supply-chain axis: a committed
+`packages.lock.json` (restored with `--locked-mode` in CI), NuGet audit over
+direct and transitive packages, and a `nuget.config` that maps every package to
+nuget.org to block dependency-confusion. Package versions are **pinned from the
+vetted manifest `scripts/versions.json`** - a known-good floor, never "latest".
+Refresh that floor deliberately with `scripts/Update-ScaffoldVersions.ps1`, which
+proposes only versions that pass a quarantine window plus advisory, deprecation,
+listing, and license-allowlist checks (and can scaffold-and-build to confirm TFM
+compatibility); review the diff before committing. The GitHub Actions pinned in
+the workflow templates carry the same quarantine floor, refreshed by
+`scripts/Update-ScaffoldActions.ps1` (the actions counterpart). Keeping both
+floors current, plus a `dependabot.yml` that **groups every update per ecosystem
+into one PR**, is what stops a fresh repo from opening a long list of day-one
+dependency bumps.
+
+Test projects run on the **Microsoft Testing Platform** (MTP) and default to
+**MSTest** (`-TestRunner xunit` switches to xunit.v3); both run at the fullest
+parallelism by default, and `global.json` selects the MTP runner.
+
+The shippable project is marked **AOT/trim clean** (`IsAotCompatible`) on its
+modern target, so the trim, AOT, and single-file analyzers run by default and the
+code stays composable into AOT apps even when AOT is never published.
+
+## 3. Pin the action SHAs (domain 6)
+
+The workflows emit `<SHA>` placeholders for every third-party action, each with
+its target version in a trailing comment kept current by
+`scripts/Update-ScaffoldActions.ps1`. Replace each placeholder with the full
+commit SHA for the commented version before the first push, then let Dependabot's
+grouped `github-actions` updates keep them current. Use
+[StepSecurity](https://app.stepsecurity.io) or
+`gh api repos/<owner>/<repo>/git/refs/tags` to resolve each version to a SHA.
+
+This is a local, reversible edit - do it before `git init`.
+
+## 4. Extend for multi-target (domain 2, conditional)
+
+For `multi-target`, the script adds the framework pair to `Directory.Build.props`
+and switches the main project to `<TargetFrameworks>`. The polyfill package
+strategy for the legacy target (PolySharp, `Microsoft.Bcl.*`, `System.Memory`,
+etc.) is not added by the script - hand that off to the polyfill skill a
+consuming repository names in its overlay.
+
+## 5. Add optional surfaces (domain 3, conditional)
+
+The script does not scaffold a perf or fuzz project; add those only if the
+tool/library has a hot path or an untrusted-input surface. Hand them off to the
+perf-testing and fuzz-testing skills a consuming repository names in its overlay.
+
+## 6. Wire agent enablement (domain 9)
+
+The script creates an `AGENTS.md` stub, generates its Copilot mirror
+(`.github/copilot-instructions.md`) with `tools/Sync-AgentInstructions.ps1`, adds
+an `agent-files.yml` workflow that fails if the mirror drifts from `AGENTS.md`,
+and vendors a pinned starting skill tier into `.agents/skills/` via `gh skill`
+(`manage-skills`, `agent-files-review`, `create-pr`, `address-pr-feedback`,
+and `security-review` by default; override with `-Skills` / `-SkillsRef`). When
+`gh skill` is unavailable it records the pinned install commands instead of
+failing. Vendor the GitHub Actions cost optimization skill when the repository
+needs a measured workflow audit beyond these defaults. The broader agent-file
+gate (skill-frontmatter validation, link checking) and vendoring any domain
+skills remain a handoff to the skill-lifecycle skill and the fleet onboarding
+runbook - do not reinvent that pipeline here.
+
+## 7. Validate locally
+
+```pwsh
+dotnet build -c Release
+dotnet test  -c Release
+dotnet pack  src/<Name>/<Name>.csproj -c Release -o artifacts/packages
+```
+
+All three must be clean before going near the remote. The pack confirms the
+package metadata is correct and SourceLink is wired. Fix anything red first.
+
+## 8. Propose the remote setup (the boundary)
+
+The script prints a remote setup checklist at the end. Everything on it is
+remote or hard to reverse - **propose each step and wait for an explicit
+publishing verb.** Do not run them silently:
+
+- Replace `<SHA>` placeholders in workflows (see step 3).
+- `gh repo create <owner>/<name> --public --source . --remote origin`
+- `git init && git add -A && git commit -m "Initial scaffold" && git push -u origin main`
+- For a private repository, enable GitHub Code Security before the first pull
+    request. If it is unavailable, replace CodeQL with a supported scanner.
+- Branch protection / ruleset on `main`: require `build`, strict up-to-date
+    branches or a merge queue, and either CodeQL code-scanning results at
+    documented thresholds or the replacement scanner's status check; require pull
+    requests with no bypass path; block force-push and deletion. If a bypass path
+    is required, restore default-branch push validation in CI, CodeQL or its
+    replacement, and the agent mirror first. Emit the exact `gh api` call or
+    ruleset JSON for review.
+- Enable secret scanning and push protection (GitHub repo Settings > Security).
+- Register the trusted-publishing policy on nuget.org before the first publish.
+
+Present these as a numbered checklist, then stop.
+
+## 9. Report back
+
+Summarize the archetype, the tree created, what was validated locally, and the
+remote checklist still awaiting approval. End with the single next action.

--- a/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
+++ b/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
@@ -1,0 +1,643 @@
+<#
+.SYNOPSIS
+    Scaffolds a new .NET repository built to the engineering-baseline standard.
+
+.DESCRIPTION
+    Creates the local tree for a CLI tool, class library, or multi-target library,
+    including centralized build configuration, test project, CI workflows,
+    governance files, and agent-enablement stubs.
+
+    The static file bodies live as real files under this script's `template/`
+    folder and are rendered with simple {{TOKEN}} substitution. This script is the
+    orchestration layer: it runs `dotnet new` for the project skeletons, renders
+    the template folder, and applies the project-file hardening that `dotnet new`
+    does not (Central Package Management fix-ups, packaging metadata, Source Link).
+
+    Stops at the remote boundary: does not create the GitHub repository, configure
+    branch protection, or publish any package. Those steps are printed at the end
+    as a checklist for explicit approval.
+
+.PARAMETER Root
+    The directory to scaffold into. Created if it does not exist. Must be empty.
+
+.PARAMETER Name
+    The repository and solution name (for example "widgettool" or "MyLib").
+
+.PARAMETER Archetype
+    The kind of project to create:
+      tool          - A dotnet tool (PackAsTool). Produces a console entry point.
+      library       - A single-TFM NuGet library.
+      multi-target  - A library targeting a modern TFM and a legacy TFM side by side.
+
+.PARAMETER PackageId
+    The NuGet package id (for example "WidgetTool" or "Contoso.MyLib").
+
+.PARAMETER Description
+    One-line package description, used in csproj and README.
+
+.PARAMETER Owner
+    The GitHub owner (user or org) for repository URLs and author metadata.
+
+.PARAMETER ToolCommandName
+    For archetype=tool: the CLI command name. Defaults to -Name in lowercase.
+
+.PARAMETER Framework
+    The primary (modern) target framework moniker. Default: net10.0.
+
+.PARAMETER FrameworkLegacy
+    For archetype=multi-target: the legacy TFM (for example "net481").
+
+.PARAMETER License
+    SPDX license identifier. Default: MIT. Only the MIT body is bundled; other
+    licenses render every reference but skip the LICENSE file with a warning.
+
+.PARAMETER TestRunner
+    The test framework, both run on Microsoft Testing Platform. Accepted:
+    mstest (default) or xunit (uses xunit.v3).
+
+.PARAMETER Skills
+    The agent skills to vendor into .agents/skills from the commons. Default: the
+    universal starting tier (manage-skills, agent-files-review, create-pr,
+    address-pr-feedback, security-review). Pass an empty array to skip vendoring.
+
+.PARAMETER SkillsRef
+    The release tag or commit SHA to pin vendored skills to. Default: the latest
+    published release of -SkillsRepo, resolved at run time via gh.
+
+.PARAMETER SkillsRepo
+    The OWNER/REPO of the skills commons to vendor from. Default:
+    JeremyKuhne/agent-skills.
+
+.EXAMPLE
+    .\New-DotnetRepo.ps1 -Root C:\src\widgettool -Name widgettool `
+        -Archetype tool -PackageId WidgetTool -ToolCommandName widgettool `
+        -Description "A sample command-line tool." -Owner JeremyKuhne
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Root,
+    [Parameter(Mandatory)] [string] $Name,
+    [Parameter(Mandatory)] [ValidateSet('tool', 'library', 'multi-target')] [string] $Archetype,
+    [Parameter(Mandatory)] [string] $PackageId,
+    [Parameter(Mandatory)] [string] $Description,
+    [Parameter(Mandatory)] [string] $Owner,
+    [string] $ToolCommandName,
+    [string] $Framework = 'net10.0',
+    [string] $FrameworkLegacy,
+    [string] $License = 'MIT',
+    [ValidateSet('mstest', 'xunit')] [string] $TestRunner = 'mstest',
+    [string[]] $Skills = @(
+        'manage-skills',
+        'agent-files-review',
+        'create-pr',
+        'address-pr-feedback',
+        'security-review'),
+    [string] $SkillsRef,
+    [string] $SkillsRepo = 'JeremyKuhne/agent-skills'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+function Step ([string] $msg) { Write-Host "  $msg" -ForegroundColor Cyan }
+function Done ([string] $msg) { Write-Host "  OK  $msg" -ForegroundColor Green }
+function Warn ([string] $msg) { Write-Host "  WARN $msg" -ForegroundColor Yellow }
+
+function New-Dir ([string] $path) {
+    if ($path -and -not (Test-Path $path)) { New-Item -ItemType Directory -Path $path -Force | Out-Null }
+}
+
+function Invoke-Dotnet {
+    $output = & dotnet @args 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "dotnet $args failed (exit $LASTEXITCODE):`n$output" }
+}
+
+# Render every file under $TemplateRoot into $DestRoot, stripping the trailing
+# .tmpl and replacing {{TOKEN}} placeholders. {{TOKEN}} never collides with
+# GitHub Actions ${{ ... }} expressions because only the literal token keys below
+# are replaced.
+function Expand-Template {
+    param(
+        [string] $TemplateRoot,
+        [string] $DestRoot,
+        [hashtable] $Tokens,
+        [string[]] $SkipLeaf = @()
+    )
+    Get-ChildItem -LiteralPath $TemplateRoot -Recurse -File -Force | ForEach-Object {
+        $rel = $_.FullName.Substring($TemplateRoot.Length).TrimStart([char]'\', [char]'/')
+        if ($rel.EndsWith('.tmpl')) { $rel = $rel.Substring(0, $rel.Length - 5) }
+        if ($SkipLeaf -contains (Split-Path $rel -Leaf)) { return }
+        $text = Get-Content -LiteralPath $_.FullName -Raw
+        foreach ($k in $Tokens.Keys) { $text = $text.Replace("{{$k}}", [string]$Tokens[$k]) }
+        $dest = Join-Path $DestRoot $rel
+        New-Dir (Split-Path $dest -Parent)
+        Set-Content -LiteralPath $dest -Value $text -Encoding utf8NoBOM -NoNewline
+    }
+}
+
+# ---------------------------------------------------------------------------
+# locate the bundled template content folder (travels next to this script)
+# ---------------------------------------------------------------------------
+
+$TemplateRoot = Join-Path $PSScriptRoot 'template'
+if (-not (Test-Path $TemplateRoot)) { throw "Template folder not found next to the script: $TemplateRoot" }
+
+# ---------------------------------------------------------------------------
+# derived values and template tokens
+# ---------------------------------------------------------------------------
+
+if ($Archetype -eq 'multi-target' -and -not $FrameworkLegacy) {
+    throw "Archetype 'multi-target' requires -FrameworkLegacy (for example -FrameworkLegacy net472)."
+}
+
+$ToolCommandName = if ($ToolCommandName) { $ToolCommandName } else { $Name.ToLowerInvariant() }
+$RepoUrl       = "https://github.com/$Owner/$Name"
+$Year          = (Get-Date).Year
+$IsMultiTarget = $Archetype -eq 'multi-target'
+$IsTool        = $Archetype -eq 'tool'
+$MainTfm       = $Framework
+# Title-case only an all-lowercase name; preserve any name the user already cased
+# (ToTitleCase would downcase internal capitals, for example MyLib -> Mylib).
+$NameTitle     = if ($Name -cmatch '[A-Z]') { $Name } else { (Get-Culture).TextInfo.ToTitleCase($Name) }
+$SdkVersion    = (& dotnet --version 2>&1).Trim()
+
+# The generated global.json pins this exact SDK. If the host SDK is a prerelease,
+# allowPrerelease must be true or the pinned version cannot resolve - keep them in
+# sync rather than emitting a contradictory, unbuildable global.json.
+$SdkIsPrerelease = $SdkVersion -match '-'
+$AllowPrerelease = if ($SdkIsPrerelease) { 'true' } else { 'false' }
+if ($SdkIsPrerelease) { Warn "host SDK $SdkVersion is a prerelease; global.json will set allowPrerelease=true" }
+
+$LegacyTfmLine     = if ($IsMultiTarget) { "`n    <LegacyTfm>$FrameworkLegacy</LegacyTfm>" } else { '' }
+$FrameworksDisplay = if ($IsMultiTarget) { "$Framework, $FrameworkLegacy" } else { $Framework }
+$CiRunner          = if ($IsMultiTarget) { 'windows-latest' } else { 'ubuntu-latest' }
+
+$installLines = if ($IsTool) {
+    @('```shell', "dotnet tool install --global $PackageId", '```')
+} else {
+    @('```shell', "dotnet add package $PackageId", '```')
+}
+$InstallCommand = $installLines -join "`n"
+
+# Pinned, vetted package versions come from the manifest - never 'latest'.
+# Refresh deliberately with scripts/Update-ScaffoldVersions.ps1.
+$versionsPath = Join-Path $PSScriptRoot 'versions.json'
+if (-not (Test-Path $versionsPath)) { throw "Version manifest not found: $versionsPath" }
+$pin = (Get-Content $versionsPath -Raw | ConvertFrom-Json).packages
+
+$coreIds = @('MinVer', 'Microsoft.SourceLink.GitHub')
+$testIds = switch ($TestRunner) {
+    'mstest' { @('MSTest') }
+    'xunit'  { @('xunit.v3', 'xunit.runner.visualstudio') }
+}
+$PackageVersionsXml = (@($coreIds; $testIds) | ForEach-Object {
+    $v = $pin.$_
+    if (-not $v) { throw "versions.json has no pinned version for '$_'. Run Update-ScaffoldVersions.ps1." }
+    "    <PackageVersion Include=`"$_`" Version=`"$v`" />"
+}) -join "`n"
+
+$tokens = @{
+    SDK_VERSION        = $SdkVersion
+    ALLOW_PRERELEASE   = $AllowPrerelease
+    FRAMEWORK          = $Framework
+    LEGACY_TFM_LINE    = $LegacyTfmLine
+    FRAMEWORKS_DISPLAY = $FrameworksDisplay
+    OWNER              = $Owner
+    YEAR               = "$Year"
+    LICENSE            = $License
+    REPO_URL           = $RepoUrl
+    NAME               = $Name
+    NAME_TITLE         = $NameTitle
+    DESCRIPTION        = $Description
+    PACKAGE_ID         = $PackageId
+    ARCHETYPE          = $Archetype
+    CI_RUNNER           = $CiRunner
+    INSTALL_COMMAND    = $InstallCommand
+    PACKAGE_VERSIONS   = $PackageVersionsXml
+}
+
+# License header for generated source. No per-file year - that is maintenance
+# churn with no legal benefit; "and contributors" credits everyone without a roster.
+$headerLines = @(
+    "Copyright (c) $Owner and contributors."
+    "SPDX-License-Identifier: $License"
+    "See LICENSE in the project root for license information."
+)
+$fileHeaderComment = (($headerLines | ForEach-Object { "// $_" }) -join "`n") + "`n`n"
+
+# ---------------------------------------------------------------------------
+# 0. prepare root
+# ---------------------------------------------------------------------------
+
+Write-Host "`nScaffolding '$Name' ($Archetype) -> $Root`n" -ForegroundColor White
+
+if (Test-Path -LiteralPath $Root) {
+    $existing = @(Get-ChildItem -LiteralPath $Root -Force -ErrorAction SilentlyContinue)
+    if ($existing.Count -gt 0) {
+        throw "Root '$Root' is not empty ($($existing.Count) items). Remove it or choose a different path."
+    }
+} else {
+    New-Item -ItemType Directory -Path $Root -Force | Out-Null
+}
+
+Push-Location -LiteralPath $Root
+try {
+
+# ---------------------------------------------------------------------------
+# 1. project skeleton via dotnet new
+# ---------------------------------------------------------------------------
+Step 'solution'
+Invoke-Dotnet new sln -n $Name --output . --format slnx
+
+Step 'main project'
+$srcDir = "src/$Name"
+if ($IsTool) {
+    Invoke-Dotnet new console -n $Name -o $srcDir --framework $MainTfm --no-restore
+} else {
+    Invoke-Dotnet new classlib -n $Name -o $srcDir --framework $MainTfm --no-restore
+}
+Invoke-Dotnet sln "$Name.slnx" add $srcDir --in-root
+
+Step 'test project'
+$testDir = "tests/$Name.tests"
+$testProjectName = "$Name.Tests"
+if ($TestRunner -eq 'mstest') {
+    # No --coverage-tool: the hardening step below wipes the template's package
+    # references, so the coverage package it would add is removed anyway.
+    Invoke-Dotnet new mstest --test-runner Microsoft.Testing.Platform -n $testProjectName -o $testDir --framework $MainTfm --no-restore
+} else {
+    # The SDK ships no xunit v3 template; generate the v2 template for its file
+    # structure and convert it to xunit.v3 + MTP during hardening below.
+    Invoke-Dotnet new xunit -n $testProjectName -o $testDir --framework $MainTfm --no-restore
+}
+Invoke-Dotnet sln "$Name.slnx" add $testDir --in-root
+Done 'project skeleton'
+
+# Point every project's TargetFramework at the central $(MainTfm) property so
+# Directory.Build.props is the single source of truth.
+foreach ($csproj in Get-ChildItem -Recurse -Filter '*.csproj') {
+    $doc = [xml](Get-Content $csproj.FullName -Raw)
+    foreach ($node in $doc.SelectNodes('//*[local-name()="TargetFramework"]')) { $node.InnerText = '$(MainTfm)' }
+    $doc.Save($csproj.FullName)
+}
+
+# ---------------------------------------------------------------------------
+# 2. render the bundled template content folder
+# ---------------------------------------------------------------------------
+Step 'render template files'
+$skip = @()
+if ($License -ne 'MIT') { $skip += 'LICENSE' }
+Expand-Template -TemplateRoot $TemplateRoot -DestRoot (Get-Location).Path -Tokens $tokens -SkipLeaf $skip
+if ($License -ne 'MIT') {
+    # Only the MIT body ships with the scaffold. Write a TODO placeholder so the
+    # source headers and the README "See LICENSE" reference still resolve to a file.
+    $licensePlaceholder = @(
+        "Copyright (c) $Year $Owner and contributors."
+        ''
+        "SPDX-License-Identifier: $License"
+        ''
+        "TODO: Replace this placeholder with the full $License license text before"
+        "publishing. The scaffold only bundles the MIT body; the canonical text is at"
+        "https://spdx.org/licenses/$License.html."
+    )
+    Set-Content -LiteralPath 'LICENSE' -Value (($licensePlaceholder -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+    Warn "License '$License': wrote a TODO placeholder LICENSE - replace it with the full $License text before publishing."
+}
+Done 'template files rendered'
+
+# ---------------------------------------------------------------------------
+# 3. foundation: .editorconfig + .gitignore via dotnet new (good defaults)
+# ---------------------------------------------------------------------------
+Step 'foundation (.editorconfig, .gitignore)'
+Invoke-Dotnet new gitignore --output .
+Invoke-Dotnet new editorconfig --output .
+
+# Enforce a license header on C# source (IDE0073). The file_header_template uses
+# a literal \n as its line separator; warnings-as-errors then fails the build on
+# any file missing the header.
+$headerTemplate = $headerLines -join '\n'
+Add-Content -LiteralPath '.editorconfig' -Value "`n[*.cs]`nfile_header_template = $headerTemplate`ndotnet_diagnostic.IDE0073.severity = warning`n"
+
+# Keep the top-level artifacts output tree untracked - but only if the gitignore
+# template does not already cover it. Matched per line (Get-Content strips line
+# endings) so a CRLF gitignore does not defeat the check and duplicate the entry.
+$ignoreLines = if (Test-Path -LiteralPath '.gitignore') { Get-Content -LiteralPath '.gitignore' } else { @() }
+if ($ignoreLines -notcontains 'artifacts/') {
+    Add-Content -LiteralPath '.gitignore' -Value "`n# Build outputs`nartifacts/`n"
+}
+Done 'foundation'
+
+# ---------------------------------------------------------------------------
+# 4. harden the main project file (packaging metadata, Source Link, MinVer)
+# ---------------------------------------------------------------------------
+Step "harden $srcDir/$Name.csproj"
+$mainCsproj = "$srcDir/$Name.csproj"
+$xml = [xml](Get-Content $mainCsproj -Raw)
+
+$pg = $xml.CreateElement('PropertyGroup')
+$pg.SetAttribute('Label', 'Package identity')
+$props = [ordered]@{
+    PackageId         = $PackageId
+    Description       = $Description
+    PackageTags       = if ($IsTool) { 'dotnet;dotnet-tool;cli' } else { 'dotnet;library' }
+    PackageReadmeFile = 'README.md'
+}
+if ($IsTool) {
+    $props['PackAsTool']      = 'true'
+    $props['ToolCommandName'] = $ToolCommandName
+}
+foreach ($kv in $props.GetEnumerator()) {
+    $el = $xml.CreateElement($kv.Key); $el.InnerText = $kv.Value; $pg.AppendChild($el) | Out-Null
+}
+# Keep the shippable project AOT/trim clean on its modern target: enables the
+# trim, AOT, and single-file analyzers so the code composes into trimmed/AOT apps
+# and avoids runtime reflection, even when AOT is never published. (Net-only, so
+# it is scoped to the modern TFM - the analyzers do not apply to .NET Framework.)
+$aot = $xml.CreateElement('IsAotCompatible')
+$aot.SetAttribute('Condition', "'`$(TargetFramework)' == '`$(MainTfm)'")
+$aot.InnerText = 'true'
+$pg.AppendChild($aot) | Out-Null
+$xml.Project.AppendChild($pg) | Out-Null
+
+# README packed onto the gallery page.
+$ig = $xml.CreateElement('ItemGroup')
+$none = $xml.CreateElement('None')
+$none.SetAttribute('Include', '$(MSBuildThisFileDirectory)../../README.md')
+$none.SetAttribute('Pack', 'true')
+$none.SetAttribute('PackagePath', '\')
+$none.SetAttribute('Visible', 'false')
+$ig.AppendChild($none) | Out-Null
+$xml.Project.AppendChild($ig) | Out-Null
+
+# MinVer + Source Link (versions come from Directory.Packages.props).
+$ig2 = $xml.CreateElement('ItemGroup')
+foreach ($ref in @(
+    @{ Include = 'MinVer'; PrivateAssets = 'all' },
+    @{ Include = 'Microsoft.SourceLink.GitHub'; PrivateAssets = 'All'; IncludeAssets = 'runtime; build; native; contentfiles; analyzers; buildtransitive' }
+)) {
+    $pr = $xml.CreateElement('PackageReference')
+    $pr.SetAttribute('Include', $ref.Include)
+    $pr.SetAttribute('PrivateAssets', $ref.PrivateAssets)
+    if ($ref.ContainsKey('IncludeAssets')) { $pr.SetAttribute('IncludeAssets', $ref.IncludeAssets) }
+    $ig2.AppendChild($pr) | Out-Null
+}
+$xml.Project.AppendChild($ig2) | Out-Null
+
+if ($IsMultiTarget) {
+    $tfmNode = $xml.SelectSingleNode('//*[local-name()="TargetFramework"]')
+    if ($tfmNode) {
+        $tfs = $xml.CreateElement('TargetFrameworks')
+        $tfs.InnerText = '$(MainTfm);$(LegacyTfm)'
+        $tfmNode.ParentNode.ReplaceChild($tfs, $tfmNode) | Out-Null
+    }
+}
+
+$xml.Save((Resolve-Path $mainCsproj))
+Done "$Name.csproj hardened"
+
+if ($IsTool) {
+    # Replace the console template's top-level statements with an explicit Program
+    # class and Main method - a clearer, more discoverable entry point for a CLI.
+    $rootNs = $Name -replace '[^\w.]', '_'
+    if ($rootNs -match '^[0-9]') { $rootNs = "_$rootNs" }
+    $programLines = @(
+        "namespace $rootNs;"
+        ''
+        'internal sealed class Program'
+        '{'
+        '    private static void Main(string[] args)'
+        '    {'
+        '        Console.WriteLine("Hello, World!");'
+        '    }'
+        '}'
+    )
+    Set-Content -LiteralPath "$srcDir/Program.cs" -Value (($programLines -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+}
+else {
+    # Document the classlib placeholder so a library builds under
+    # GenerateDocumentationFile + TreatWarningsAsErrors (CS1591).
+    $classFile = "$srcDir/Class1.cs"
+    if (Test-Path $classFile) {
+        $doc = "/// <summary>`n/// Placeholder type - replace with the library's public API.`n/// </summary>`npublic class Class1"
+        (Get-Content $classFile -Raw) -replace 'public class Class1', $doc |
+            Set-Content -LiteralPath $classFile -Encoding utf8NoBOM -NoNewline
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 5. harden the test project file (CPM fix-up, doc-gen off, project reference)
+# ---------------------------------------------------------------------------
+Step "harden $testDir/$testProjectName.csproj"
+$testCsproj = "$testDir/$testProjectName.csproj"
+$xml = [xml](Get-Content $testCsproj -Raw)
+$proj = $xml.Project
+
+# Drop the template's PackageReferences (packages/versions vary) and any now-empty
+# ItemGroup, then add the MTP package set from the manifest (versionless; CPM pins).
+foreach ($pr in @($xml.SelectNodes('//*[local-name()="PackageReference"]'))) {
+    $grp = $pr.ParentNode; $grp.RemoveChild($pr) | Out-Null
+    if (-not $grp.HasChildNodes) { $grp.ParentNode.RemoveChild($grp) | Out-Null }
+}
+$pkgGroup = $xml.CreateElement('ItemGroup')
+foreach ($pkgId in $testIds) {
+    $pr = $xml.CreateElement('PackageReference'); $pr.SetAttribute('Include', $pkgId)
+    $pkgGroup.AppendChild($pr) | Out-Null
+}
+$proj.AppendChild($pkgGroup) | Out-Null
+
+# Idempotently set the MTP + test-project properties (the mstest template already
+# sets some of these, so update in place rather than duplicating). Keep XML-doc
+# generation enabled because IDE0005 requires it when code style runs at build;
+# suppress only CS1591 for the test surface.
+$firstPg = $xml.SelectSingleNode('//*[local-name()="PropertyGroup"]')
+if (-not $firstPg) { $firstPg = $xml.CreateElement('PropertyGroup'); $proj.InsertBefore($firstPg, $proj.FirstChild) | Out-Null }
+$wanted = [ordered]@{ OutputType = 'Exe'; IsPackable = 'false'; GenerateDocumentationFile = 'true'; NoWarn = '$(NoWarn);CS1591' }
+if ($TestRunner -eq 'mstest') { $wanted['EnableMSTestRunner'] = 'true' }
+else { $wanted['UseMicrosoftTestingPlatformRunner'] = 'true' }
+foreach ($kv in $wanted.GetEnumerator()) {
+    $existing = $xml.SelectSingleNode("//*[local-name()='$($kv.Key)']")
+    if ($existing) { $existing.InnerText = $kv.Value }
+    else { $el = $xml.CreateElement($kv.Key); $el.InnerText = $kv.Value; $firstPg.AppendChild($el) | Out-Null }
+}
+
+# Reference the project under test.
+$ig = $xml.CreateElement('ItemGroup')
+$ref = $xml.CreateElement('ProjectReference'); $ref.SetAttribute('Include', "../../$srcDir/$Name.csproj")
+$ig.AppendChild($ref) | Out-Null
+$proj.AppendChild($ig) | Out-Null
+$xml.Save((Resolve-Path $testCsproj))
+
+# Run at the fullest level of concurrency by default.
+if ($TestRunner -eq 'mstest') {
+    # The MTP MSTest template emits MSTestSettings.cs with method-level parallelism;
+    # overwrite it to make the worker count explicit (0 = all processors). Fully
+    # qualify the attribute because MSTest is already imported implicitly and an
+    # explicit using fails the generated repo's IDE0005 build gate.
+    Set-Content -LiteralPath "$testDir/MSTestSettings.cs" -Encoding utf8NoBOM -NoNewline -Value @'
+// Fullest MSTest parallelization: every test method may run concurrently across
+// all available processors.
+[assembly: Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize(
+    Workers = 0,
+    Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel)]
+'@
+} else {
+    Set-Content -LiteralPath "$testDir/Parallelism.cs" -Encoding utf8NoBOM -NoNewline -Value @'
+// xunit.v3 parallelizes test collections by default; lift the thread cap so every
+// available processor is used (the fullest level of concurrency).
+[assembly: Xunit.CollectionBehavior(MaxParallelThreads = -1)]
+'@
+}
+Done "$testProjectName.csproj hardened"
+
+# ---------------------------------------------------------------------------
+# 5b. prepend the license header to generated source (enforced by IDE0073)
+# ---------------------------------------------------------------------------
+Step 'file headers'
+Get-ChildItem -Path 'src', 'tests' -Recurse -Filter '*.cs' -File |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin|artifacts)[\\/]' } |
+    ForEach-Object {
+        $body = Get-Content -LiteralPath $_.FullName -Raw
+        if ($body -notmatch '(?m)^// Copyright \(c\)') {
+            Set-Content -LiteralPath $_.FullName -Value ($fileHeaderComment + $body) -Encoding utf8NoBOM -NoNewline
+        }
+    }
+Done 'file headers'
+
+# ---------------------------------------------------------------------------
+# 6. AGENTS.md -> .github/copilot-instructions.md mirror
+# ---------------------------------------------------------------------------
+# The mirror logic lives in the generated repo's tools/Sync-AgentInstructions.ps1
+# so the same code regenerates the mirror here and verifies it in CI
+# (.github/workflows/agent-files.yml).
+Step 'agent mirror'
+& (Join-Path $PWD 'tools/Sync-AgentInstructions.ps1')
+Done 'agent mirror'
+
+# ---------------------------------------------------------------------------
+# 6b. vendor the starting agent-skill tier (domain 9)
+# ---------------------------------------------------------------------------
+# Pinned, provenance-stamped copies of the universal skill cores from the commons.
+# A greenfield repo has nothing to reconcile, so this reduces to "vendor the tier".
+# Graceful: install with `gh skill` when available, otherwise record the exact
+# pinned commands in the final summary so the scaffold never hard-fails offline.
+$skillSummary = ''
+if ($Skills -and $Skills.Count -gt 0) {
+    Step 'vendor starting skills'
+    $skillsDir = '.agents/skills'
+    New-Dir $skillsDir
+    $destAbs = Join-Path (Get-Location).Path $skillsDir
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    $ref = $SkillsRef
+    if ($gh -and -not $ref) {
+        $ref = (& gh release view --repo $SkillsRepo --json tagName --jq '.tagName' 2>$null)
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($ref)) { $ref = $null }
+    }
+    $ghSkill = $false
+    if ($gh) { & gh skill --help *> $null; $ghSkill = ($LASTEXITCODE -eq 0) }
+
+    $vendored = @()
+    $pending = @()
+    if ($ghSkill -and $ref) {
+        foreach ($s in $Skills) {
+            & gh skill install $SkillsRepo $s --pin $ref --dir $destAbs --agent github-copilot --force *> $null
+            if ($LASTEXITCODE -eq 0) { $vendored += $s; Done "vendored $s ($ref)" }
+            else { $pending += $s; Warn "could not vendor $s - recorded as a manual step" }
+        }
+    }
+    else {
+        $pending = @($Skills)
+        $reason = if (-not $gh) { 'gh not found' } elseif (-not $ghSkill) { 'gh skill unavailable' } else { 'could not resolve a release ref' }
+        Warn "skill vendoring deferred ($reason) - commands are in the final summary"
+    }
+
+    # A short catalog documents the intended set and how to manage it even when the
+    # install was deferred; gh skill writes per-skill provenance into frontmatter.
+    $pin = if ($ref) { $ref } else { '<latest release>' }
+    $readmePath = Join-Path $skillsDir 'README.md'
+    if (-not (Test-Path $readmePath)) {
+        $lines = @(
+            '# Vendored agent skills'
+            ''
+            "Pinned, provenance-stamped copies of shared skill cores from $SkillsRepo,"
+            'each with a thin repo-specific overlay. Manage them with the manage-skills'
+            'skill (find / build / update); never edit a vendored core silently - record'
+            'every change as upstreamed, moved to the overlay, or a tracked divergence.'
+            ''
+            '| Skill | Pin |'
+            '| ----- | --- |'
+        ) + ($Skills | ForEach-Object { "| $_ | $pin |" })
+        Set-Content -LiteralPath $readmePath -Value (($lines -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+    }
+
+    if ($vendored.Count -gt 0) {
+        $skillSummary += "`n  Review and commit the vendored skills under .agents/skills (pinned $ref):`n" +
+            (($vendored | ForEach-Object { "    - $_" }) -join "`n") + "`n"
+    }
+    if ($pending.Count -gt 0) {
+        $pinCmd = if ($ref) { $ref } else { 'vX.Y.Z' }
+        $cmds = ($pending | ForEach-Object { "    gh skill install $SkillsRepo $_ --pin $pinCmd --agent github-copilot" }) -join "`n"
+        $skillSummary += "`n  Vendor the starting skill tier (needs gh skill), then commit .agents/skills:`n$cmds`n"
+    }
+    Done 'starting skills'
+}
+
+# ---------------------------------------------------------------------------
+# 7. final restore (packages now centrally pinned)
+# ---------------------------------------------------------------------------
+Step 'dotnet restore'
+Invoke-Dotnet restore
+Done 'restore'
+
+# ---------------------------------------------------------------------------
+# done - print the remote boundary checklist
+# ---------------------------------------------------------------------------
+
+Write-Host @"
+
+Local scaffold complete. Before starting remote setup, verify:
+  dotnet build -c Release
+  dotnet test  -c Release
+$skillSummary
+Then, with explicit approval for each step, run:
+
+  REMOTE SETUP CHECKLIST
+  ----------------------
+  1. Replace <SHA> placeholders in .github/workflows/*.yml with full commit SHAs
+     (use Dependabot or https://app.stepsecurity.io to resolve them).
+
+  2. Create the repository (choose visibility - default to private):
+       gh repo create $Owner/$Name --private --source . --remote origin
+     (use --public instead to publish it openly)
+
+  3. git init && git add -A && git commit -m "Initial scaffold"
+     git branch -M main
+     git push -u origin main
+
+  4. For a private repository, enable GitHub Code Security before the first pull
+     request. If it is unavailable, replace CodeQL with a supported scanner.
+
+  5. Branch protection: require the build status check, branches up to date or a
+     merge queue, and either CodeQL code-scanning results at documented
+     thresholds or the replacement scanner's status check. Require pull requests
+     with no bypass path; block force-push and deletion. If a direct or bypass
+     push is required, restore default-branch push validation in ci.yml,
+     codeql.yml or its replacement, and agent-files.yml first.
+
+  6. Enable secret scanning and push protection (GitHub repo Settings > Security).
+
+  7. Register trusted-publishing policy on nuget.org before the first publish:
+     Owner: $Owner  Repo: $Name  Workflow: publish.yml
+     https://www.nuget.org/account/transform/trusted-publishers
+
+"@ -ForegroundColor White
+
+} finally {
+    Pop-Location
+}

--- a/.agents/skills/engineering-baseline/scripts/Update-ScaffoldActions.ps1
+++ b/.agents/skills/engineering-baseline/scripts/Update-ScaffoldActions.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+    Vets and pins the GitHub Actions referenced by the scaffold's workflow
+    templates. The github-actions counterpart to Update-ScaffoldVersions.ps1
+    (which pins NuGet packages in versions.json).
+
+.DESCRIPTION
+    Scans the workflow templates under template/.github/workflows for
+    `uses: <owner>/<repo>[/<path>]@<ref> # vX.Y.Z` lines and, for every distinct
+    action, resolves the newest STABLE release that was published at least
+    -MinimumReleaseAgeDays ago. That quarantine window keeps freshly published -
+    and therefore least-vetted, possibly compromised - action releases out of
+    newly scaffolded repositories, mirroring the NuGet policy in versions.json.
+
+    Keeping these version comments current is what stops a freshly scaffolded
+    repo from opening a long list of day-one Dependabot action bumps: if the
+    template already pins the newest vetted major, Dependabot has nothing to
+    propose. Stale comments (for example checkout pinned at v4 while v7 ships)
+    are exactly what produce that flood.
+
+    Reports proposed changes by default. Use -Apply to rewrite the version
+    comment (and any already-resolved 40-hex commit SHA) in every template. The
+    `<SHA>` placeholder that the scaffold resolves at pin time is preserved; the
+    refreshed comment is the version the pinner should resolve that placeholder
+    to. Review the diff before committing.
+
+    Requires the GitHub CLI (gh), authenticated, to read release metadata.
+
+.PARAMETER WorkflowsDir
+    Directory of workflow templates to scan. Defaults to
+    template/.github/workflows next to this script.
+
+.PARAMETER MinimumReleaseAgeDays
+    Quarantine window in days. A release newer than this is skipped in favour of
+    the newest release old enough to have been vetted. Default: 30.
+
+.PARAMETER Apply
+    Write the refreshed version comments (and resolved SHAs) back to the
+    templates. Without it, only a report is printed.
+
+.EXAMPLE
+    .\Update-ScaffoldActions.ps1                 # report only
+    .\Update-ScaffoldActions.ps1 -Apply          # refresh the templates
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [string] $WorkflowsDir = (Join-Path $PSScriptRoot 'template/.github/workflows'),
+    [int]    $MinimumReleaseAgeDays = 30,
+    [switch] $Apply,
+    [Parameter(DontShow)] [switch] $SkipMain
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Step ([string] $msg) { Write-Host "  $msg" -ForegroundColor Cyan }
+function Warn ([string] $msg) { Write-Host "  WARN $msg" -ForegroundColor Yellow }
+
+# uses: owner/repo[/sub/path]@<ref> # vX[.Y[.Z]][suffix]
+$usesRegex = [regex]'^(?<pre>\s*(?:-\s+)?uses:\s*)(?<action>[^@\s]+)@(?<ref>\S+)(?<mid>\s+#\s+)(?<ver>v\d[^\s]*)\s*$'
+
+# owner/repo from owner/repo[/sub/...] (codeql-action/init -> codeql-action).
+function Get-ActionRepo ([string] $action) {
+    $parts = $action -split '/'
+    if ($parts.Count -lt 2) { return $null }
+    "$($parts[0])/$($parts[1])"
+}
+
+# [version] from a vX[.Y[.Z]] tag, padded to three components.
+function ConvertTo-SortableVersion ([string] $tag) {
+    $base = ($tag.TrimStart('v') -split '[-+]', 2)[0]
+    $n = @($base -split '\.' | ForEach-Object { [int]$_ })
+    while ($n.Count -lt 3) { $n += 0 }
+    [version]::new($n[0], $n[1], $n[2])
+}
+
+# Newest stable vX.Y.Z release published at least $minAge days ago. Falls back to
+# tags (no publish date, so no age gate) for actions that ship without releases.
+function Resolve-ActionVersion ([string] $repo, [int] $minAge) {
+    $cutoff = (Get-Date).ToUniversalTime().AddDays(-$minAge)
+
+    $releases = @(gh api "repos/$repo/releases" --paginate `
+            --jq '.[] | select(.draft==false and .prerelease==false) | "\(.tag_name)\t\(.published_at)"' 2>$null)
+
+    $candidates = @()
+    foreach ($line in $releases) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $tag, $published = $line -split "`t", 2
+        if ($tag -notmatch '^v\d+(\.\d+){0,2}$') { continue }
+        $pub = [datetime]::Parse($published).ToUniversalTime()
+        if ($pub -gt $cutoff) { continue }
+        $candidates += [pscustomobject]@{ Tag = $tag; Published = $pub }
+    }
+
+    $usedFallback = $false
+    if (-not $candidates) {
+        # No qualifying releases; fall back to stable tags (age cannot be checked).
+        $tags = @(gh api "repos/$repo/tags" --paginate --jq '.[].name' 2>$null)
+        foreach ($tag in $tags) {
+            if ($tag -notmatch '^v\d+(\.\d+){0,2}$') { continue }
+            $candidates += [pscustomobject]@{ Tag = $tag; Published = $null }
+        }
+        $usedFallback = $true
+    }
+    if (-not $candidates) { return $null }
+
+    $best = $candidates | Sort-Object { ConvertTo-SortableVersion $_.Tag } -Descending | Select-Object -First 1
+    $sha = (gh api "repos/$repo/commits/$($best.Tag)" --jq '.sha' 2>$null)
+    if ([string]::IsNullOrWhiteSpace($sha)) { return $null }
+
+    [pscustomobject]@{ Tag = $best.Tag; Sha = $sha; Fallback = $usedFallback }
+}
+
+# ---------------------------------------------------------------------------
+# 1. discover every action reference in the templates
+# ---------------------------------------------------------------------------
+
+if ($SkipMain) { return }
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "gh (GitHub CLI) is required to resolve action releases. Install it and run 'gh auth login'."
+}
+if (-not (Test-Path $WorkflowsDir)) {
+    throw "Workflows directory not found: $WorkflowsDir"
+}
+
+$files = @(Get-ChildItem -Path $WorkflowsDir -Recurse -File -Filter '*.tmpl' |
+    Sort-Object FullName)
+if (-not $files) { $files = @(Get-ChildItem -Path $WorkflowsDir -Recurse -File | Sort-Object FullName) }
+
+$refs = @()   # one row per matching line
+foreach ($file in $files) {
+    $lineNo = 0
+    foreach ($line in [System.IO.File]::ReadAllLines($file.FullName)) {
+        $lineNo++
+        $m = $usesRegex.Match($line)
+        if (-not $m.Success) { continue }
+        $repo = Get-ActionRepo $m.Groups['action'].Value
+        if (-not $repo) { continue }
+        $refs += [pscustomobject]@{
+            File    = $file.FullName
+            Line    = $lineNo
+            Action  = $m.Groups['action'].Value
+            Repo    = $repo
+            CurRef  = $m.Groups['ref'].Value
+            CurVer  = $m.Groups['ver'].Value
+        }
+    }
+}
+
+if (-not $refs) {
+    Write-Host "No action references found under $WorkflowsDir." -ForegroundColor Yellow
+    return
+}
+
+# ---------------------------------------------------------------------------
+# 2. resolve the newest vetted release per distinct repo
+# ---------------------------------------------------------------------------
+Step "Resolving latest vetted releases (>= ${MinimumReleaseAgeDays}d old)..."
+$resolved = @{}
+foreach ($repo in ($refs.Repo | Sort-Object -Unique)) {
+    $r = Resolve-ActionVersion $repo $MinimumReleaseAgeDays
+    if (-not $r) { Warn "could not resolve a release for $repo - leaving as-is"; continue }
+    if ($r.Fallback) { Warn "$repo has no dated releases - used tag $($r.Tag) without an age check" }
+    $resolved[$repo] = $r
+}
+
+# ---------------------------------------------------------------------------
+# 3. report, and (optionally) rewrite the templates
+# ---------------------------------------------------------------------------
+$changes = 0
+$plan = @{}   # file -> ordered list of {Line, New}
+foreach ($ref in $refs) {
+    if (-not $resolved.ContainsKey($ref.Repo)) { continue }
+    $target = $resolved[$ref.Repo]
+    $newVer = $target.Tag
+    $newRef = if ($ref.CurRef -match '^[0-9a-f]{40}$') { $target.Sha } else { $ref.CurRef }
+    $verChanged = ($ref.CurVer -ne $newVer)
+    $refChanged = ($ref.CurRef -ne $newRef)
+    if (-not ($verChanged -or $refChanged)) { continue }
+
+    $changes++
+    $short = [System.IO.Path]::GetFileName($ref.File)
+    Write-Host ("  {0,-22} {1,-28} {2,-9} -> {3}" -f $short, $ref.Action, $ref.CurVer, $newVer)
+
+    if ($Apply) {
+        if (-not $plan.ContainsKey($ref.File)) { $plan[$ref.File] = @() }
+        $plan[$ref.File] += [pscustomobject]@{ Line = $ref.Line; Ref = $newRef; Ver = $newVer }
+    }
+}
+
+if ($changes -eq 0) {
+    Write-Host "All action pins are already current. Nothing to do." -ForegroundColor Green
+    return
+}
+
+if (-not $Apply) {
+    Write-Host ""
+    Write-Host "Report only. Re-run with -Apply to rewrite the templates, then review the diff." -ForegroundColor Yellow
+    return
+}
+
+foreach ($file in $plan.Keys) {
+    # Preserve the file's existing newline style (LF vs CRLF). WriteAllLines would
+    # otherwise force the current platform's newline (CRLF on Windows) and churn
+    # every line across OSes.
+    $raw = [System.IO.File]::ReadAllText($file)
+    $nl = if ($raw.Contains("`r`n")) { "`r`n" } else { "`n" }
+    $lines = [System.IO.File]::ReadAllLines($file)
+    foreach ($edit in $plan[$file]) {
+        $idx = $edit.Line - 1
+        $m = $usesRegex.Match($lines[$idx])
+        if (-not $m.Success) { continue }
+        $lines[$idx] = "{0}{1}@{2}{3}{4}" -f `
+            $m.Groups['pre'].Value, $m.Groups['action'].Value, $edit.Ref, $m.Groups['mid'].Value, $edit.Ver
+    }
+    [System.IO.File]::WriteAllText($file, ($lines -join $nl) + $nl)
+}
+
+Write-Host ""
+Write-Host "Updated $changes reference(s) across $($plan.Keys.Count) file(s). Review the diff before committing." -ForegroundColor Green

--- a/.agents/skills/engineering-baseline/scripts/Update-ScaffoldVersions.ps1
+++ b/.agents/skills/engineering-baseline/scripts/Update-ScaffoldVersions.ps1
@@ -1,0 +1,229 @@
+<#
+.SYNOPSIS
+    Vets and pins the package versions used by New-DotnetRepo.ps1.
+
+.DESCRIPTION
+    Resolves the latest KNOWN-GOOD version of each managed package - never simply
+    the latest. A candidate is rejected unless it is, per the policy in
+    versions.json: old enough (minimum release age / quarantine), listed (not
+    yanked), not deprecated, free of known advisories, and under an allowed
+    license. This keeps freshly published - and therefore least-vetted - versions,
+    including compromised ones, out of newly scaffolded repositories.
+
+    Reports proposed changes by default. Use -Apply to write versions.json (review
+    the diff before committing). Use -SmokeTest to authoritatively validate the
+    pinned set against the real project layouts (a tool and a multi-target library
+    that builds on net472), which is the ground-truth TFM-compatibility check.
+
+.PARAMETER VersionsPath
+    Path to the manifest. Defaults to versions.json next to this script.
+
+.PARAMETER MinimumReleaseAgeDays
+    Override the manifest's quarantine window for this run.
+
+.PARAMETER Source
+    NuGet v3 source. Defaults to the manifest's source (nuget.org).
+
+.PARAMETER Apply
+    Write the resolved versions back to versions.json and stamp lastVetted.
+
+.PARAMETER SmokeTest
+    After resolving (and applying), scaffold a tool and a multi-target library
+    into temp folders and build them, to confirm the pinned set restores and
+    builds on every targeted TFM.
+
+.EXAMPLE
+    .\Update-ScaffoldVersions.ps1                 # report only
+    .\Update-ScaffoldVersions.ps1 -Apply -SmokeTest
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [string] $VersionsPath = (Join-Path $PSScriptRoot 'versions.json'),
+    [int]    $MinimumReleaseAgeDays,
+    [string] $Source,
+    [switch] $Apply,
+    [switch] $SmokeTest,
+    [Parameter(DontShow)] [switch] $SkipMain
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Resolved from the feed's v3 service index once $Source is known (see below).
+$flat = $null
+$reg  = $null
+
+function Get-StableVersions ([string] $id) {
+    $u = "$flat/$($id.ToLowerInvariant())/index.json"
+    (Invoke-RestMethod $u -TimeoutSec 30).versions | Where-Object { $_ -notmatch '-' }
+}
+
+function Get-VersionMeta ([string] $id, [string] $v) {
+    $lid  = $id.ToLowerInvariant()
+    $leaf = Invoke-RestMethod "$reg/$lid/$v.json" -TimeoutSec 30
+    $ce = $leaf.catalogEntry
+    if ($ce -is [string]) { $ce = Invoke-RestMethod $ce -TimeoutSec 30 }
+
+    $license = if ($ce.PSObject.Properties['licenseExpression'] -and $ce.licenseExpression) {
+        $ce.licenseExpression
+    } else {
+        try {
+            $nuspec = [xml]((Invoke-WebRequest "$flat/$lid/$v/$lid.nuspec" -TimeoutSec 30).Content)
+            [string]$nuspec.package.metadata.license.'#text'
+        } catch { $null }
+    }
+
+    [pscustomobject]@{
+        Version    = $v
+        Published  = [datetime]$ce.published
+        Listed     = [bool]$ce.listed
+        Deprecated = [bool]($ce.PSObject.Properties['deprecation'] -and $ce.deprecation)
+        Vulnerable = [bool]($ce.PSObject.Properties['vulnerabilities'] -and $ce.vulnerabilities)
+        License    = $license
+    }
+}
+
+# True only when every SPDX identifier in the (possibly compound) expression is on
+# the allowlist. NuGet returns SPDX expressions such as "MIT OR Apache-2.0" or
+# "(MIT AND BSD-3-Clause)"; an exact match would wrongly reject those. Custom
+# (LicenseRef) expressions cannot be validated and are rejected.
+function Test-LicenseAllowed ([string] $license, [string[]] $allow) {
+    if ([string]::IsNullOrWhiteSpace($license)) { return $false }
+    if ($license -match '(?i)LicenseRef') { return $false }
+    $ids = $license -split '(?i)\s+(?:AND|OR|WITH)\s+' |
+        ForEach-Object { ($_ -replace '[()]', '').Trim().TrimEnd('+') } |
+        Where-Object { $_ }
+    if (-not $ids) { return $false }
+    foreach ($id in $ids) { if ($allow -notcontains $id) { return $false } }
+    return $true
+}
+
+# Newest stable version that passes every gate, scanning newest-first.
+function Resolve-KnownGood ([string] $id, [int] $minAge, [string[]] $allow) {
+    $versions = Get-StableVersions $id | Sort-Object {
+        # Order by full numeric version, padding to four components and dropping any
+        # build metadata, so 4-segment versions are not collapsed to three.
+        $base = ($_ -split '[-+]', 2)[0]
+        $n = @($base -split '\.' | ForEach-Object { [int]$_ })
+        while ($n.Count -lt 4) { $n += 0 }
+        [version]::new($n[0], $n[1], $n[2], $n[3])
+    } -Descending
+    foreach ($v in $versions) {
+        try { $m = Get-VersionMeta $id $v } catch { continue }
+        $age = [int]((Get-Date) - $m.Published).TotalDays
+        $reasons = @()
+        if (-not $m.Listed)  { $reasons += 'unlisted' }
+        if ($m.Deprecated)   { $reasons += 'deprecated' }
+        if ($m.Vulnerable)   { $reasons += 'advisory' }
+        if ($age -lt $minAge) { $reasons += "age ${age}d<${minAge}d" }
+        if (-not $m.License) { $reasons += 'license unknown' }
+        elseif (-not (Test-LicenseAllowed $m.License $allow)) { $reasons += "license $($m.License)" }
+        if ($reasons.Count -eq 0) {
+            return [pscustomobject]@{ Version = $v; Age = $age; License = $m.License; Reason = '' }
+        }
+        Write-Verbose "$id $v rejected: $($reasons -join ', ')"
+    }
+    return [pscustomobject]@{ Version = $null; Age = $null; License = $null; Reason = 'no known-good version' }
+}
+
+# ---------------------------------------------------------------------------
+
+if ($SkipMain) { return }
+
+$doc    = Get-Content $VersionsPath -Raw | ConvertFrom-Json
+$minAge = if ($PSBoundParameters.ContainsKey('MinimumReleaseAgeDays')) { $MinimumReleaseAgeDays } else { [int]$doc.policy.minimumReleaseAgeDays }
+$allow  = @($doc.policy.allowedLicenses)
+if (-not $Source) { $Source = [string]$doc.policy.source }
+
+# Resolve the flat-container and registration endpoints from the feed's v3 service
+# index so -Source actually targets the requested feed (not a hard-coded nuget.org).
+$index = Invoke-RestMethod $Source -TimeoutSec 30
+$flat = ($index.resources | Where-Object { $_.'@type' -eq 'PackageBaseAddress/3.0.0' } | Select-Object -First 1).'@id'
+foreach ($rt in @('RegistrationsBaseUrl/3.6.0', 'RegistrationsBaseUrl/Versioned', 'RegistrationsBaseUrl/3.4.0', 'RegistrationsBaseUrl')) {
+    $reg = ($index.resources | Where-Object { $_.'@type' -eq $rt } | Select-Object -First 1).'@id'
+    if ($reg) { break }
+}
+if (-not $flat -or -not $reg) { throw "Could not resolve PackageBaseAddress/RegistrationsBaseUrl from the service index at $Source." }
+$flat = $flat.TrimEnd('/')
+$reg = $reg.TrimEnd('/')
+
+Write-Host "Vetting scaffold package versions" -ForegroundColor White
+Write-Host "  source:    $Source"
+Write-Host "  min age:   $minAge days (quarantine)"
+Write-Host "  licenses:  $($allow -join ', ')`n"
+
+$rows = foreach ($prop in $doc.packages.PSObject.Properties) {
+    $id = $prop.Name
+    $current = [string]$prop.Value
+    $kg = Resolve-KnownGood $id $minAge $allow
+    $action = if (-not $kg.Version) { 'BLOCKED' }
+              elseif ($kg.Version -eq $current) { 'current' }
+              else { 'bump' }
+    [pscustomobject]@{
+        Package   = $id
+        Current   = $current
+        KnownGood = $kg.Version
+        AgeDays   = $kg.Age
+        License   = $kg.License
+        Action    = $action
+        Note      = $kg.Reason
+    }
+}
+
+$rows | Format-Table Package, Current, KnownGood, AgeDays, License, Action -AutoSize | Out-String | Write-Host
+$blocked = @($rows | Where-Object Action -eq 'BLOCKED')
+if ($blocked) { Write-Host "BLOCKED (no known-good version): $($blocked.Package -join ', ')" -ForegroundColor Yellow }
+
+if ($Apply) {
+    foreach ($r in $rows) { if ($r.KnownGood) { $doc.packages.$($r.Package) = $r.KnownGood } }
+    if ($blocked) {
+        Write-Host "`nNOT stamping lastVetted - no known-good version for $($blocked.Package -join ', '); resolve those before claiming a full vet." -ForegroundColor Yellow
+    } else {
+        $doc.policy.lastVetted = (Get-Date).ToString('yyyy-MM-dd')
+    }
+    ($doc | ConvertTo-Json -Depth 8) + "`n" | Set-Content -LiteralPath $VersionsPath -Encoding utf8NoBOM -NoNewline
+    Write-Host "`nApplied to $VersionsPath. Review the diff and commit deliberately." -ForegroundColor Green
+} else {
+    Write-Host "`nReport only. Re-run with -Apply to write versions.json." -ForegroundColor Cyan
+}
+
+if ($SmokeTest) {
+    $scaffold = Join-Path $PSScriptRoot 'New-DotnetRepo.ps1'
+    $cases = @(
+        @{ Name = 'vettool'; WindowsOnly = $false; Args = @('-Archetype', 'tool', '-PackageId', 'VetTool', '-ToolCommandName', 'vettool', '-Description', 'compat probe', '-Owner', 'vet') }
+        @{ Name = 'vetlib';  WindowsOnly = $true;  Args = @('-Archetype', 'multi-target', '-PackageId', 'Vet.Lib', '-Framework', 'net10.0', '-FrameworkLegacy', 'net472', '-Description', 'compat probe', '-Owner', 'vet') }
+    )
+    $smokeFailed = $false
+    foreach ($c in $cases) {
+        if ($c.WindowsOnly -and -not $IsWindows) {
+            Write-Host "`nSmoke test ($($c.Name)) skipped - building net472 needs Windows (or reference-assembly packages)." -ForegroundColor DarkGray
+            continue
+        }
+        $root = Join-Path ([IO.Path]::GetTempPath()) "vet-$($c.Name)-$(Get-Random)"
+        Write-Host "`nSmoke test ($($c.Name)) -> $root" -ForegroundColor White
+        try {
+            $out = & pwsh -NoProfile -File $scaffold -Root $root -Name $c.Name @($c.Args) *>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "  SCAFFOLD FAILED for $($c.Name) (exit $LASTEXITCODE)" -ForegroundColor Red
+                $out | Select-Object -Last 20 | Out-String | Write-Host
+                $smokeFailed = $true
+                continue
+            }
+            Push-Location $root
+            try {
+                $out = & dotnet build -c Release --nologo *>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "  BUILD FAILED for $($c.Name) - the pinned set is not TFM-compatible" -ForegroundColor Red
+                    $out | Select-Object -Last 20 | Out-String | Write-Host
+                    $smokeFailed = $true
+                }
+                else { Write-Host "  OK ($($c.Name) builds on its targeted TFMs)" -ForegroundColor Green }
+            } finally { Pop-Location }
+        } finally {
+            Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    if ($smokeFailed) { throw "Smoke test failed: the pinned set did not scaffold and build on every targeted TFM." }
+}

--- a/.agents/skills/engineering-baseline/scripts/template/.gitattributes.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.gitattributes.tmpl
@@ -1,0 +1,2 @@
+# Normalize line endings on check-in so cross-platform clones are consistent.
+* text=auto

--- a/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/bug_report.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/bug_report.md.tmpl
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Report a defect
+labels: bug
+---
+
+**Describe the bug**
+A clear, concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS:
+- .NET version:
+- Package version:

--- a/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/feature_request.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/feature_request.md.tmpl
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new capability
+labels: enhancement
+---
+
+**Is this related to a problem?**
+A clear, concise description of what the problem is.
+
+**Proposed solution**
+Describe the change you would like to see.
+
+**Alternatives considered**
+Any alternative solutions you have considered.

--- a/.agents/skills/engineering-baseline/scripts/template/.github/PULL_REQUEST_TEMPLATE.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/PULL_REQUEST_TEMPLATE.md.tmpl
@@ -1,0 +1,17 @@
+## Summary
+
+*Describe what this PR does and why.*
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `dotnet build -c Release` passes
+- [ ] `dotnet test -c Release` passes
+- [ ] New public surface has tests
+
+## Related issues
+
+Fixes #

--- a/.agents/skills/engineering-baseline/scripts/template/.github/dependabot.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/dependabot.yml.tmpl
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Collapse every NuGet update into ONE grouped PR so the repo never opens a
+    # long list of individual bump PRs (day one or later).
+    groups:
+      nuget:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Collapse every GitHub Actions update into ONE grouped PR (same reason).
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
@@ -1,0 +1,30 @@
+name: Agent files
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - AGENTS.md
+      - .github/copilot-instructions.md
+      - .github/workflows/agent-files.yml
+      - tools/Sync-AgentInstructions.ps1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  mirror-check:
+    name: copilot-instructions mirror
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+
+      - name: Verify .github/copilot-instructions.md mirrors AGENTS.md
+        shell: pwsh
+        run: ./tools/Sync-AgentInstructions.ps1 -Check

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/ci.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/ci.yml.tmpl
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build
+    runs-on: {{CI_RUNNER}}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@<SHA> # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/packages.lock.json', '**/Directory.Packages.props', '**/Directory.Build.props', 'global.json') }}
+          restore-keys: nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - uses: actions/setup-dotnet@<SHA> # v5.3.0
+        # SDK version comes from global.json
+
+      - run: dotnet restore --locked-mode
+      - run: dotnet build --configuration Release --no-restore
+      # The global.json MTP runner treats --no-build as a test-app argument and
+      # exits 5 with zero tests. CI=true keeps this implicit restore locked.
+      - run: dotnet test --configuration Release

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'   # weekly Monday scan
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+      - uses: github/codeql-action/init@<SHA> # v4.36.2
+        with:
+          languages: csharp
+      - uses: github/codeql-action/autobuild@<SHA> # v4.36.2
+      - uses: github/codeql-action/analyze@<SHA> # v4.36.2

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/full-ci.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/full-ci.yml.tmpl
@@ -1,0 +1,39 @@
+name: Full CI
+
+# Maintainers run this before each release and after SDK or build-tool changes.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Debug and Release
+    runs-on: {{CI_RUNNER}}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@<SHA> # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/packages.lock.json', '**/Directory.Packages.props', '**/Directory.Build.props', 'global.json') }}
+          restore-keys: nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - uses: actions/setup-dotnet@<SHA> # v5.3.0
+        # SDK version comes from global.json
+
+      - run: dotnet restore --locked-mode
+      - run: dotnet build --configuration Debug --no-restore
+      # The global.json MTP runner treats --no-build as a test-app argument and
+      # exits 5 with zero tests. CI=true keeps this implicit restore locked.
+      - run: dotnet test --configuration Debug
+      - run: dotnet build --configuration Release --no-restore
+      - run: dotnet test --configuration Release

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/publish.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/publish.yml.tmpl
@@ -1,0 +1,47 @@
+name: publish
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: pack and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # OIDC trusted publishing
+    steps:
+      - name: Validate SemVer tag
+        shell: bash
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' is not a valid SemVer tag." && exit 1
+          fi
+
+      - uses: actions/checkout@<SHA> # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@<SHA> # v5.3.0
+
+      - run: dotnet restore --locked-mode
+      - run: dotnet pack src/{{NAME}}/{{NAME}}.csproj --configuration Release --no-restore --output artifacts/packages
+
+      # Exchange the workflow OIDC token for a short-lived NuGet API key.
+      # Requires a trusted-publishing policy registered on nuget.org (see the
+      # remote setup checklist the scaffold script prints).
+      - name: Authenticate to NuGet
+        id: nuget-login
+        uses: NuGet/login@<SHA> # v1.2.0
+        with:
+          user: {{OWNER}}
+
+      - run: >
+          dotnet nuget push artifacts/packages/*.nupkg
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/.agents/skills/engineering-baseline/scripts/template/AGENTS.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/AGENTS.md.tmpl
@@ -1,0 +1,32 @@
+# Agent guidance for {{NAME_TITLE}}
+
+<!--
+Single source of truth for AI agent instructions. After editing this file, run
+tools/Sync-AgentInstructions.ps1 to regenerate the mirror
+.github/copilot-instructions.md; do not edit the mirror directly. CI
+(agent-files.yml) verifies the two stay in sync.
+-->
+
+## Project overview
+
+{{DESCRIPTION}}
+
+**Archetype:** {{ARCHETYPE}} | **Target frameworks:** {{FRAMEWORKS_DISPLAY}}
+
+## Repository layout
+
+| Directory | Purpose |
+| --------- | ------- |
+| `src/{{NAME}}/` | Main project |
+| `tests/{{NAME}}.tests/` | Tests |
+
+## Build and test
+
+```shell
+dotnet build
+dotnet test -c Release
+```
+
+## Conventions
+
+*TODO: document coding style, naming, and design conventions.*

--- a/.agents/skills/engineering-baseline/scripts/template/CODE_OF_CONDUCT.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/CODE_OF_CONDUCT.md.tmpl
@@ -1,0 +1,9 @@
+# Contributor Covenant Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+We pledge to make participation in our community a harassment-free experience for everyone.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+project maintainer at the email address listed in the project's GitHub profile.

--- a/.agents/skills/engineering-baseline/scripts/template/CONTRIBUTING.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/CONTRIBUTING.md.tmpl
@@ -1,0 +1,24 @@
+# Contributing to {{NAME_TITLE}}
+
+Thanks for your interest in contributing!
+
+## Getting started
+
+```shell
+git clone {{REPO_URL}}
+cd {{NAME}}
+dotnet build
+dotnet test
+```
+
+## Submitting changes
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes and add or update tests.
+3. Ensure `dotnet build` and `dotnet test` both pass in Release.
+4. Open a pull request against `main`.
+
+## License
+
+By submitting a pull request you agree that your contribution is licensed under
+the [{{LICENSE}} license](LICENSE) that governs this project.

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Build.props.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Build.props.tmpl
@@ -1,0 +1,76 @@
+<Project>
+
+  <PropertyGroup Label="Target frameworks">
+    <MainTfm>{{FRAMEWORK}}</MainTfm>{{LEGACY_TFM_LINE}}
+  </PropertyGroup>
+
+  <PropertyGroup Label="Output layout">
+    <!-- Keep all build output under a single top-level artifacts/ directory. -->
+    <ArtifactsDir>$(MSBuildThisFileDirectory)artifacts\</ArtifactsDir>
+    <BaseOutputPath>$(ArtifactsDir)bin\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(ArtifactsDir)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Language and analysis">
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--
+      NuGet audit advisories (NU190x) warn but must not block an otherwise green
+      build; a newly published advisory should not break CI until the bump lands.
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Deterministic build">
+    <Deterministic>true</Deterministic>
+    <!--
+      GitHub Actions sets CI=true; enables deterministic source-path
+      normalization in PDBs so the package is reproducible.
+    -->
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Supply chain">
+    <!--
+      Commit packages.lock.json so the full dependency graph (including
+      transitives, where compromises usually hide) is pinned; CI restores in
+      locked mode to fail on any drift.
+    -->
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+    <!--
+      Audit direct AND transitive packages against the GitHub Advisory DB on
+      every restore (NU1901-1904). Kept as warnings via WarningsNotAsErrors so
+      a newly disclosed advisory surfaces without breaking the build.
+    -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package metadata (shared)">
+    <Authors>{{OWNER}}</Authors>
+    <Copyright>Copyright (c) {{YEAR}} {{OWNER}} and contributors</Copyright>
+    <PackageLicenseExpression>{{LICENSE}}</PackageLicenseExpression>
+    <PackageProjectUrl>{{REPO_URL}}</PackageProjectUrl>
+    <RepositoryUrl>{{REPO_URL}}</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <!--
+      Source Link embeds the exact commit in the PDB so debuggers can fetch
+      source on demand.
+    -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Documentation">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Build.targets.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Build.targets.tmpl
@@ -1,0 +1,12 @@
+<Project>
+
+  <!--
+    MinVer derives the package version from the nearest git tag.
+    Create a tag "v0.1.0" to release; CI produces "0.1.0-alpha.0.N" until then.
+    See https://github.com/adamralph/minver
+  -->
+  <PropertyGroup>
+    <MinVerTagPrefix Condition="'$(MinVerTagPrefix)' == ''">v</MinVerTagPrefix>
+  </PropertyGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Packages.props.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Packages.props.tmpl
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!--
+    Central Package Management pins one version per package for every project.
+    Dependabot (.github/dependabot.yml) proposes updates; review and merge them
+    deliberately.
+  -->
+  <ItemGroup>
+{{PACKAGE_VERSIONS}}
+  </ItemGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/LICENSE.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/LICENSE.tmpl
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{YEAR}} {{OWNER}} and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/engineering-baseline/scripts/template/README.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/README.md.tmpl
@@ -1,0 +1,15 @@
+# {{NAME_TITLE}}
+
+{{DESCRIPTION}}
+
+## Installation
+
+{{INSTALL_COMMAND}}
+
+## Usage
+
+*TODO: add usage examples.*
+
+## License
+
+[{{LICENSE}}](LICENSE)

--- a/.agents/skills/engineering-baseline/scripts/template/SECURITY.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/SECURITY.md.tmpl
@@ -1,0 +1,15 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report privately via GitHub Security Advisories:
+[https://github.com/{{OWNER}}/{{NAME}}/security/advisories/new](https://github.com/{{OWNER}}/{{NAME}}/security/advisories/new)
+
+We aim to acknowledge reports within 5 business days and provide a patch or
+mitigation plan within 90 days.
+
+## Supported versions
+
+Only the latest release receives security fixes.

--- a/.agents/skills/engineering-baseline/scripts/template/global.json.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/global.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "{{SDK_VERSION}}",
+    "rollForward": "disable",
+    "allowPrerelease": {{ALLOW_PRERELEASE}}
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/.agents/skills/engineering-baseline/scripts/template/nuget.config.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/nuget.config.tmpl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--
+      Clear inherited sources so the build only ever resolves from nuget.org,
+      regardless of machine-level NuGet configuration.
+    -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <!--
+    Source mapping pins every package id to nuget.org. This is the primary
+    defense against dependency-confusion: a package can never be silently
+    served from an unexpected feed.
+  -->
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/.agents/skills/engineering-baseline/scripts/template/tools/Sync-AgentInstructions.ps1.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/tools/Sync-AgentInstructions.ps1.tmpl
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+    Keeps .github/copilot-instructions.md in sync with AGENTS.md.
+
+.DESCRIPTION
+    AGENTS.md is the single source of truth for agent instructions. GitHub Copilot
+    reads .github/copilot-instructions.md, so this script regenerates that file as
+    a mirror with a "do not edit" header.
+
+    Default: rewrite the mirror from AGENTS.md. With -Check: verify only and fail
+    if the mirror is missing or stale (used by the agent-files CI workflow);
+    nothing is written in -Check mode.
+
+.PARAMETER Check
+    Verify the mirror is current without modifying it. Fails on drift.
+
+.EXAMPLE
+    ./tools/Sync-AgentInstructions.ps1
+    Regenerate the mirror after editing AGENTS.md.
+
+.EXAMPLE
+    ./tools/Sync-AgentInstructions.ps1 -Check
+    Fail if the mirror is out of date (CI).
+#>
+
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [switch] $Check
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# tools/ sits one level under the repository root.
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$source   = Join-Path $repoRoot 'AGENTS.md'
+$mirror   = Join-Path $repoRoot '.github/copilot-instructions.md'
+
+if (-not (Test-Path $source)) { throw "Source not found: $source" }
+
+# The expected mirror is a do-not-edit header over the verbatim source. Line
+# endings are normalized to LF so the check is stable across platforms and the
+# `* text=auto` .gitattributes policy.
+$header   = '<!-- DO NOT EDIT. Generated mirror of /AGENTS.md. -->'
+$body     = (Get-Content -LiteralPath $source -Raw) -replace "`r`n", "`n"
+$expected = "$header`n$body"
+
+if ($Check) {
+    $current = if (Test-Path $mirror) { (Get-Content -LiteralPath $mirror -Raw) -replace "`r`n", "`n" } else { '' }
+    if ($current -ne $expected) {
+        throw "'.github/copilot-instructions.md' is out of sync with AGENTS.md. Run tools/Sync-AgentInstructions.ps1 and commit the result."
+    }
+    Write-Host '.github/copilot-instructions.md is in sync with AGENTS.md.'
+    return
+}
+
+New-Item -ItemType Directory (Split-Path $mirror -Parent) -Force | Out-Null
+Set-Content -LiteralPath $mirror -Value $expected -Encoding utf8NoBOM -NoNewline
+Write-Host 'Regenerated .github/copilot-instructions.md from AGENTS.md.'

--- a/.agents/skills/engineering-baseline/scripts/versions.json
+++ b/.agents/skills/engineering-baseline/scripts/versions.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "minimumReleaseAgeDays": 30,
+    "allowedLicenses": [
+      "MIT",
+      "Apache-2.0",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "MS-PL"
+    ],
+    "source": "https://api.nuget.org/v3/index.json",
+    "lastVetted": "2026-07-04",
+    "note": "Pinned, vetted versions for scaffolded repos. Do not edit versions by hand - run scripts/Update-ScaffoldVersions.ps1, review the diff, then commit. New projects start from this known-good floor, never from 'latest'."
+  },
+  "packages": {
+    "MinVer": "7.0.0",
+    "Microsoft.SourceLink.GitHub": "10.0.300",
+    "MSTest": "4.2.3",
+    "xunit.v3": "3.2.2",
+    "xunit.runner.visualstudio": "3.1.5"
+  }
+}

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -1,0 +1,104 @@
+---
+compatibility: Requires access to the repository's GitHub Actions workflows; precise estimates require current GitHub billing rates and representative job durations.
+description: Audit and reduce GitHub Actions runner usage and normalized cost without weakening required validation. Use when asked to reduce CI cost, spend, minutes, or job count; optimize workflow triggers, matrices, runner selection, caches, or artifact retention; eliminate duplicate Actions runs; or decide which checks should be automatic versus scheduled or manual. Not for application runtime performance, which belongs in a performance-testing workflow.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/github-actions-cost-optimization
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
+    maturity: canary
+    portability: portable
+    related: engineering-baseline, security-review
+    requires: none
+    risk: local-write
+name: github-actions-cost-optimization
+---
+# GitHub Actions cost optimization
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Reduce the cost and latency of GitHub Actions while preserving the checks that
+make a change safe to merge and release. Optimize the repository's full change
+lifecycle, not one conspicuous job: duplicate triggers, repeated setup, matrix
+fan-out, retries, and retained storage can outweigh the longest individual step.
+
+This skill applies to requests such as "reduce our CI spend", "why does this
+workflow use so many minutes?", "move expensive checks out of every PR", and
+"choose cheaper runners without losing coverage". It should not trigger for
+"make this parser faster" or "reduce allocations in this method"; those are
+application performance questions.
+
+## Non-negotiable rule
+
+State the validation invariants before proposing savings. A cheaper workflow
+that no longer tests the merge candidate, a supported platform, a release
+configuration, or a security boundary is not an optimization. Treat changes to
+CodeQL frequency, untrusted-code permissions, branch protection, and merge
+bypass paths as security or governance decisions, not accounting details.
+
+For public repositories, standard GitHub-hosted runners may have no invoiced
+minute charge. Still report normalized list-price cost and runner usage so
+alternatives remain comparable and the workflow stays economical if repository
+visibility or billing policy changes. Keep actual invoiced cost distinct from
+that normalized comparison. Public and private repositories can receive
+different hardware for the same runner label; when they do, label the normalized
+number as a synthetic rate-weighted comparison, not a visibility-change forecast.
+
+## Workflow
+
+1. Read [audit.md](audit.md). Inventory workflows, triggers, required checks,
+   merge paths, runner types, matrices, setup duplication, storage, and recent
+   durations. Identify every automatic run caused by one logical change.
+2. Write down the load-bearing invariants and classify each check as automatic
+   blocking, scheduled/manual breadth, or release-only. Do not reclassify a check
+   merely because its runner is expensive.
+3. Read [cost-model.md](cost-model.md). Calculate the current per-PR, per-merge,
+   and periodic cost from current official rates and observed job durations.
+   State assumptions and show both actual and normalized cost where they differ.
+4. Read [optimizations.md](optimizations.md). Rank changes by savings,
+   confidence, and validation risk. Prefer removing work over making redundant
+   work slightly faster.
+5. Implement the smallest coherent set of workflow changes. Keep repository-
+   specific commands, required status names, platform obligations, and ruleset
+   details in the consuming repository's overlay.
+6. Validate workflow syntax, local build/test equivalents, required-context
+   behavior, and at least one hosted run for every retained native platform.
+   Compare observed durations with the estimate and record any gap.
+
+## Required output
+
+Report:
+
+- the current and proposed job/trigger topology;
+- observed durations, runner hardware, invocation assumptions, and the rate
+  source/date;
+- actual and normalized cost per PR, merged change, and periodic run;
+- validation invariants preserved automatically and breadth moved elsewhere;
+- expected savings, residual risks, and the hosted checks still required;
+- workflow files changed and deterministic validation performed.
+
+Do not present a precise percentage without exposing its inputs. Do not claim
+that a manual or scheduled workflow preserves coverage unless it has a named
+owner, trigger, and occasion or cadence.
+
+## Remote boundary
+
+Workflow edits are local and reversible. Changing repository rulesets, required
+status checks, budgets, merge-queue settings, or Actions retention settings is a
+remote operation: propose the exact change and wait for explicit approval.
+Committing, pushing, and opening a pull request remain separate approval
+boundaries defined by the consuming repository.
+
+## Sub-pages
+
+- [audit.md](audit.md) - inventory, validation invariants, and evidence
+  collection.
+- [cost-model.md](cost-model.md) - actual versus normalized cost calculations
+  and the reporting table.
+- [optimizations.md](optimizations.md) - ordered savings levers, guardrails, and
+  validation traps.

--- a/.agents/skills/github-actions-cost-optimization/audit.md
+++ b/.agents/skills/github-actions-cost-optimization/audit.md
@@ -1,0 +1,139 @@
+# Audit GitHub Actions usage
+
+Build an evidence-backed picture before editing a workflow. The audit has two
+outputs: the current job topology and the validation invariants that topology is
+supposed to enforce.
+
+## 1. Inventory local workflow topology
+
+Read every workflow under `.github/workflows/`, including reusable and release
+workflows. Record one row per job, after expanding matrix legs conceptually:
+
+| Field | What to record |
+| ----- | -------------- |
+| Workflow and job | Display name, job id, and matrix leg names |
+| Trigger | `pull_request`, `push`, `merge_group`, tag, schedule, dispatch, or caller |
+| Filters | Branch, tag, and path filters plus job-level `if` expressions |
+| Runner | Exact label, architecture, operating system, and standard/larger/self-hosted class |
+| Dependencies | `needs`, reusable workflow calls, and aggregate status jobs |
+| Work | Restore, build, tests, coverage, analysis, perf, AOT, pack, publish, or scripts |
+| Repetition | Checkout, SDK setup, restore, cache, and artifact transfer repeated in sibling jobs |
+| Storage | Cache keys/paths and uploaded artifact size and retention |
+| Controls | Concurrency group, cancellation policy, permissions, and timeout |
+
+Check for trigger overlap. A pull request that runs once before merge and again
+on the resulting default-branch push consumes two workflow lifecycles. Tag
+pushes can match both branch and release workflows. A reusable workflow is billed
+to its caller, so include it in the caller's topology rather than treating it as
+free shared infrastructure.
+
+Do not infer behavior from names. Confirm what each command compiles or runs,
+whether `--no-build` actually reuses prior output, and whether a cache path
+matches the tool's configured package/cache directory.
+
+## 2. Inventory remote merge and governance paths
+
+Read the repository rulesets or branch protection when access permits. Otherwise
+mark each item unverified and ask for the missing facts:
+
+- required status-check names and whether they are tied to a GitHub App;
+- pull-request and review requirements;
+- merge queue use and whether workflows handle `merge_group`;
+- administrator, team, automation, or deploy-key bypass paths;
+- whether direct pushes, merge commits, or branch updates can reach the default
+  branch without testing the exact merge candidate;
+- release environments, protected tags, and publishing approvals;
+- Actions budgets, artifact/log retention, and cache limits.
+
+This determines whether a default-branch `push` run is duplicate confirmation or
+the only validation for a bypass path. Do not remove it based only on the presence
+of a `pull_request` trigger.
+
+Required checks and path filters need special care. If an entire required
+workflow is skipped because no filtered path matched, GitHub can leave its check
+pending and block the merge. Prefer an always-created aggregate check, job-level
+conditional work, or a ruleset design that does not require a path-filtered
+workflow.
+
+## 3. State validation invariants
+
+List what must remain true before merge and release. Derive this from supported
+platforms, packaging promises, security posture, and repository guidance, not
+from the current matrix alone. Common invariants include:
+
+- Release configuration builds and tests the merge candidate;
+- legacy target frameworks compile or execute on a compatible host;
+- platform-specific source and native interop execute on each supported native
+  operating system or architecture that cannot be represented elsewhere;
+- coverage, API compatibility, formatting, generated-file, and lock-file gates
+  continue to fail the required aggregate check;
+- performance gates run in a stable environment and cannot reuse stale output;
+- trim and Native AOT paths publish and execute for the support contract they
+  protect;
+- package creation and release authentication are tested before publishing;
+- untrusted pull-request code never receives write tokens or secrets;
+- code scanning runs at the cadence and merge boundary required by the security
+  model.
+
+Classify each invariant:
+
+| Class | Meaning |
+| ----- | ------- |
+| Automatic blocking | Every merge candidate must pass it |
+| Scheduled/manual breadth | Important regression coverage with a named cadence or operator |
+| Release-only | Must pass before a release, but not every change |
+
+Record the owner and trigger for every non-automatic invariant. "Available
+manually" without an owner or occasion is deferred indefinitely, not preserved
+coverage.
+
+## 4. Collect representative execution evidence
+
+Use Actions usage/performance metrics when available. They expose workflow and
+job minutes, runner type, average runtime, queue time, and failure rate. The
+displayed usage metrics do not apply billing multipliers, so join them to current
+runner rates in the cost model.
+
+Without organization metrics, inspect recent runs with GitHub CLI:
+
+```shell
+gh run list --workflow WORKFLOW --limit 20
+gh run view RUN_ID --json event,startedAt,updatedAt,jobs
+```
+
+For each material job, collect successful, failed, and canceled samples over a
+representative period. Prefer at least 10 recent ordinary runs when the history
+exists. Report the median for a typical estimate and a high percentile (for
+example p75) for a conservative estimate. Keep queue time separate from runner
+execution time.
+
+Include:
+
+- reruns after flaky or infrastructure failures;
+- time consumed before superseded runs are canceled;
+- cache-hit and cache-miss samples;
+- pull-request updates per merged change;
+- scheduled, bot, merge-queue, and post-merge invocations;
+- jobs created only to emit required status contexts.
+
+Do not substitute workflow wall-clock duration for runner usage. Parallel jobs
+reduce elapsed feedback time while still consuming and billing each runner.
+
+## 5. Produce the baseline topology
+
+End the audit with:
+
+1. A diagram or table showing which logical change causes each workflow and job.
+2. The automatic, periodic, and release validation invariants.
+3. Unverified remote assumptions that could make an optimization unsafe.
+4. The duration samples and invocation frequencies used by the cost model.
+5. Obvious waste hypotheses, each paired with a check that could disprove it.
+
+Examples of falsifiable hypotheses:
+
+- "The default-branch run duplicates PR validation" is disproved by an allowed
+  direct-push or bypass path.
+- "This Linux job can move to ARM64" is disproved by an unavailable toolchain,
+  native dependency, or architecture-sensitive test.
+- "The cache saves restore time" is disproved when cache-hit and no-cache
+  durations are equivalent or the configured path is never populated.

--- a/.agents/skills/github-actions-cost-optimization/cost-model.md
+++ b/.agents/skills/github-actions-cost-optimization/cost-model.md
@@ -1,0 +1,160 @@
+# Model GitHub Actions cost
+
+Use current official billing rules and observed job durations. Do not preserve a
+copied price table as timeless policy: runner SKUs and rates change.
+
+## Sources
+
+Record the access date and use GitHub's current documentation:
+
+- [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)
+  for standard and larger runner rates and billing granularity;
+- [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+  for plan allowances, public-repository treatment, and artifact/cache storage;
+- [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+  for visibility-specific CPU, memory, architecture, and image specifications;
+- [Actions usage metrics](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-usage-metrics-for-github-actions)
+  for organization-level job and workflow evidence.
+
+At the time of analysis, verify rather than assume these rules:
+
+- whether each job's partial minute is rounded up independently;
+- whether the runner is standard, larger, or self-hosted;
+- whether repository visibility makes standard hosted minutes free;
+- whether plan allowances make the next minute non-billable but still consume a
+  finite quota;
+- current artifact, cache, and custom-image storage treatment.
+
+## Two cost views
+
+Always distinguish:
+
+1. **Actual invoiced cost.** What the owner is expected to pay under current
+   visibility, plan allowance, budgets, runner class, and storage usage.
+2. **Normalized list-price cost.** A synthetic rate-weighted measure: observed
+  job duration multiplied by current published runner rates before
+  public-repository or plan allowances.
+
+For a public repository on standard hosted runners, actual minute cost may be
+zero while normalized cost is nonzero. Report both. Normalized cost makes runner
+choices comparable, exposes resource use, and remains useful if visibility or
+billing policy changes.
+
+Runner labels do not always identify equivalent hardware across visibility. For
+example, GitHub can assign more CPU and memory to a standard public
+`ubuntu-latest` or `windows-latest` job than to the same label in a private
+repository. In that case:
+
+- call the normalized result a **synthetic rate-only comparison**;
+- record both hardware specifications beside the rate;
+- do not present the number as what making the repository private would cost;
+- forecast a visibility change only from durations measured on equivalent paid
+  hardware, or report a runtime range that accounts for the hardware change.
+
+Comparing alternatives measured on the same public runner remains useful, but
+the rate-weighted result ranks their observed usage rather than predicting a
+different runner's elapsed time.
+
+Do not label a self-hosted runner free. GitHub may not charge hosted-runner
+minutes, but infrastructure, maintenance, scaling, and incident response still
+have a cost. Model those separately when they matter.
+
+## Job-level calculation
+
+When current GitHub policy rounds each job up to a whole minute:
+
+```text
+billedMinutesPerJob = ceiling(observedRunnerSeconds / 60)
+normalizedJobCost = invocations * billedMinutesPerJob * currentRunnerRate
+```
+
+Apply the rounding to every matrix leg and aggregate job independently. Do not
+round the sum of raw seconds once at workflow level. This is why six 15-second
+jobs can cost six billed minutes while one sequential 90-second job costs two.
+
+Use runtime after a runner starts; queue time affects feedback latency but is not
+runner execution. Setup, checkout, restore, and cleanup run on the runner and do
+count. Canceled and failed jobs consume the time used before they stop.
+
+If GitHub changes billing granularity, replace the `ceiling` function with the
+current rule and cite it in the report.
+
+## Lifecycle calculation
+
+Calculate at least three scopes:
+
+```text
+perPullRequest = sum(PR update and rerun job costs)
+perMergedChange = perPullRequest + merge-queue + default-branch + deployment jobs
+monthlyPeriodic = scheduled frequency * cost per scheduled run
+```
+
+State invocation assumptions explicitly. Useful variables include:
+
+- average pull-request updates before merge;
+- percentage of pull requests merged;
+- bot/dependency pull-request volume;
+- flaky rerun rate;
+- cancellation delay for superseded runs;
+- releases and manual full-matrix runs per month.
+
+Report both a typical estimate (median durations and ordinary update count) and a
+conservative estimate (high-percentile durations plus observed reruns). Do not
+claim precision beyond the quality of the history.
+
+## Storage calculation
+
+Runner minutes and retained storage are separate. Inventory:
+
+- uploaded artifacts and their `retention-days`;
+- repository-level log/artifact retention;
+- cache size, key cardinality, churn, and eviction;
+- custom images used by larger runners;
+- package storage if the workflow publishes artifacts externally.
+
+GitHub bills applicable storage over time, commonly in GB-hours converted to
+GB-months. Deleting an artifact stops future accrual but does not erase storage
+already accrued. Use the current billing page for allowances and rates.
+
+Caching is an optimization only when its time savings exceed restore/upload
+overhead and storage pressure. Compare cache-hit, cache-miss, and no-cache runs.
+Key caches on dependency inputs and runner compatibility; a cache pointed at a
+different directory than the tool uses has zero benefit.
+
+## Reporting table
+
+Use one row per expanded job:
+
+| Workflow / job | Trigger | Runner / hardware / SKU | Runs per scope | p50 / p75 | Billed min | Rate | Normalized cost |
+| -------------- | ------- | ----------------------- | -------------- | --------- | ---------- | ---- | --------------- |
+| Example | PR | current label and specs | measured | measured | calculated | dated source | calculated |
+
+Then summarize:
+
+| Scope | Current actual | Current normalized | Proposed actual | Proposed normalized | Change |
+| ----- | -------------- | ------------------ | --------------- | ------------------- | ------ |
+| Pull request | | | | | |
+| Merged change | | | | | |
+| Monthly periodic | | | | | |
+
+Calculate reduction as:
+
+```text
+reductionPercent = (currentNormalized - proposedNormalized) / currentNormalized * 100
+```
+
+If current normalized cost is zero, report the absolute duration/job reduction
+instead of an undefined percentage.
+
+## Sanity checks
+
+- The sum includes every matrix leg and every tiny aggregate job.
+- PR and default-branch triggers are modeled separately.
+- Public-repository free usage is not presented as zero resource consumption.
+- Visibility-specific runner hardware is recorded; a synthetic public-duration
+  by private-rate number is not presented as a private-repository forecast.
+- Larger runners are not assumed free for public repositories.
+- Canceled, failed, scheduled, release, and manual runs are either modeled or
+  explicitly excluded.
+- Rates have a source and access date.
+- The proposed estimate uses the same assumptions as the baseline.

--- a/.agents/skills/github-actions-cost-optimization/optimizations.md
+++ b/.agents/skills/github-actions-cost-optimization/optimizations.md
@@ -1,0 +1,153 @@
+# Optimize GitHub Actions safely
+
+Apply changes in this order. Earlier steps remove unnecessary work and usually
+carry less validation risk than deleting matrix dimensions.
+
+## 1. Stop runs that should not start
+
+- Cancel superseded pull-request runs with a concurrency key stable for that
+  pull request. A run id is unique and therefore cannot cancel anything.
+- Remove the default-branch `push` trigger only when rulesets prove every path to
+  the branch validates an equivalent merge candidate. Keep it when direct or
+  bypass pushes remain possible.
+- Avoid overlapping branch, tag, and release workflows.
+- Use path filters for optional workflows whose absence cannot block a required
+  status. For required checks, ensure the context is always emitted.
+- Group dependency updates when repository policy permits so one compatible
+  batch pays one CI lifecycle instead of many.
+- Add `merge_group` when a merge queue requires testing the synthetic merge
+  candidate; do not count a PR-head test as equivalent.
+
+## 2. Remove repeated setup and rounding overhead
+
+Every job pays for runner startup, checkout, SDK/tool setup, restore, and current
+job-level billing granularity. Consolidate sequential work that needs the same
+runner and artifacts when the saved setup and rounded minutes outweigh the lost
+parallelism.
+
+Good consolidation candidates include build plus tests, multiple target
+framework test invocations on one compatible host, and performance gates that
+can reuse a verified Release build. Preserve separate jobs when they provide
+material wall-clock savings, isolation, permissions boundaries, or genuinely
+different runners.
+
+Do not split tiny script checks into many jobs merely for presentation. A cheap
+aggregate required check should be one job when one stable context is enough.
+
+## 3. Choose the cheapest compatible runner
+
+- Use a slim one-core Linux runner for short scripts and aggregate status jobs
+  when its toolset and speed are sufficient.
+- Prefer standard Linux for portable build/test work.
+- Consider Linux ARM64 only after restore, toolchain, native dependency, and test
+  compatibility are demonstrated. Architecture substitution is a test-coverage
+  decision as well as a price decision.
+- Keep Windows or macOS where native APIs, legacy frameworks, packaging, signing,
+  filesystem semantics, or supported-platform behavior requires them.
+- Compare larger runners by total job cost, not minute rate alone. A faster,
+  more expensive runner can be cheaper if measured runtime falls enough.
+
+Cross-compiling proves compilation for a target; it does not replace executing
+native behavior on that target.
+
+## 4. Make the automatic matrix load-bearing
+
+Run Release tests automatically because Release code generation is what ships.
+Keep Debug automatic only when it detects a distinct class of regressions that
+the project has chosen to gate.
+
+For operating-system, architecture, target-framework, runtime-identifier, AOT,
+and SDK matrices:
+
+1. Map every leg to a stated invariant.
+2. Keep merge-blocking legs for common or high-risk behavior.
+3. Move expensive breadth to a named scheduled/manual workflow or a release gate
+   only when delayed detection is acceptable.
+4. Give periodic breadth a cadence and owner so it cannot silently rot.
+
+Do not call a reduced automatic matrix "equivalent" to the full matrix. Report
+what remains automatic and what becomes delayed.
+
+## 5. Fix restore and cache behavior
+
+- Restore once per job and use `--no-restore` or the tool's equivalent only when
+  the following command truly supports it.
+- Point the cache at the actual configured package directory. If an environment
+  variable redirects that directory, cache the redirected path.
+- Include operating system, architecture, lock files, SDK/tool versions, and
+  other compatibility inputs in the key when they affect cache validity.
+- Use restore keys only when a partial match is safe.
+- Remove caches whose hit-rate or measured savings do not justify upload,
+  download, and storage churn.
+
+Never share build output across jobs without proving it cannot become stale or
+mix configurations. Rebuilding is cheaper than trusting the wrong binary.
+
+## 6. Control artifacts and logs
+
+- Upload only outputs needed by downstream jobs, diagnostics, or release.
+- Set the shortest practical `retention-days` on large transient artifacts.
+- Avoid uploading duplicate binaries from every matrix leg.
+- Keep test logs and failure diagnostics long enough to debug ordinary failures.
+- Review repository retention and cache limits as remote settings; changing them
+  requires approval.
+
+## 7. Treat security scans as security decisions
+
+Moving CodeQL or another scanner from every pull request to a schedule lowers
+runner cost but delays detection. Before doing so, record:
+
+- whether the repository handles untrusted input or sensitive data;
+- whether language/compiler analyzers cover part of the same risk;
+- whether branch protection currently requires the scan;
+- scheduled cadence, alert ownership, and response expectations;
+- whether release gates need a fresh scan.
+
+Use a security-review workflow when this decision is material. Never run
+untrusted pull-request code with write permissions or repository secrets to save
+the setup cost of a separate trusted job.
+
+## 8. Preserve required-check behavior
+
+When branch protection depends on historical check names, a temporary aggregate
+job can preserve them while the underlying topology changes. The aggregate must:
+
+- use `if: always()` so it runs after failed, canceled, or skipped dependencies;
+- inspect every dependency result;
+- succeed only when all required dependencies succeeded;
+- use a cheap compatible runner and a short timeout.
+
+An aggregate that runs only after success can be skipped on failure and leave an
+ambiguous required context. An aggregate that accepts `skipped` without a
+deliberate policy can turn missing validation green.
+
+Update or remove legacy contexts only with explicit approval to change the
+remote ruleset. Required-check changes and workflow changes should be sequenced
+so merges are never accidentally unguarded.
+
+## 9. Validate in layers
+
+After each coherent edit:
+
+1. Run an Actions-aware linter and YAML/editor diagnostics.
+2. Run whitespace and repository policy checks.
+3. Execute the local build, Release tests, and any perf/AOT/package commands the
+   changed automatic jobs will use.
+4. Confirm cache paths and generated artifact locations statically.
+5. Push only with approval and observe one hosted run on every retained native
+   platform and architecture.
+6. Confirm required contexts appear and fail closed for a deliberately failed or
+   canceled dependency when practical.
+7. Replace estimated durations with hosted measurements and recalculate cost.
+
+## Common traps
+
+- A path-filtered required workflow never starts and leaves the PR pending.
+- A concurrency group includes a unique run id, so no prior run is canceled.
+- A cache saves the default directory while the build uses a redirected one.
+- A shallow checkout changes git-derived versioning such as MinVer.
+- `--no-build` reuses output from a different configuration or target.
+- A manual full matrix has no cadence or owner and quietly stops being useful.
+- Removing post-merge CI ignores an administrator or automation bypass path.
+- Replacing native execution with cross-compilation drops behavior coverage.
+- Many tiny jobs look parallel but multiply setup and rounded billing minutes.

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,0 +1,21 @@
+---
+core: github-actions-cost-optimization
+core-pin: v0.11.0
+---
+
+# GitHub Actions cost optimization overlay
+
+Repository-specific bindings for thirtytwo.
+
+- The current workflow surface is
+  [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml).
+- It gates pushes and pull requests to `main` and performs restore, Debug and
+  Release builds, Release tests, and TRX upload.
+- Keep a Windows runner for product validation: the library targets
+  `net10.0-windows`, and tests exercise Win32, COM, UI, and native resource
+  behavior. Do not model a Linux runner as an equivalent cheaper substitute.
+- Preserve pull-request validation, required checks, test-result retention on
+  failure, and least-privilege defaults. Cost proposals must identify which
+  duplicate work they remove and which validation evidence remains.
+- Use representative GitHub run durations and current billing rates before
+  attaching savings numbers to a recommendation.

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -1,0 +1,130 @@
+---
+compatibility: Requires a Release build with portable or embedded PDBs and an IL reader such as ilspycmd, ildasm, Cecil, or System.Reflection.Metadata.
+description: Find struct value copies in a method's compiled IL - defensive copies, boxing, by-value field/argument/return copies - by reading the emitted bytecode rather than predicting from source. Use when asked to "find struct copies", "where does the compiler copy this struct", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy here", "confirm the analyzer's defensive-copy warning", or "audit a [NonCopyable] type's copies after build". Post-build, ground-truth counterpart to source-level defensive-copy analyzers - IL is post-lowering, so synthesized copies the analyzer cannot see are visible here. Not for wall-clock/allocation measurement (that is `performance-testing`) nor for JIT-emitted machine code (that is `framework-jit-optimization` + `DisassemblyDiagnoser`).
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/il-copy-inspection
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
+    maturity: canary
+    portability: portable
+    related: roslyn-analyzers, framework-jit-optimization, performance-testing, scratch-buffer-strategy
+    requires: none
+    risk: advisory
+name: il-copy-inspection
+---
+# Inspecting IL for struct copies
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+A struct copy is invisible in C# source but concrete in IL. This skill reads a
+method's **emitted bytecode** to find where the compiler actually copies a value
+type - defensive copies, boxing, and by-value field/argument/return copies - and
+maps each back to a source line. It is the ground-truth, post-build complement to
+the predictive, in-IDE rules of a source-level defensive-copy analyzer.
+
+## The four layers (where this sits)
+
+A struct copy can be reasoned about at four levels. Pick the layer that answers the
+question; they are complementary, not interchangeable.
+
+| Layer | Artifact | Tool / skill | What it tells you |
+| ----- | -------- | ------------ | ----------------- |
+| Source | `IOperation` (pre-lowering) | `roslyn-analyzers` (defensive-copy rules) | A copy is *predicted* from C# rules, live in the IDE |
+| **IL** | **compiled bytecode (post-lowering)** | **this skill** (`ildasm` / `ilspycmd` / Cecil) | **A copy was *emitted* by the C# compiler** |
+| Asm | JIT machine code | `framework-jit-optimization` + `DisassemblyDiagnoser` | Whether the JIT *kept* the copy or elided it |
+| Runtime | ETW / wall-clock | `performance-testing` + `filtrace` | Whether the copy *costs* measurable time / allocation |
+
+The IL layer is uniquely able to see copies the **compiler synthesizes during
+lowering** - async / iterator state-machine field hoisting, closures, thunks -
+which have no source operation and are therefore out of reach for an analyzer. It
+is also the cheapest way to *confirm* a defensive-copy prediction: if the IL has
+the defensive-copy signature, the analyzer was right.
+
+## Step 0 - is something already answering this?
+
+- **"Does my code have a defensive copy I can fix in the editor?"** -> a
+  source-level defensive-copy analyzer (`roslyn-analyzers`) already flags the
+  common cases live. Use this skill only to (a) confirm a flagged case, or (b) find
+  the synthesized copies the analyzer documents as out of scope.
+- **"Is this copy actually costing me time / allocations?"** -> `performance-testing`
+  (boxing shows as `Allocated` under `[MemoryDiagnoser]`; a hot defensive copy shows
+  in a trace).
+- **"Did the JIT keep the copy?"** -> `framework-jit-optimization` /
+  `[DisassemblyDiagnoser]`. The C# compiler may emit an IL copy that the JIT then
+  elides, so IL presence is necessary but not sufficient for a runtime cost.
+- Otherwise, read the IL (below).
+
+## Workflow
+
+1. **Build Release with a portable PDB.** Optimized IL is what ships; Debug IL has
+   extra copies and spills. The PDB's sequence points are what map IL offsets back
+   to `file:line`. Make sure the build emits a portable PDB -
+   `<DebugType>embedded</DebugType>` or `<DebugType>portable</DebugType>` in the
+   project.
+2. **Extract the method's IL.** Pick a tool from the table below. Disassemble the
+   single method of interest, not the whole assembly.
+3. **Match the copy patterns.** Scan the method body for the copy opcodes and the
+   defensive-copy temp signature. The full catalog - every opcode, the
+   `ldobj`/`stloc`/`ldloca`/`call` defensive sequence, `box`, `cpobj`, `ldfld` vs
+   `ldflda` - is in
+   [references/copy-opcodes.md](references/copy-opcodes.md).
+4. **Map IL offset to source.** Use the PDB sequence points (most disassemblers can
+   interleave source, e.g. `ilspycmd -il` with debug info, or read sequence points
+   via `System.Reflection.Metadata`) to attribute each copy to a line - the same
+   artifact-to-source drill the `performance-testing` skill does with `filtrace`.
+5. **Report** the type copied, the mechanism (defensive / box / by-value), and the
+   source line. Distinguish *intended* copies (a documented value transfer) from
+   *unintended* ones; IL alone cannot, so use the source context.
+
+## Tool options
+
+| Tool | Good for | Note |
+| ---- | -------- | ---- |
+| `ilspycmd -il <dll>` ([ICSharpCode.ILSpyCmd](https://github.com/icsharpcode/ILSpy)) | One-method IL dump, scriptable | `dotnet tool install -g ilspycmd`; cross-platform |
+| `ildasm` | Quick Windows dump | Ships with the .NET SDK / VS; Windows-centric |
+| `Mono.Cecil` | Programmatic body walking, custom rules | Best when scripting a repeatable copy audit |
+| `System.Reflection.Metadata` (`MetadataReader`, `MethodBodyBlock`) | In-proc, no extra dependency, owns the PDB sequence-point mapping | Most code; the right base for an automated pass |
+
+For a repeatable, automated audit, `Mono.Cecil` or `System.Reflection.Metadata`
+walking the method body and matching the opcode patterns from the catalog is the
+durable choice; `ilspycmd` is the fastest manual spot-check.
+
+## Constraints
+
+- **Needs a build and a PDB.** Unlike an analyzer (source only), this requires
+  compiled output. No PDB means no source-line mapping - opcodes only.
+- **IL copy != runtime cost.** The JIT may elide an emitted copy. Confirm cost at
+  the asm or runtime layer before claiming a perf impact.
+- **Generics share IL.** A copy of `T` appears once in the shared body; the real
+  cost depends on the instantiation. Note the open generic, then reason per
+  value-type substitution.
+- **Intent is lost in IL.** A by-value copy that is a deliberate transfer looks
+  identical to an accidental one. Keep the source open to classify; this is the same
+  "unintended vs intended" limit a defensive-copy analyzer's docs call out.
+
+## Cross-skill
+
+- `roslyn-analyzers` - the source-level, predictive side (defensive-copy rules).
+  This skill confirms its predictions and covers the synthesized copies it cannot
+  see.
+- `framework-jit-optimization` - the next layer down (asm); whether the JIT kept the
+  copy, and what to do about it on .NET Framework.
+- `performance-testing` - whether the copy costs measurable time / allocation.
+- `scratch-buffer-strategy` - many `[NonCopyable]` types are pooled buffers; this
+  skill audits whether one is being copied by value.
+- A consuming repository wires these cross-references and its concrete diagnostic
+  IDs and project names in its overlay.
+
+## Disambiguation
+
+"Find the copies" is ambiguous across layers. Route by artifact: **predict from
+source, live** -> `roslyn-analyzers`; **read the compiler's emitted IL** -> this
+skill; **read the JIT's machine code** -> `framework-jit-optimization`; **measure
+the runtime cost** -> `performance-testing`. This skill never runs the code and
+never measures time - it reads static bytecode.

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,0 +1,32 @@
+---
+core: il-copy-inspection
+core-pin: v0.11.0
+---
+
+# IL copy inspection overlay
+
+Repository-specific bindings for thirtytwo.
+
+High-value copy-sensitive surfaces include:
+
+- handle and value projections under
+  [src/thirtytwo/Win32](../../../src/thirtytwo/Win32);
+- COM scopes and lifetime types under
+  [Win32/System/Com](../../../src/thirtytwo/Win32/System/Com);
+- stack and pooled buffers under
+  [src/thirtytwo/Support](../../../src/thirtytwo/Support);
+- readonly message views under
+  [src/thirtytwo/Messages](../../../src/thirtytwo/Messages).
+
+Build Release before inspecting emitted IL:
+
+```pwsh
+dotnet build src/thirtytwo/thirtytwo.csproj --configuration Release
+Get-ChildItem artifacts -Filter thirtytwo.dll -Recurse
+```
+
+Use [scratch-buffer-strategy](../scratch-buffer-strategy/SKILL.md) for storage
+design and [security-review](../security-review/SKILL.md) for unsafe
+preconditions. This repository has no dedicated analyzer or performance
+project, so do not claim source diagnostics or benchmark evidence that was not
+actually produced.

--- a/.agents/skills/il-copy-inspection/references/copy-opcodes.md
+++ b/.agents/skills/il-copy-inspection/references/copy-opcodes.md
@@ -1,0 +1,100 @@
+# IL copy opcode and pattern catalog
+
+Reference for the [il-copy-inspection](../SKILL.md) skill. The opcodes and patterns
+that correspond to a struct value copy in compiled IL, and how to tell each apart
+from its non-copying address-based counterpart.
+
+## The defensive-copy signature
+
+A *defensive copy* is the one the compiler inserts silently when a non-`readonly`
+instance member is invoked on a read-only struct location (an `in` parameter, a
+`readonly` field, a `ref readonly` local). It is the highest-value find because it
+is invisible in source. For `void M(in Pooled p) => p.Mutate();` where `Mutate` is
+not `readonly`, the compiler emits a **synthesized temporary**:
+
+```cil
+ldarg.1            // &p   - address of the in-parameter (no copy yet)
+ldobj      Pooled  // copy *p onto the stack
+stloc.0            // spill the copy into a compiler temp local
+ldloca.s   0       // &temp - address of the COPY
+call       instance void Pooled::Mutate()   // mutate the copy, then discard it
+```
+
+The tell is the **`ldobj` -> `stloc <temp>` -> `ldloca <temp>` -> `call instance`**
+chain on a receiver that started as an address (`ldarg`/`ldflda`/`ldsflda` of a
+read-only location). The mutation lands on the temp and is thrown away. Contrast the
+no-copy form, where a `readonly` member (or a mutable receiver) is called directly
+on the address with no intervening `ldobj`/`stloc`:
+
+```cil
+ldarg.1            // &p
+call       instance int32 Pooled::Peek()    // readonly member - no copy
+```
+
+## Explicit copy opcodes
+
+| Opcode | Meaning | Copy? |
+| ------ | ------- | ----- |
+| `ldobj <type>` | Load a value type from an address onto the stack | **Yes** - copies the value |
+| `stobj <type>` | Store a value type from the stack through an address | **Yes** |
+| `cpobj <type>` | Copy a value type from one address to another | **Yes** |
+| `box <type>` | Box a value type into a reference | **Yes** - copy + heap allocation |
+| `unbox.any <type>` | Unbox to a value on the stack | **Yes** - copies out |
+| `ldfld <field>` | Load a field **by value** | **Yes** when the field is a struct |
+| `ldflda <field>` | Load a field **address** | No - address, no copy |
+| `ldsfld` / `ldsflda` | Static field, by value / by address | `ldsfld` copies; `ldsflda` does not |
+| `ldloc` / `ldloca` | Local, by value / by address | `ldloc` of a struct copies; `ldloca` does not |
+| `ldarg` / `ldarga` | Argument, by value / by address | `ldarg` of a struct copies; `ldarga` does not |
+| `ldelem <type>` / `ldelema` | Array element, by value / by address | `ldelem` copies; `ldelema` does not |
+
+The recurring distinction is **value form vs address form**: the `...a` suffix
+(`ldflda`, `ldloca`, `ldarga`, `ldelema`, `ldsflda`) takes an address and does
+**not** copy. The non-`a` form of a struct loads a copy.
+
+## By-value argument / return / assignment
+
+- **By-value argument.** A struct pushed onto the stack (via `ldloc`/`ldfld`/etc.,
+  not `ldloca`) into a call whose parameter is not `ref`/`in`/`out` is copied into
+  the callee. The callee's signature (no `&` on the parameter type) confirms by-value.
+- **By-value return.** `ret` with a struct value on the stack returns a copy. A
+  method that returns `ref` puts an address on the stack instead - no copy.
+- **Assignment / field store.** `stfld`/`stloc`/`stsfld` of a struct value, or
+  `stobj`/`cpobj` through an address, copies into the destination.
+
+## Boxing
+
+`box <ValueType>` is the easiest copy to spot and almost always unintended for a
+resource-owning struct: it copies the value onto the GC heap. It appears whenever a
+value type is converted to `object`, an interface, or `dynamic`, or wrapped in
+`Nullable<T>` patterns. Boxing is also the one copy whose runtime cost (an
+allocation) is directly visible at the runtime layer via `[MemoryDiagnoser]`.
+
+## Caveats when reading IL
+
+- **Move vs copy is still inferred.** IL shows a copy opcode but not whether the
+  source value had another owner. A `ldloc`/`ldobj` feeding a `ret` may be a
+  deliberate transfer. Cross-reference the source line (via the PDB) before calling
+  it unintended - the same limit the source analyzer documents.
+- **The JIT may elide it.** `ldobj`/`stloc` of a small struct can be optimized away
+  by the JIT. IL presence proves the *compiler* copied; confirm a *runtime* cost at
+  the asm (`DisassemblyDiagnoser`) or trace layer.
+- **Generics emit shared IL.** The body of a generic method shows one copy of `T`;
+  whether `T` is a large struct, a small struct, or a reference type changes the
+  real cost. Record the open generic and reason per value-type instantiation.
+- **Debug vs Release.** Debug IL adds spills and temporaries that look like copies.
+  Always read optimized Release IL for a representative picture.
+- **Compiler-synthesized members.** Async/iterator state machines hoist captured
+  structs into generated fields; the copy lives in the `MoveNext` body, not the
+  user method. Disassemble the generated nested type to see it.
+
+## Mapping IL offset to source line
+
+Each IL instruction has an offset; the portable PDB's **sequence points** map offset
+ranges to `(document, startLine, startColumn)`. To attribute a copy:
+
+- With a disassembler: use a mode that interleaves source (`ilspycmd` with debug
+  info, ILSpy's "IL with C#").
+- Programmatically: open the PDB with `System.Reflection.Metadata.MetadataReader`,
+  read the method's `MethodDebugInformation.GetSequencePoints()`, and find the
+  sequence point whose IL range contains the copy opcode's offset. This is the same
+  offset-to-line mechanism a profiler uses, applied statically.

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -1,0 +1,100 @@
+---
+compatibility: Requires gh 2.90 or later for install and update operations; manual file comparison remains available without gh.
+description: Find, add, update, and share agent skills in this repo. Use when asked to "find a skill" for a task, "build a skill" or "create a skill" (this skill checks whether one already exists - in the repo, the shared commons, or a public catalog - before authoring a new one), "update a skill", or reconcile a local skill change against the upstream commons vs a repo-local overlay. Covers the find-first build path, the tiered search, and the pull/push update flow. Not for validating one agent file's syntax - that is `agent-files-review`.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/manage-skills
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 5b881e8d4c0a1d5e9bdf3d48cb91d515088e44d2
+    maturity: canary
+    portability: portable
+    related: agent-files-review
+    requires: none
+    risk: remote-write
+name: manage-skills
+---
+# Manage skills
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+The lifecycle skill for the skills under a repo's `.agents/skills/`: discover one,
+add one, update one, and keep local changes in sync with the shared set. It turns
+"find a skill", "build a skill", and "update the skill" into actions aligned with
+the sharing model instead of ad-hoc edits.
+
+The model in one paragraph: skills are authored once as a portable **core** and
+shared through a common skills repo (the **commons**); each consuming repo holds a
+pinned, provenance-stamped **copy** plus a thin repo-specific **overlay**. The
+commons is bidirectional - a generic improvement made in any repo flows back
+upstream, while a repo-specific tweak lives only in that repo's overlay.
+
+## The three verbs
+
+| Ask | Do | Detail |
+| --- | --- | ------ |
+| "find a skill for X", "is there a skill that does X" | Tiered search (local -> commons -> public), with an applicability check for this repo. | [find.md](find.md) |
+| "build a skill for X", "create a skill" | **Run find first.** Only author new if it exists nowhere; otherwise vendor or tweak the existing one. | [build.md](build.md) |
+| "update the skill", "sync my change", "pull skill updates" | Pull upstream drift; or push a local improvement, classified common (ask before upstreaming) vs deviation (overlay). | [update.md](update.md) |
+
+These chain: `build` always begins by running `find`, and a `find` that turns up a
+local skill needing a tweak hands off to the overlay path in `build`.
+
+## The golden rule
+
+When you change a skill that was vendored from the commons: **never let a vendored
+core diverge silently.** A vendored core is a mirror of upstream. Classify the
+edit, then place it - and **nothing about upstreaming is automatic**:
+
+- **Local deviation** (the change is specific to this repo) -> move it into the
+  repo's **overlay**, and restore the vendored core to match upstream.
+- **Common** (the change helps every consumer) -> it *should* go upstream, but
+  upstreaming is not always plausible. **Ask** before attempting it; never open a
+  commons PR unprompted. If upstreamed, re-pin to the new version; if not yet,
+  keep it as a recorded *pending-upstream divergence* so it is intentional, not
+  silent.
+
+So a vendored-core edit ends in one of three **recorded** states - upstreamed,
+moved to the overlay, or a tracked pending-upstream divergence - never an
+unexplained one. The provenance frontmatter (source repo, ref, and tree SHA) plus
+the `update` drift check is what enforces this: unexplained drift is the signal
+that an improvement was written into the wrong layer. See [update.md](update.md).
+
+## Conventions every skill follows
+
+Whatever the verb, the result must satisfy the repo's authoring rules
+(`FORMAT.md`) and then pass `agent-files-review`, which owns the file-level
+checks - frontmatter, mirror sync, whitespace, and the validator and link
+checker. Don't restate those rules here.
+
+For the `SKILL.md` frontmatter check specifically, this skill bundles
+[scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) - a dependency-free
+PowerShell port of the Agent Skills spec validator - so the check runs anywhere
+the skill is vendored, without the upstream tool. Run it on the skill directory:
+`pwsh scripts/Validate-Skills.ps1 <skill-dir>`. A commons portfolio uses
+`-RequirePortfolioMetadata` to enforce its metadata and overlay contract.
+
+For a new downstream binding, start from
+`assets/overlay.md.tmpl`, replace its skill and pin tokens, and keep every local
+path and concrete cross-reference in that overlay.
+
+## Sub-pages
+
+- [find.md](find.md) - the tiered search, the applicability check, and the
+  recommendation report.
+- [build.md](build.md) - the find-first decision tree, the security gate for
+  public sources, and authoring a new skill (born-local vs born-shared).
+- [update.md](update.md) - the pull (drift) and push (common vs deviation)
+  flows and the provenance mechanics behind the golden rule.
+
+## Disambiguation
+
+`manage-skills` operates on the **catalog lifecycle** - discover, add, vendor,
+sync. It is not `agent-files-review`, which
+validates the **syntax and conventions** of one agent file (frontmatter, mirror
+sync, whitespace). The normal order is: run `manage-skills` to bring a skill in
+or push one out, then `agent-files-review` to validate the file you ended up with.

--- a/.agents/skills/manage-skills/assets/overlay.md.tmpl
+++ b/.agents/skills/manage-skills/assets/overlay.md.tmpl
@@ -1,0 +1,21 @@
+---
+core: {{SKILL_NAME}}
+core-pin: {{CORE_PIN}}
+---
+
+# {{SKILL_NAME}} overlay
+
+Repository-specific bindings for the vendored core beside this file. Keep paths,
+project names, local examples, and concrete cross-skill links here. Do not copy
+portable workflow rules out of the core.
+
+## Bindings
+
+- Replace this line with the repository-specific paths and conventions the core
+  needs.
+
+## Updating
+
+When the core is re-pinned, update `core-pin`, review these bindings against the
+new core, and run the repository's strict skill validator and relative-link
+check.

--- a/.agents/skills/manage-skills/build.md
+++ b/.agents/skills/manage-skills/build.md
@@ -1,0 +1,85 @@
+# Build a skill
+
+Detail for the [manage-skills](SKILL.md) skill. "Build a skill for X" / "create a
+skill" does **not** start by writing a new skill. It starts by finding one.
+
+## The find-first decision tree
+
+Reinventing a skill that already exists - in this repo, the commons, or a public
+catalog - is the failure mode this path exists to prevent. Always run
+[find.md](find.md) first, then act on the result:
+
+1. **Run find.**
+2. **Already in this repo** -> do not build. If it does not quite fit, add or edit
+   the repo's **overlay** (see [update.md](update.md)), never the vendored core.
+3. **In the commons** -> do not build. Vendor it and add a thin overlay for any
+   repo-specific paths or cross-references:
+
+   ```pwsh
+   gh skill install JeremyKuhne/agent-skills <skill> --pin vX.Y.Z
+   ```
+
+   `--pin` records the exact version so later `update --all` runs skip it until
+   you deliberately re-pin. The install writes provenance frontmatter (source
+   repo, ref, and tree SHA); commit it.
+4. **In a public catalog** -> do not build from scratch. Apply the security gate
+   below. If it is good, vendor it; if it is close but imperfect, fork it into the
+   commons and vendor that. A mediocre public skill is usually worth adapting over
+   a blank start.
+5. **Nowhere** -> build new (next section).
+
+## Security gate for public sources
+
+Public skills are an instruction-injection supply chain - audits have found a
+meaningful fraction carry a critical issue (prompt injection, malicious scripts,
+exposed secrets). Before installing anything from a public source:
+
+- **Preview, do not blind-install:** `gh skill preview <owner/repo> <skill>` and
+  read the `SKILL.md`, every script, and every `references/` file - not just the
+  summary.
+- **Pin** to a tag or commit SHA; never track a moving ref.
+- **Never accept `allowed-tools` from a third party**, especially `shell` / `bash`
+  - it removes the per-command confirmation. Strip it on import and let the host
+  prompt.
+- **Prefer provenance-bearing sources** (the curated registry, verified
+  publishers) over a random repo from a blog post.
+- Treat a cloned repo's `.agents/` as untrusted code: opening it can load skills
+  into a trusted session.
+
+## Building a new skill (it exists nowhere)
+
+Author it to the repo's `FORMAT.md`:
+
+- A thin `SKILL.md` core under the size budget; push deep detail into sibling
+  `*.md` files in the same directory (the pattern this very skill uses).
+- `name` matches the directory; a "pushy" `description` with explicit trigger
+  phrasing that will auto-invoke on the right asks without over-firing.
+- Set every portfolio metadata field (`portability`, `applicability`, `binding`,
+  `risk`, `maturity`, `requires`, and `related`) using the repo's `FORMAT.md`.
+- For an overlay-aware core, include the standard loader sentence. Create a
+  downstream overlay from `assets/overlay.md.tmpl`; replace `{{SKILL_NAME}}` and
+  `{{CORE_PIN}}`, then add only repository-specific bindings.
+- Add a row to the catalog `README.md` inventory in the same change, and a
+  disambiguation entry if the trigger phrasing competes with an existing skill.
+- Validate the `SKILL.md` frontmatter with the bundled
+  [scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) in strict portfolio
+  mode, then run the repo's remaining agent-file checks (the installed-artifact
+  link check, markdown lint, and generated catalog check).
+
+### Born-local vs born-shared
+
+Decide where the skill's home is before writing much:
+
+- **Born-local** - the skill is specific to this repo (its paths, projects, or
+  one-off workflow). Author it here under `.agents/skills/` and leave it; it never
+  goes to the commons.
+- **Born-shared** - the skill is generic and other repos will want it. Author the
+  portable core directly in the commons, then vendor it back here with an overlay.
+  Keep repo-specific paths, cross-references, and example links out of the core
+  from the start - they belong in the overlay. Leave a short prose cue in the core
+  telling the agent to read `overlay.md` when present; that stable loader contract
+  is what gets the overlay read.
+
+A skill that is mostly generic but needs a few local specifics is still
+born-shared: the generic part is the core, the specifics are the overlay. The test
+is whether another repo would want the core unchanged.

--- a/.agents/skills/manage-skills/find.md
+++ b/.agents/skills/manage-skills/find.md
@@ -1,0 +1,65 @@
+# Find a skill
+
+Detail for the [manage-skills](SKILL.md) skill. Answers "find a skill for X" /
+"is there a skill that does X" with a tiered search and a per-repo applicability
+check, then a short recommendation.
+
+## Tiered search (nearest trust first)
+
+Search in order and stop reporting once you have the picture; do not skip a tier,
+because a local hit changes the recommendation entirely.
+
+1. **Local - this repo's `.agents/skills/`.** List the skill directories and read
+   the catalog `README.md` inventory and disambiguation. A match here means the
+   skill is already present; the answer is "you have it", and the only question is
+   whether it needs an overlay tweak. No tooling required.
+
+2. **The commons.** Search the shared skills repo:
+
+   ```pwsh
+   gh skill search <terms> --repo JeremyKuhne/agent-skills
+   ```
+
+   Anything here is curated and pre-vetted. When `gh` is unavailable, browse the
+   commons repo directly and note that the install path will be manual.
+
+3. **Public catalogs.** Search the wider ecosystem - the awesome-copilot
+   collection, `anthropics/skills`, and the registry:
+
+   ```pwsh
+   gh skill search <terms>
+   ```
+
+   Public results are **untrusted by default**. Do not recommend installing one
+   without the security gate in [build.md](build.md). When `gh` is unavailable,
+   fall back to browsing the catalogs in a browser and note that the install path
+   will be manual.
+
+## Applicability check
+
+A skill existing is not the same as a skill belonging here. Before recommending a
+vendor, judge whether the skill's domain applies to **this** repo:
+
+- A domain skill (for example a CsWin32 COM skill) is irrelevant in a repo that
+  does no COM, even though it is a perfectly good skill. Say so; do not recommend
+  vendoring something that will never fire.
+- A project-gated skill (one that drives a sibling project such as a fuzz or perf
+  project) applies if the repo has that project *or should have it*. If the
+  project is missing, report that project creation as a separate prerequisite;
+  vendoring the current core does not scaffold it.
+- A repo-local skill from another repo (tied to that repo's unique structure)
+  does not transfer; flag it as out of scope.
+
+## Recommendation report
+
+Output a short summary, not a raw search dump:
+
+- **Where it exists:** local / commons / public / nowhere.
+- **Applicable here:** yes / no / only if a gated project is added, with the
+  one-line reason.
+- **Recommended action:** use it (already local) / tweak the overlay / vendor from
+  the commons / evaluate-and-vendor from public / build new / skip as
+  inapplicable.
+
+That recommendation is the hand-off into [build.md](build.md), which turns "vendor"
+or "build new" into concrete steps.

--- a/.agents/skills/manage-skills/overlay.md
+++ b/.agents/skills/manage-skills/overlay.md
@@ -1,0 +1,41 @@
+---
+core: manage-skills
+core-pin: v0.11.0
+---
+
+# Manage skills overlay
+
+Repository-specific bindings for thirtytwo.
+
+## Ownership
+
+- Every provenance-bearing core under `.agents/skills/` comes from
+  `JeremyKuhne/agent-skills` and must remain identical to its pinned upstream
+  artifact.
+- Put thirtytwo paths, commands, examples, and cross-skill links in
+  `overlay.md`. The local [catalog](../README.md) and
+  [format contract](../FORMAT.md) are also downstream-owned.
+- The current portfolio is reviewed against the immutable `v0.11.0` release.
+
+## Pulling a commons release
+
+Use the exact source path and an immutable pin:
+
+```pwsh
+gh skill install JeremyKuhne/agent-skills skills/<name> --pin vX.Y.Z --agent github-copilot --scope project --force
+```
+
+Install `cswin32-interop` before its required consumer `cswin32-com`. Preserve
+the local overlay, update its `core-pin`, update the catalog when the portfolio
+changes, and review the normal diff.
+
+## Validation
+
+```pwsh
+pwsh -NoProfile -File .agents/skills/manage-skills/scripts/Validate-Skills.ps1 .agents/skills -RequirePortfolioMetadata
+Get-ChildItem .agents/skills -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'SKILL.md') } | ForEach-Object { npx --yes skills-ref@0.1.5 validate $_.FullName }
+git diff --check
+```
+
+Do not vendor a project-gated skill until its required perf, fuzz, or analyzer
+project exists or is being added in the same reviewed effort.

--- a/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
+++ b/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
@@ -1,0 +1,523 @@
+<#
+.SYNOPSIS
+    Validates Agent Skills (SKILL.md) against the agentskills.io specification. A
+    dependency-free PowerShell check based on `agentskills/skills-ref` (frontmatter),
+    plus the spec's length recommendation and Claude's no-XML-tags rule.
+
+.DESCRIPTION
+    For each skill directory, checks the SKILL.md against the Agent Skills
+    spec (https://agentskills.io/specification):
+
+      - required fields present: name and description. Any other field (the spec's
+        optionals, client extensions, or custom keys) is allowed and not flagged.
+      - name: required; <= 64 chars; NFKC-normalized; lowercase; letters, digits,
+        and hyphens only; no leading/trailing or consecutive hyphen; matches the
+        directory name.
+      - description: required; non-empty; <= 1024 chars; no XML-style tags (the
+        name and description are injected into the agent's skill-metadata block).
+      - compatibility: if present, a string <= 500 chars.
+      - yaml: inline scalar values carry no unquoted ':' (a mapping indicator that
+        a strict parser, like the strictyaml skills-ref uses, would reject).
+      - readability: Markdown files contain no HTML entities; direct Unicode and
+        plain words remain valid.
+      - length: SKILL.md is at most 500 lines (the spec's progressive-disclosure
+        recommendation, "Keep your main SKILL.md under 500 lines").
+
+    The length and no-XML-tags checks go beyond skills-ref, which validates
+    frontmatter only; the colon check restores parity with its strict YAML parser.
+
+    With -RequirePortfolioMetadata, also enforces this commons' portable-core
+    policy: metadata.portability/applicability/binding/risk/maturity/requires/
+    related, the optional-overlay loader cue, and overlay.md frontmatter when an
+    overlay is present.
+
+    The frontmatter parser handles inline scalars, `>`/`|` block scalars, and one
+    level of `metadata:` mapping, with `---` matched line by line. A known field
+    given a block mapping/sequence (or an unquoted-colon scalar) is rejected;
+    unknown fields may take any shape. For arbitrary YAML use the `skills-ref` tool.
+
+    Exits 0 when every skill is valid, 1 otherwise.
+
+.PARAMETER Path
+    One or more paths. Each may be a skill directory (contains SKILL.md) or a
+    parent directory whose immediate subdirectories are skills (e.g. skills/).
+    Defaults to the current directory.
+
+.PARAMETER Quiet
+    Print only failures.
+
+.PARAMETER RequirePortfolioMetadata
+    Require and validate the commons portfolio metadata and overlay contract.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/
+    Validate every skill directory under skills/.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/manage-skills
+    Validate a single skill directory.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/ -RequirePortfolioMetadata
+    Validate every commons core against the stricter portfolio policy.
+#>
+
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)] [string[]] $Path,
+    [switch] $Quiet,
+    [switch] $RequirePortfolioMetadata
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$MaxName = 64
+$MaxDescription = 1024
+$MaxCompatibility = 500
+$MaxSkillLines = 500
+$PortfolioMetadataFields = @('portability', 'applicability', 'binding', 'risk', 'maturity', 'requires', 'related')
+$AllowedPortability = @('portable', 'semi-portable', 'repo-specific')
+$AllowedApplicability = @('universal', 'git-github', 'agent-customization', 'dotnet', 'dotnet-framework', 'dotnet-project-gated', 'tool-shipped', 'repo-local')
+$AllowedBinding = @('none', 'optional-overlay', 'required-overlay')
+$AllowedRisk = @('advisory', 'local-write', 'remote-write')
+$AllowedMaturity = @('experimental', 'canary', 'stable')
+$OverlayCue = 'If `overlay.md` exists beside this file, read it before acting'
+# Spec scalar fields. If one of these is given a block mapping/sequence instead of
+# a scalar it is rejected; unknown fields and `metadata` are not shape-checked.
+$KnownScalarFields = @('name', 'description', 'license', 'compatibility', 'allowed-tools')
+
+function Get-SkillMd ([string] $dir) {
+    foreach ($n in 'SKILL.md', 'skill.md') {
+        $p = Join-Path $dir $n
+        if (Test-Path -LiteralPath $p -PathType Leaf) { return $p }
+    }
+    return $null
+}
+
+# Unwrap a YAML scalar's surrounding quotes. A single-quoted scalar un-doubles ''
+# (the YAML single-quote escape); a double-quoted scalar is stripped as-is.
+function Get-ScalarValue ([string] $value) {
+    if ($value.Length -ge 2 -and $value.StartsWith("'") -and $value.EndsWith("'")) {
+        return $value.Substring(1, $value.Length - 2).Replace("''", "'")
+    }
+    if ($value.Length -ge 2 -and $value.StartsWith('"') -and $value.EndsWith('"')) {
+        return $value.Substring(1, $value.Length - 2)
+    }
+    return $value
+}
+
+# Reject an unquoted inline scalar whose value holds a ':' followed by whitespace
+# (or a trailing ':') - a YAML mapping indicator that strict parsers (strictyaml,
+# which skills-ref uses) reject. Quoted values and flow collections ({ } / [ ]) are
+# exempt (their inner colons are valid YAML); true block scalars are handled before
+# this is reached, so a leading '>'/'|' here is plain text.
+function Test-InlineColon ([string] $key, [string] $value) {
+    if ($value -match '^["''\[{]') { return }
+    if ($value -match ':(\s|$)') {
+        throw "Invalid YAML in frontmatter: value for '$key' has an unquoted ':' (a YAML mapping indicator); quote the value or use a block scalar (>-)."
+    }
+}
+
+# Fold a YAML block scalar (the lines under a `key: >` or `key: |`) into a string:
+# common indentation stripped, '|' kept literal (newline-joined), '>' folded with
+# spaces.
+function Join-BlockScalar ([System.Collections.Generic.List[string]] $blockLines, [bool] $literal) {
+    $nonBlank = @($blockLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($nonBlank.Count -eq 0) { return '' }
+    $minIndent = ($nonBlank | ForEach-Object { [regex]::Match($_, '^\s*').Length } | Measure-Object -Minimum).Minimum
+    $dedented = $blockLines | ForEach-Object {
+        if ([string]::IsNullOrWhiteSpace($_)) { '' } else { $_.Substring([Math]::Min($minIndent, $_.Length)) }
+    }
+    if ($literal) { return ($dedented -join "`n").Trim() }
+    $sb = [System.Text.StringBuilder]::new()
+    $prevBlank = $true
+    foreach ($l in $dedented) {
+        if ($l -eq '') { [void]$sb.Append("`n"); $prevBlank = $true }
+        else { if (-not $prevBlank) { [void]$sb.Append(' ') }; [void]$sb.Append($l); $prevBlank = $false }
+    }
+    return $sb.ToString().Trim()
+}
+
+# Parse SKILL.md frontmatter into a case-sensitive ordered map. The `---`
+# delimiters are matched line by line. Handles inline scalars, `>`/`|` block
+# scalars, and one level of `metadata:` block mapping. A known field given a block
+# mapping/sequence is rejected; an unknown field may take any shape (unvalidated).
+# Not a general YAML parser; for arbitrary YAML use `skills-ref`.
+function Read-Frontmatter ([string] $content) {
+    $allLines = $content -split "\r?\n"
+    if ($allLines.Count -eq 0 -or $allLines[0].Trim() -ne '---') {
+        throw 'SKILL.md must start with YAML frontmatter (---)'
+    }
+    $end = -1
+    for ($k = 1; $k -lt $allLines.Count; $k++) {
+        if ($allLines[$k].Trim() -eq '---') { $end = $k; break }
+    }
+    if ($end -lt 0) { throw 'SKILL.md frontmatter not properly closed with ---' }
+
+    $map = New-Object System.Collections.Specialized.OrderedDictionary ([System.StringComparer]::Ordinal)
+    $lines = @()
+    if ($end -gt 1) { $lines = @($allLines[1..($end - 1)]) }
+    $i = 0
+    while ($i -lt $lines.Count) {
+        $line = $lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) { $i++; continue }
+        if ($line.TrimStart().StartsWith('#')) { $i++; continue }
+        if ($line -notmatch '^\S') { throw "Invalid YAML in frontmatter near: $line" }
+
+        $idx = $line.IndexOf(':')
+        if ($idx -lt 0) { throw "Invalid YAML in frontmatter near: $line" }
+        $key = $line.Substring(0, $idx).Trim()
+        $rest = $line.Substring($idx + 1).Trim()
+
+        if ($rest -match '^[|>][+-]?\d*\s*$') {
+            $literal = $rest.StartsWith('|')
+            $i++
+            $blockLines = [System.Collections.Generic.List[string]]::new()
+            while ($i -lt $lines.Count -and ([string]::IsNullOrWhiteSpace($lines[$i]) -or $lines[$i] -match '^\s')) {
+                $blockLines.Add($lines[$i]); $i++
+            }
+            $map[$key] = Join-BlockScalar $blockLines $literal
+            continue
+        }
+
+        if ($rest -eq '') {
+            # Empty value: classify the following block (mapping, sequence, or none).
+            $j = $i + 1
+            while ($j -lt $lines.Count -and [string]::IsNullOrWhiteSpace($lines[$j])) { $j++ }
+            $hasChild = ($j -lt $lines.Count -and $lines[$j] -match '^\s')
+            $isSequence = $hasChild -and ($lines[$j] -match '^\s+-(\s|$)')
+
+            if ($hasChild -and $key -ceq 'metadata' -and -not $isSequence) {
+                $sub = New-Object System.Collections.Specialized.OrderedDictionary ([System.StringComparer]::Ordinal)
+                $i++
+                while ($i -lt $lines.Count) {
+                    if ([string]::IsNullOrWhiteSpace($lines[$i])) { $i++; continue }
+                    if ($lines[$i] -notmatch '^\s') { break }
+                    if ($lines[$i].TrimStart().StartsWith('#')) { $i++; continue }
+                    $kv = $lines[$i].Trim()
+                    $ci = $kv.IndexOf(':')
+                    if ($ci -lt 0) { throw "Invalid YAML in frontmatter near: $kv" }
+                    $sk = $kv.Substring(0, $ci).Trim()
+                    $sv = $kv.Substring($ci + 1).Trim()
+                    Test-InlineColon $sk $sv
+                    $sub[$sk] = Get-ScalarValue $sv
+                    $i++
+                }
+                $map[$key] = $sub
+                continue
+            }
+
+            if ($hasChild -and $key -cin $KnownScalarFields) {
+                $shape = if ($isSequence) { 'sequence' } else { 'mapping' }
+                throw "Field '$key' must be a scalar value, not a block $shape."
+            }
+
+            # A null value, an unknown field's nested block, or a metadata sequence:
+            # swallow any nested lines and store an empty value (shape unvalidated).
+            if ($hasChild) {
+                $i++
+                while ($i -lt $lines.Count -and ([string]::IsNullOrWhiteSpace($lines[$i]) -or $lines[$i] -match '^\s')) { $i++ }
+            }
+            else {
+                $i++
+            }
+            $map[$key] = ''
+            continue
+        }
+
+        Test-InlineColon $key $rest
+        $map[$key] = Get-ScalarValue $rest
+        $i++
+    }
+    return $map
+}
+
+# Count physical lines in SKILL.md (matches editor line numbers / Get-Content).
+function Measure-SkillLineCount ([string] $content) {
+    if ([string]::IsNullOrEmpty($content)) { return 0 }
+    $n = ($content -split "\r?\n").Count
+    if ($content.EndsWith("`n")) { $n-- }
+    return $n
+}
+
+function Test-SkillName ($name, [string] $dir) {
+    if ($null -eq $name -or $name -isnot [string] -or [string]::IsNullOrWhiteSpace($name)) {
+        "Field 'name' must be a non-empty string"
+        return
+    }
+    $name = $name.Trim().Normalize([System.Text.NormalizationForm]::FormKC)
+
+    if ($name.Length -gt $MaxName) {
+        "Skill name '$name' exceeds $MaxName character limit ($($name.Length) chars)"
+    }
+    if ($name -cne $name.ToLowerInvariant()) {
+        "Skill name '$name' must be lowercase"
+    }
+    if ($name.StartsWith('-') -or $name.EndsWith('-')) {
+        'Skill name cannot start or end with a hyphen'
+    }
+    if ($name.Contains('--')) {
+        'Skill name cannot contain consecutive hyphens'
+    }
+    $invalid = $false
+    foreach ($c in $name.ToCharArray()) { if (-not ([char]::IsLetterOrDigit($c) -or $c -eq '-')) { $invalid = $true; break } }
+    if ($invalid) {
+        "Skill name '$name' contains invalid characters. Only letters, digits, and hyphens are allowed."
+    }
+    if ($dir) {
+        $leaf = Split-Path -Leaf $dir
+        if ($leaf.Normalize([System.Text.NormalizationForm]::FormKC) -cne $name) {
+            "Directory name '$leaf' must match skill name '$name'"
+        }
+    }
+}
+
+function Test-SkillDescription ($description) {
+    if ($null -eq $description -or $description -isnot [string] -or [string]::IsNullOrWhiteSpace($description)) {
+        "Field 'description' must be a non-empty string"
+        return
+    }
+    if ($description.Length -gt $MaxDescription) {
+        "Description exceeds $MaxDescription character limit ($($description.Length) chars)"
+    }
+    if ($description -match '</?[A-Za-z][^<>]*>') {
+        "Description must not contain XML-style tags (found '$($Matches[0])'). The name and description are injected into the agent's skill-metadata XML block; reword (e.g. 'of T') or use backticks."
+    }
+}
+
+function Test-SkillCompatibility ($compatibility) {
+    if ($compatibility -isnot [string]) {
+        "Field 'compatibility' must be a string"
+        return
+    }
+    if ($compatibility.Length -gt $MaxCompatibility) {
+        "Compatibility exceeds $MaxCompatibility character limit ($($compatibility.Length) chars)"
+    }
+}
+
+function Get-MetadataValue ($metadata, [string] $key) {
+    if ($metadata -is [System.Collections.IDictionary] -and $metadata.Contains($key)) {
+        return $metadata[$key]
+    }
+    return $null
+}
+
+function Test-MetadataEnum ($metadata, [string] $key, [string[]] $allowed) {
+    $value = Get-MetadataValue $metadata $key
+    if ($null -eq $value) { return }
+    if ($value -isnot [string] -or [string]::IsNullOrWhiteSpace($value)) {
+        "metadata.$key must be a non-empty string"
+        return
+    }
+    $value = $value.Trim()
+    if ($allowed -cnotcontains $value) {
+        "metadata.$key '$value' is invalid; expected one of: $($allowed -join ', ')"
+    }
+}
+
+function Test-RelationshipMetadata ($metadata, [string] $key) {
+    $value = Get-MetadataValue $metadata $key
+    if ($null -eq $value) { return }
+    if ($value -isnot [string] -or [string]::IsNullOrWhiteSpace($value)) {
+        "metadata.$key must be 'none' or a comma-separated list of skill names"
+        return
+    }
+    $value = $value.Trim()
+    if ($value -ceq 'none') { return }
+
+    $names = @($value -split ',' | ForEach-Object { $_.Trim() })
+    if ($names.Count -eq 0 -or $names -ccontains '') {
+        "metadata.$key must be 'none' or a comma-separated list of skill names"
+        return
+    }
+    foreach ($relationshipName in $names) {
+        if ($relationshipName -cnotmatch '^[a-z0-9]+(?:-[a-z0-9]+)*$') {
+            "metadata.$key contains invalid skill name '$relationshipName'"
+        }
+    }
+    $duplicates = @($names | Group-Object | Where-Object Count -gt 1 | ForEach-Object Name)
+    if ($duplicates.Count -gt 0) {
+        "metadata.$key contains duplicate skill name(s): $($duplicates -join ', ')"
+    }
+}
+
+function Test-OverlayContract ($metadata, [string] $raw, [string] $dir) {
+    $binding = Get-MetadataValue $metadata 'binding'
+    if ($binding -isnot [string]) { return }
+    $binding = $binding.Trim()
+    if (@('none', 'optional-overlay', 'required-overlay') -cnotcontains $binding) { return }
+
+    $overlayPath = Join-Path $dir 'overlay.md'
+    $hasOverlay = Test-Path -LiteralPath $overlayPath -PathType Leaf
+
+    if (@('optional-overlay', 'required-overlay') -ccontains $binding -and -not $raw.Contains($OverlayCue)) {
+        "metadata.binding '$binding' requires this loader cue in SKILL.md: $OverlayCue"
+    }
+    if ($binding -ceq 'required-overlay' -and -not $hasOverlay) {
+        "metadata.binding 'required-overlay' requires overlay.md beside SKILL.md"
+        return
+    }
+    if ($binding -ceq 'none' -and $hasOverlay) {
+        "overlay.md exists but metadata.binding is 'none'"
+        return
+    }
+    if (-not $hasOverlay) { return }
+
+    try {
+        $overlayFrontmatter = Read-Frontmatter (Get-Content -LiteralPath $overlayPath -Raw)
+    }
+    catch {
+        "overlay.md: $($_.Exception.Message)"
+        return
+    }
+
+    foreach ($requiredOverlayField in @('core', 'core-pin')) {
+        if (-not $overlayFrontmatter.Contains($requiredOverlayField) -or
+            [string]::IsNullOrWhiteSpace([string]$overlayFrontmatter[$requiredOverlayField])) {
+            "overlay.md is missing required frontmatter field: $requiredOverlayField"
+        }
+    }
+    if ($overlayFrontmatter.Contains('core')) {
+        $directoryName = Split-Path -Leaf $dir
+        if ([string]$overlayFrontmatter['core'] -cne $directoryName) {
+            "overlay.md core '$($overlayFrontmatter['core'])' must match skill directory '$directoryName'"
+        }
+    }
+}
+
+function Test-PortfolioMetadata ($metadata, [string] $raw, [string] $dir, [bool] $required) {
+    if ($null -eq $metadata) {
+        if ($required) { 'Missing required field in frontmatter: metadata' }
+        return
+    }
+    if ($metadata -isnot [System.Collections.IDictionary]) {
+        'Field metadata must be a mapping'
+        return
+    }
+
+    if ($required) {
+        foreach ($requiredMetadataField in $PortfolioMetadataFields) {
+            if (-not $metadata.Contains($requiredMetadataField)) {
+                "Missing required portfolio field: metadata.$requiredMetadataField"
+            }
+        }
+    }
+
+    Test-MetadataEnum $metadata 'portability' $AllowedPortability
+    Test-MetadataEnum $metadata 'applicability' $AllowedApplicability
+    Test-MetadataEnum $metadata 'binding' $AllowedBinding
+    Test-MetadataEnum $metadata 'risk' $AllowedRisk
+    Test-MetadataEnum $metadata 'maturity' $AllowedMaturity
+    Test-RelationshipMetadata $metadata 'requires'
+    Test-RelationshipMetadata $metadata 'related'
+
+    $portability = Get-MetadataValue $metadata 'portability'
+    if ($portability -is [string]) { $portability = $portability.Trim() }
+    if ($required -and $portability -cne 'portable') {
+        "Commons cores must set metadata.portability to 'portable'"
+    }
+
+    Test-OverlayContract $metadata $raw $dir
+}
+
+function Test-SkillDir ([string] $dir) {
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    $resolved = Resolve-Path -LiteralPath $dir -ErrorAction SilentlyContinue
+    if (-not $resolved) { return @("Path does not exist: $dir") }
+    $dir = $resolved.Path
+    if (-not (Test-Path -LiteralPath $dir -PathType Container)) { return @("Not a directory: $dir") }
+
+    $md = Get-SkillMd $dir
+    if (-not $md) { return @('Missing required file: SKILL.md') }
+
+    $raw = Get-Content -LiteralPath $md -Raw
+    try {
+        $fm = Read-Frontmatter $raw
+    }
+    catch {
+        return @($_.Exception.Message)
+    }
+
+    if (-not $fm.Contains('name')) { $errors.Add('Missing required field in frontmatter: name') }
+    else { Test-SkillName $fm['name'] $dir | ForEach-Object { $errors.Add($_) } }
+
+    if (-not $fm.Contains('description')) { $errors.Add('Missing required field in frontmatter: description') }
+    else { Test-SkillDescription $fm['description'] | ForEach-Object { $errors.Add($_) } }
+
+    if ($fm.Contains('compatibility')) { Test-SkillCompatibility $fm['compatibility'] | ForEach-Object { $errors.Add($_) } }
+
+    $metadata = if ($fm.Contains('metadata')) { $fm['metadata'] } else { $null }
+    Test-PortfolioMetadata $metadata $raw $dir $RequirePortfolioMetadata.IsPresent |
+        ForEach-Object { $errors.Add($_) }
+
+    $htmlEntityRegex = [regex]::new('&(?:#[0-9]+|#[xX][0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]+);', [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    foreach ($markdownFile in Get-ChildItem -LiteralPath $dir -Recurse -File -Filter '*.md') {
+        [int] $lineNumber = 0
+        foreach ($line in Get-Content -LiteralPath $markdownFile.FullName) {
+            $lineNumber++
+            foreach ($match in $htmlEntityRegex.Matches($line)) {
+                [string] $relativePath = [System.IO.Path]::GetRelativePath($dir, $markdownFile.FullName)
+                $errors.Add("$relativePath`:$lineNumber contains HTML entity '$($match.Value)'; write the character directly or use plain words.")
+            }
+        }
+    }
+
+    $lineCount = Measure-SkillLineCount $raw
+    if ($lineCount -gt $MaxSkillLines) {
+        $errors.Add("SKILL.md is $lineCount lines; keep it under the recommended $MaxSkillLines-line limit (move detail into references/ or sibling files).")
+    }
+
+    return $errors.ToArray()
+}
+
+# ---------------------------------------------------------------------------
+
+if (-not $Path -or $Path.Count -eq 0) {
+    $Path = @('.')
+}
+
+$targets = [System.Collections.Generic.List[string]]::new()
+foreach ($p in $Path) {
+    if (Get-SkillMd $p) {
+        $targets.Add((Resolve-Path -LiteralPath $p).Path)
+    }
+    elseif (Test-Path -LiteralPath $p -PathType Container) {
+        Get-ChildItem -LiteralPath $p -Directory |
+            Where-Object { Get-SkillMd $_.FullName } |
+            ForEach-Object { $targets.Add($_.FullName) }
+    }
+    else {
+        $targets.Add($p)
+    }
+}
+
+$ordered = @($targets | Sort-Object -Unique)
+if ($ordered.Count -eq 0) {
+    Write-Host 'No skills found.' -ForegroundColor Yellow
+    exit 1
+}
+
+$failed = 0
+foreach ($t in $ordered) {
+    $rel = [System.IO.Path]::GetRelativePath((Get-Location).Path, $t)
+    $errs = @(Test-SkillDir $t)
+    if ($errs.Count -eq 0) {
+        if (-not $Quiet) { Write-Host "  OK    $rel" -ForegroundColor Green }
+    }
+    else {
+        $failed++
+        Write-Host "  FAIL  $rel" -ForegroundColor Red
+        foreach ($e in $errs) { Write-Host "          - $e" -ForegroundColor Red }
+    }
+}
+
+Write-Host ''
+if ($failed -gt 0) {
+    Write-Host "$failed of $($ordered.Count) skill(s) failed validation." -ForegroundColor Red
+    exit 1
+}
+Write-Host "All $($ordered.Count) skill(s) valid." -ForegroundColor Green
+exit 0

--- a/.agents/skills/manage-skills/update.md
+++ b/.agents/skills/manage-skills/update.md
@@ -1,0 +1,95 @@
+# Update a skill
+
+Detail for the [manage-skills](SKILL.md) skill. "Update the skill" has two
+directions. The second - pushing a local improvement - is where the
+[golden rule](SKILL.md) is enforced.
+
+## Pull: take upstream changes
+
+When a vendored skill has moved upstream in the commons, pull the change:
+
+```pwsh
+# one skill
+gh skill update <skill>
+# every unpinned vendored skill
+gh skill update --all
+```
+
+`gh skill update` compares the local copy's provenance tree SHA against upstream
+and surfaces the difference as a normal diff. Review it like a dependency bump:
+read what changed, run the repo's agent-file checks (the frontmatter validator and
+the installed-artifact link checker), then re-pin when satisfied. Update the
+overlay's `core-pin` and re-review its bindings in the same change. A skill pinned
+with `--pin` is skipped by `--all`; bump its pin deliberately when you want its
+updates.
+
+Manual fallback (no `gh`): compare the local core against the commons copy at the
+recorded ref, apply the diff by hand, and update the provenance SHA.
+
+## Push: send a local improvement to the right layer
+
+When you improve a vendored skill locally, first classify the change, then decide
+where it lives. Classification does not trigger any action on its own.
+
+- **Local deviation** - specific to this repo (a repo-only tool, a local path, a
+  repo-specific example). It belongs in the **overlay**, never in the vendored
+  core. Move the change into `overlay.md` (starting from
+  `assets/overlay.md.tmpl` when needed), restore the core to match upstream, and
+  record the current pin in `core-pin`. No upstreaming question arises.
+- **Common** - generic, helps every consumer (a clearer phrasing of a portable
+  rule, a new universally-applicable check, a fixed error). It *should* go
+  upstream, but upstreaming is **never automatic** and is not always plausible:
+  the commons may be unreachable, the change may be sensitive or need discussion
+  first, or you may lack the time or rights. So **ask** before attempting it.
+
+### The upstreaming query (common changes only)
+
+Stop and ask the user whether to attempt upstreaming. **Never open a commons PR on
+your own** - it is a publish action, gated by the same rule as any push (the
+repo's contribution and publish rules). Present what the change is, why it is
+common, and the options:
+
+- **Upstream it now** - prepare the PR to the commons; *creating* it still needs an
+  explicit publish verb from the user. Once merged, re-vendor here at the new pin.
+- **Not now / not plausible** - keep the change in the local core as a *tracked
+  pending-upstream divergence*: record it (in the commit message and a short note)
+  so the drift check's later alarm is expected, not a surprise. Re-attempt
+  upstreaming when it becomes plausible; re-pinning clears the divergence.
+- **Reclassify** - if discussion shows the change is actually repo-specific, move
+  it to the overlay instead and restore the core.
+
+Default to asking even when the change looks obviously common and obviously worth
+sharing. Nothing about upstreaming happens without an explicit decision.
+
+## The golden rule and its mechanics
+
+*Never let a vendored core diverge silently.* A vendored core is a mirror of
+upstream; any edit to it is a deliberate fork that must end in one of three
+**recorded** states - never an unexplained one:
+
+- promoted upstream and the core re-pinned,
+- moved to the overlay and the core restored, or
+- kept as a **tracked pending-upstream divergence** - a common change that could
+  not be upstreamed yet, recorded so the divergence is intentional and visible.
+
+The point is *visibility*, not "resolved within the hour". A recorded divergence is
+fine; an unexplained one is the alarm. What makes this enforceable:
+
+- **Provenance frontmatter** on every vendored copy records the source repo, ref,
+  and tree SHA it was installed from.
+- **The drift check** (`gh skill update`, or the tree-SHA comparison in CI)
+  compares the local core against that recorded upstream. Unexplained drift - a
+  local core that no longer matches its pin and has no corresponding upstream PR -
+  is the alarm that an improvement was written into the wrong layer.
+
+So the discipline is mechanical: if the drift check lights up and there is no
+upstream PR in flight and no recorded pending-upstream note, the change was a local
+deviation written into the core by mistake; move it to the overlay and restore the
+core.
+
+## After any update
+
+Re-run the validators and the link check, and if the change touched the catalog
+or a skill's trigger phrasing, reconcile the catalog `README.md` (inventory row,
+disambiguation) in the same change. Then hand off to the repository's
+`agent-files-review` skill to validate the resulting files.

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -1,0 +1,177 @@
+---
+compatibility: Requires git plus the repository's build, test, and agent-file validation commands.
+description: Self-review checklist - plus an agentic review pass (a read-only reviewer persona over the diff) - before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from multi-targeted polyfill work - missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/pre-pr-self-review
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: c172ca7a01a7368bb4fee88b4d0b756442d38976
+    maturity: canary
+    portability: portable
+    related: create-pr, address-pr-feedback, security-review, performance-testing
+    requires: none
+    risk: local-write
+name: pre-pr-self-review
+---
+# Pre-PR self-review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Run this checklist before invoking the `create-pr` skill. Each item is a question
+your code or PR body must answer. Update the skill whenever a reviewer flags
+something not yet listed.
+
+This skill pairs with several others a consuming repo wires concretely in its
+overlay: a `polyfill-dotnet-api` skill (the source-preference and design rules
+this checklist validates), `create-pr` (the workflow this precedes),
+`address-pr-feedback` (the follow-up that re-runs this checklist),
+`performance-testing` (benchmark authoring required when a perf claim drives a
+change), `framework-jit-optimization` (net481 RyuJIT tradeoffs cited in the
+polyfill-correctness items), `agent-files-review` (for changes under `.agents/`,
+`AGENTS.md`, or `.github/copilot-instructions.md`), and `security-review` (the
+security-specific subset - abusive-input handling, length / integer overflow,
+allocation and algorithmic DoS, argument validation, and every use of `unsafe` /
+`Unsafe.*` / `MemoryMarshal.*` / `Marshal.*` or any BCL API whose docs say
+"unsafe" or "caller must"). Invoke `security-review` alongside this checklist for
+any change that adds or modifies a member accepting caller-supplied data, or that
+touches one of those caller-validated constructs - the common case, not a niche.
+
+## Agentic review pass
+
+Before walking the checklist, run an automated review pass over the diff so the
+reviewer-bot class of findings - correctness edge cases, hand-rolled
+parser/format pitfalls, CI and supply-chain hygiene, and doc-vs-behavior drift -
+surfaces locally instead of across PR rounds. Spawn a **read-only pre-PR reviewer
+persona** (a consuming repo wires the concrete agent in its overlay) over the
+working diff, triage its findings (valid / nit / judgment call / likely false
+positive), fix the valid ones, and re-run at most once when the fixes were
+non-trivial. Keep it bounded: a same-class model nitpicks indefinitely, so two
+passes is the cap and the deterministic gates - tests, lint, the format
+validators - stay the source of truth. The checklist below is the human
+complement: the recurring, domain-specific mistakes an agent pass tends to miss.
+
+## 1. Tests cover every new branch
+
+For each new `public` (or `InternalsVisibleTo`-internal) member:
+
+- Search the test projects for the symbol; no hits = missing test.
+- Polyfills in the Framework-only tree: tests run on both TFMs. Wrap
+  polyfill-only paths (subclass fallbacks, null-receiver guards) in
+  `#if NETFRAMEWORK`.
+- Runtime type-check fast paths (`typeof(T) == obj.GetType()`): test
+  the fast path *and* a subclass override.
+- Generic primitive specializations: every specialized branch needs a
+  test. Don't rely on `byte`/`int` covering `bool`/`sbyte`/`short`/
+  `ushort`/`uint`/`long`/`ulong` - each has independent ref
+  reinterpretation.
+- Security-sensitive APIs (`FixedTimeEquals`, hex decode): cover equal,
+  differing-content, length mismatch, both empty, one empty, and a long
+  span where only the last byte differs.
+- Allocating APIs (`Concat`, `ToHexString`): include an
+  `OverflowException` test on the length sum.
+
+Test hygiene for the tests themselves - the recurring miss list
+that costs the most review rounds on coverage-only PRs:
+
+- **Test method names start with the method under test.**
+  `MethodName_StateUnderTest_ExpectedBehavior` per the repo's test
+  conventions. `ReadOnlySpan_Empty_ReturnsEmpty` is *wrong*;
+  `SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty` is right.
+- **Every `IDisposable` test local uses `using` or `try`/`finally`.**
+  A temp-folder helper, a matcher handle, a pooled-list rental - a bare
+  local leaks the resource when an assertion fails. Use the
+  `try`/`finally` pattern when the test itself exercises explicit
+  `Dispose()`.
+- **Don't hard-code `InvariantCulture` for APIs that use
+  `CurrentCulture`.** Provider-less formatting helpers generally format
+  with `CurrentCulture`. Asserting against `InvariantCulture`-formatted
+  strings makes the test locale-dependent.
+
+## 2. Polyfill / framework correctness
+
+For any change in the Framework-only tree (a polyfill or a framework-only fast
+path), walk these items (a consuming repo may keep the per-item detail and code
+patterns in a `polyfill-correctness` overlay companion):
+
+- Empty / null spans handled before `unsafe` interop (empty source,
+  empty destination, both empty; exception type cross-checked).
+- Multi-input length sums wrapped in `checked()`.
+- Throw helpers use the standard BCL exceptions, not custom types.
+- Span overloads stay allocation-free by default (document any
+  trade-off in `<remarks>`).
+- Behavior parity with the modern BCL (exception type and message
+  family, edge cases, type-exact fast paths).
+- Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
+  and are measured or explicitly marked unmeasured.
+
+If the change is not in the Framework-only tree, skip to section 3.
+
+## 3. PR description matches reality
+
+- TFM phrasing: name the polyfill's *target* TFM (the framework target,
+  e.g. `net472`) distinctly from the TFM the tests merely *run* on (e.g.
+  `net481`). Do not call a `net472`-targeted polyfill "net481-only".
+- File list, test counts, and perf numbers all reflect the *current*
+  diff. Re-run after every commit; do not paste numbers from an earlier
+  iteration.
+- **Walk each bullet of the description against the diff before
+  pushing.** If the body says "covers `Foo` with cases A/B/C", search
+  the diff for tests named `Foo_…` and confirm A, B, and C are all
+  there. Review rounds have been lost to descriptions claiming a case
+  (a `Span<char>` "null at end", a double-dispose test) that was not
+  actually in the diff.
+- "Deliberately deferred" entries match what's actually absent from
+  the working tree.
+
+## 4. Final audit before staging
+
+- `git status --short` - delete leftover probe / scratch files;
+  confirm every listed file belongs in the change set.
+- `git diff --check` - whitespace.
+- **Rebase onto the canonical `main` if the branch trails it.** Use
+  `upstream/main` when working from a fork (the canonical repo lives at
+  `upstream`), `origin/main` when cloning the canonical repo directly.
+  Recently-merged sister PRs may have introduced files this PR
+  cross-references; running off a stale base point makes those links look
+  broken to an offline link check that gates `.agents/**`, `AGENTS.md`,
+  and `*.instructions.md` changes. A PR once lost a review round to
+  exactly this.
+- For changes that touch `.agents/`, `AGENTS.md`, or
+  `.github/copilot-instructions.md`, also run the repo's agent-file link
+  checker (see the `agent-files-review` skill for options, including
+  changed-only and base-ref modes).
+- Build both TFMs.
+- Run the test suite in **both Debug and Release**. Release-mode RyuJIT
+  inlining surfaces bugs Debug doesn't - e.g.
+  `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates
+  the caller's int-promoted argument into the comparison immediate
+  (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative
+  signed-primitive inputs on net481, but only in Release. Mask
+  explicitly with `& 0xFF` / `& 0xFFFF`. See the `polyfill-dotnet-api`
+  and `framework-jit-optimization` skills.
+- Stage **by path**, never `git add -A` / `git add .` when the working
+  tree spans more than one logical change. If topics are intermingled,
+  ask before staging.
+
+## 5. Failing CI is a stop, not a sprint
+
+When a build / test / CI run fails on a PR:
+
+1. Diagnose.
+2. Prepare the fix in the working tree.
+3. Describe what changed, why, and any risks.
+4. **Stop and wait for explicit approval before commit/push.**
+
+Stacked rapid-fire fix commits are how perf regressions and unrelated
+sweep-ups get into history.
+
+## 6. Update this skill
+
+If a reviewer flags something not in this checklist, add it. If the
+review touched `.agents/` files, also update via the `agent-files-review`
+workflow so the validator and any CI mirror stay in sync.

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,0 +1,35 @@
+---
+core: pre-pr-self-review
+core-pin: v0.11.0
+---
+
+# Pre-PR self-review overlay
+
+Repository-specific bindings for thirtytwo.
+
+- Product code is [src/thirtytwo](../../../src/thirtytwo); tests are
+  [src/thirtytwo_tests](../../../src/thirtytwo_tests), with samples under
+  [src/samples](../../../src/samples).
+- The repository targets only `net10.0-windows`. Skip the portable core's
+  .NET Framework and polyfill checks unless target frameworks change.
+- Use a read-only review pass over the complete diff; no dedicated local
+  reviewer agent is currently installed.
+- Invoke [security-review](../security-review/SKILL.md) for changes involving
+  `unsafe`, pointers, `Unsafe`, `MemoryMarshal`, `Marshal`, `stackalloc`, COM,
+  P/Invoke, native ownership, or caller-supplied buffers and lengths.
+- Invoke [agent-files-review](../agent-files-review/SKILL.md) for changes under
+  `.agents/`.
+
+Run both configurations before publishing:
+
+```pwsh
+dotnet build --configuration Debug
+dotnet test --configuration Debug --no-build --report-trx
+dotnet build --configuration Release
+dotnet test --configuration Release --no-build --report-trx
+git diff --check
+```
+
+Test names should identify the member under test, the relevant state, and the
+expected behavior. Dispose native and managed resources even when an assertion
+fails.

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -1,0 +1,133 @@
+---
+compatibility: Applies to multi-targeted .NET code where modern .NET and .NET Framework runtime costs can be measured separately.
+description: Choose how a hot path gets a short-lived scratch buffer - zeroed `stackalloc`, `[SkipLocalsInit]` + `stackalloc`, `BufferScope` of T (stack with pool fallback), or a rental from the shared `ArrayPool` of T - and apply the net481/net10 size crossovers. Use when designing or reviewing a performance-sensitive path that needs a temporary buffer, when deciding "should I rent or stackalloc?", when weighing `[SkipLocalsInit]`, or when evaluating buffer/allocation cost. Defers the backing measurements and full reasoning to the bundled references/arraypool-performance.md.
+license: MIT
+metadata:
+    applicability: dotnet-framework
+    binding: optional-overlay
+    github-path: skills/scratch-buffer-strategy
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
+    maturity: canary
+    portability: portable
+    related: performance-testing, framework-jit-optimization
+    requires: none
+    risk: advisory
+name: scratch-buffer-strategy
+---
+# Scratch buffer strategy (net481 + net10)
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Pick the cheapest correct way to get a short-lived scratch buffer on a hot path.
+This skill is the compact decision aid; the measured numbers, the per-call
+ArrayPool autopsy, the inlining traps, and the references live in the bundled
+[references/arraypool-performance.md](references/arraypool-performance.md). Read
+that doc before quoting a number or making a non-obvious call.
+
+A multi-targeted library runs on **net481** (older RyuJIT: unvectorized `memset`,
+no tiered JIT/PGO, weaker inliner) and **net10**. Buffer costs differ enough
+between them that every decision must hold on both. Name the JIT in any writeup
+(the JIT-naming rule).
+
+## Four options, ranked for the common case
+
+1. **`[SkipLocalsInit]` + `stackalloc`** - fastest (~1-2 ns, both TFMs).
+   Requires: fixed/bounded size, stack-safe, and **every read slot written
+   first**. Put the attribute on the method that physically contains the
+   `stackalloc`.
+2. **Zeroed `stackalloc`** - safe default. Cost scales with byte count;
+   net481 zeroing is ~3.6x net10 for a **compile-time-constant** size (for a
+   runtime-variable size both TFMs zero at ~the same rate - see the doc).
+3. **`BufferScope<T>(stackalloc T[N], minimumLength)`** - variable/unbounded
+   size that is usually small. Stays on the stack for the common case, rents
+   from `ArrayPool` only on overflow. Wrapper overhead ~1 ns net481 / ~0.3 ns
+   net10. Forwards the caller's `[SkipLocalsInit]` to the stack buffer.
+   (`BufferScope<T>` ships as `Touki.Buffers.BufferScope<T>` in the
+   [`KlutzyNinja.Touki`](https://www.nuget.org/packages/KlutzyNinja.Touki) NuGet
+   package - consume that rather than rolling or supplying your own.)
+4. **`ArrayPool<T>.Shared` Rent/Return** - large, unbounded, recursive, or must
+   escape the frame. Has a fixed per-call floor that warmup never removes
+   (~10 ns/op net481, ~4 ns/op net10). Rent **once** and reuse across the loop.
+
+## Decision tree
+
+```text
+Short-lived scratch buffer on a hot path?
+|
++- Fixed/small (one frame, few KB), not recursive/looped?
+|   +- Write every slot before reading?  --> [SkipLocalsInit] + stackalloc
+|   +- Cannot guarantee that?            --> zeroed stackalloc (or zero only
+|                                            the prefix you read)
+|
++- Usually small but occasionally large (variable size)?
+|   --> BufferScope<T>(stackalloc T[N], minLen); put [SkipLocalsInit] on the
+|       CALLING method to drop the stack-buffer zeroing
+|
++- Large / unbounded / recursive / must escape frame?
+    --> ArrayPool<T>.Shared, rented once and reused
+```
+
+## Crossover thresholds (zeroed stackalloc vs a rental)
+
+For a **runtime-variable** size, zeroing a `stackalloc` is cheaper than renting
+below these sizes; above them the rental's flat floor wins (only if you can use
+the memory uninitialized):
+
+| Rental kind | net481 | net10 |
+| --- | --: | --: |
+| Warm TLS hit (first rental) | ~1.3 KB | ~190 B |
+| Locked (second same-bucket rental) | ~3 KB | ~1.8 KB |
+
+A **compile-time-constant** size zeroes far cheaper on net10, pushing its
+crossover higher. If you would have to `Clear()` the rented array, add that cost
+back to the rental side - the crossover then exceeds any sane stack size, so
+just stack-allocate.
+
+## Load-bearing facts (do not re-derive)
+
+- **net481 honors `[SkipLocalsInit]`.** The `localsinit`-flag suppression works
+  on the desktop CLR exactly as on CoreCLR; the attribute *type* is
+  source-generated downlevel by PolySharp. A 4 KB clear drops from ~53 ns to
+  ~1.7 ns on net481.
+- **Only byte count drives zeroing cost** - struct arrays zero exactly like
+  primitive arrays of the same size.
+- **A warm pool is not a free pool.** Rent/Return pays bucket-index math, a
+  one-deep TLS cache (two same-bucket rentals collide into the locked stack),
+  and a separate pool per element type - on every call, net481 ~2.5x worse.
+- **`[SkipLocalsInit]` hands you uninitialized memory.** Use it only where a
+  profile shows the clear is hot, every read slot is provably written first, and
+  no unwritten bytes can escape (info-disclosure risk). The JIT inliner does not
+  spread the attribute; net481's weaker inliner can move where zeroing lands, so
+  verify on both TFMs.
+- **`Unsafe.SkipInit` does NOT suppress the zeroing.** Common mistake: assuming
+  `Unsafe.SkipInit(out x)` makes a stack buffer un-zeroed. It compiles to a bare
+  `ret` and only satisfies C# definite-assignment so you can read an unassigned
+  local; the runtime still zeroes via the method's `.locals init` flag, which
+  only `[SkipLocalsInit]` (or `[module: SkipLocalsInit]`) removes. A "fixed
+  buffer left uninitialized with `Unsafe.SkipInit`" but *without*
+  `[SkipLocalsInit]` pays full zeroing. See
+  [references/arraypool-performance.md](references/arraypool-performance.md)
+  section 8.
+
+## Stack-safety guardrail
+
+`stackalloc` only belongs on the stack at all if it is bounded: keep a single
+frame's `stackalloc` to a few KB, and never `stackalloc` on a recursive or
+unbounded-loop path (CA2014). Default Windows managed stack is 1 MB, but library
+code may run on a 256 KB partial-trust thread. Past those limits, rent once and
+reuse instead.
+
+## Related
+
+- [references/arraypool-performance.md](references/arraypool-performance.md) -
+  the full measured tables, the ArrayPool per-call autopsy, the `BufferScope`
+  overhead numbers, the inlining trap, and references. **This is the backing
+  data; cite it.**
+- The repository's performance-testing and framework-JIT-optimization skills
+  (author/run the BenchmarkDotNet benchmarks that produced these numbers, and
+  net481 loop tuning once a buffer choice is made) - a consuming repository
+  wires the concrete cross-references in its overlay.

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,0 +1,24 @@
+---
+core: scratch-buffer-strategy
+core-pin: v0.11.0
+---
+
+# Scratch buffer strategy overlay
+
+Repository-specific bindings for thirtytwo.
+
+- [StackBufferScope16<T>](../../../src/thirtytwo/Support/StackBufferScope16.cs)
+  provides 16 inline elements and falls back through `BufferScope<T>`.
+- [ValueBuffer<T>](../../../src/thirtytwo/Support/ValueBuffer.cs) grows from a
+  caller-supplied span into an `ArrayPool<byte>` rental and is explicitly
+  experimental.
+- The repository targets only `net10.0-windows`; ignore net481 crossover data
+  when making a local decision.
+- There is no dedicated performance project. Do not change thresholds or make
+  performance claims from the portable skill's historical measurements alone;
+  add a focused, reviewed benchmark prerequisite when evidence is needed.
+- Audit checked byte-size arithmetic, alignment, empty spans, pool return on
+  every path, and stack-size bounds with
+  [security-review](../security-review/SKILL.md).
+- Use [il-copy-inspection](../il-copy-inspection/SKILL.md) when changing a ref
+  struct or `[NonCopyable]` layout.

--- a/.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md
+++ b/.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md
@@ -1,0 +1,518 @@
+# ArrayPool vs stack scratch: performance on net481 and net10
+
+When a hot path needs a short-lived scratch buffer, there are three ways to get
+one: `stackalloc` (zero-initialized by default), `ArrayPool<T>.Shared`
+rent/return, or a `stackalloc`/fixed buffer with the zeroing suppressed. The
+right choice depends on the buffer's size, lifetime, and - critically - which
+target framework's JIT is running. This document captures the measured costs and
+a decision procedure for choosing between them.
+
+All numbers below come from BenchmarkDotNet projects (listed in section 7),
+run in Release on a development machine against
+**.NET Framework 4.8.1 RyuJIT** and **modern .NET RyuJIT** (.NET 10). Per the
+JIT-naming rule, every claim names the JIT, because the two behave very
+differently here.
+
+For the compact decision aid (decision tree + crossover thresholds without the
+backing tables), see the [`scratch-buffer-strategy`](../SKILL.md) skill. This
+document is the data it cites.
+
+---
+
+## 1. The headline result
+
+For a fixed-size scratch buffer whose every slot is written before it is read,
+**`[SkipLocalsInit]` + `stackalloc` is the fastest option on both target
+frameworks** - faster than an `ArrayPool` rental and far faster than a
+zero-initialized `stackalloc`. The pool only wins when the buffer is large,
+unbounded, or must escape the stack frame.
+
+The single most important and most counter-intuitive fact:
+
+> **.NET Framework 4.8.1 RyuJIT honors `[SkipLocalsInit]`** for the locals it
+> governs. Suppressing the `localsinit` flag on a method removes the zeroing of
+> that method's `stackalloc` / local stack storage on net481 just as it does on
+> modern .NET. A 4 KB stack buffer drops from ~53 ns to ~1.7 ns on net481.
+
+This corrects the common assumption that Framework "always zeroes stackalloc".
+It does zero by default, but the absence of the `localsinit` flag is respected by
+the desktop runtime, so the zeroing of the attributed method's locals is fully
+suppressible. (The attribute governs only the methods it is applied to; it is not
+a claim that *no* prologue zeroing ever occurs anywhere.)
+
+---
+
+## 2. The cost of zeroing
+
+`stackalloc` without `[SkipLocalsInit]` clears the buffer on every call. That
+clear is a `memset` whose cost scales with the **byte size** of the buffer.
+
+### 2.1 Zeroing cost by size
+
+| Buffer | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| `byte[256]` (256 B) | 7.0 ns | 1.7 ns |
+| `byte[1024]` (1 KB) | 14.0 ns | 5.8 ns |
+| `byte[4096]` (4 KB) | 53.4 ns | 14.5 ns |
+
+Two things to read off this:
+
+- The cost is roughly linear in bytes once past the smallest sizes.
+- **net481 zeroing is ~3.6x more expensive than net10 zeroing** for the same
+  buffer (53 ns vs 15 ns at 4 KB). The desktop `memset` path is not vectorized
+  the way the modern runtime's is. This is why a zeroing cost that is a minor
+  line item on net10 can become the dominant per-call cost on net481.
+
+This ~3.6x gap holds for a **compile-time-constant** size, which is what these
+measurements use. For a runtime-variable `stackalloc byte[n]` net10 loses the
+vectorized clear and zeroes at nearly the same rate as net481 - see the note in
+section 3.2.
+
+### 2.2 Struct arrays zero exactly like primitive arrays
+
+A frequent worry is that an array of structs costs more to clear than an array
+of primitives. It does not - zeroing is byte-wise and ignores the element type.
+At an equal 4 KB:
+
+| Buffer | Bytes | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|--:|
+| `byte[4096]` | 4096 | 53.4 ns | 14.5 ns |
+| `int[1024]` | 4096 | 51.3 ns | 14.6 ns |
+| `Range16[256]` (4x `int`) | 4096 | 52.4 ns | 15.0 ns |
+
+The three are within noise of each other on both TFMs. **Only the byte count
+matters.** Do not restructure a struct buffer into a primitive one hoping to
+zero faster - reduce the byte count or suppress the zeroing instead.
+
+---
+
+## 3. The cost of an ArrayPool rental
+
+`ArrayPool<T>.Shared` hands back **uninitialized** memory, so it never pays the
+zeroing tax. But Rent/Return are not free, and - this is the key gotcha - the
+overhead is **per-call bookkeeping that warmup cannot eliminate**.
+
+`ArrayPoolSeedRentPerf` measures a representative multi-buffer rental shape: five
+buffers (a 28-byte frame struct x32, a 16-byte range struct x128, that range
+struct x18 twice, and an `int[57]`), rented and returned together, ~3.7 KB
+aggregate, with the pool pre-warmed 64x in `[GlobalSetup]`.
+
+| Operation | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| 5x Rent + 5x Return (`PoolRent`) | 104.3 ns | 40.6 ns |
+| equivalent zeroed `stackalloc` | 55.2 ns | 20.9 ns |
+| **pool penalty over stackalloc** | **+49 ns** | **+20 ns** |
+
+The pool is **slower than even a zeroing `stackalloc`** on both TFMs for this
+size. Roughly 10 ns per Rent/Return pair on net481, 4 ns on net10.
+
+### 3.1 Why warmup does not hide it
+
+The pool is fully warm - `[GlobalSetup]` and BenchmarkDotNet's own warmup run it
+hundreds of times - yet the cost persists, because it is steady-state work done
+on **every** call:
+
+1. **Bucket-index math per call.** `Shared` is
+   `TlsOverPerCoreLockedStacksArrayPool<T>`. Each Rent computes a bucket index
+   (a log2) from the requested length; each Return recomputes it from
+   `array.Length`. Ten times for five buffers.
+2. **The thread-local cache holds one array per bucket.** If two rentals hit the
+   same bucket - in the engine, `work` and `rest` are both `ProgramRange[18]` -
+   the second misses the TLS fast path and falls through to the per-core
+   **locked** stack (an interlocked/`Monitor` acquire). So does the second
+   return.
+3. **Separate pools per element type.** `Frame`, `ProgramRange`, and `int` are
+   three independent `ArrayPool<T>.Shared` instances with three separate per-core
+   stacks; no sharing, three sets of the above.
+4. **net481 makes all of it ~2.5x worse.** The pool internals are not inlined
+   (no tiered JIT, no dynamic PGO), the locked-stack path is heavier, and the
+   bucket math is not folded into the caller. That is why the penalty is +49 ns
+   on net481 versus +20 ns on net10.
+
+The lesson: **a warm pool is not a free pool.** Rent/Return has a fixed per-call
+floor that no amount of warmup removes.
+
+### 3.2 Where zeroing crosses the rental floor
+
+The previous tables compare a single fixed size. The more actionable question is
+"above what size does zeroing a `stackalloc` cost more than renting?" Because
+zeroing scales with the byte count while a rental is a flat per-call floor, there
+is a crossover size. `ArrayPoolCrossoverPerf` sweeps `stackalloc byte[N]` against
+a rental for `N` from 64 to 8192 bytes, separating the two rental floors:
+
+- **TLS hit** (`RentTls`): the first rental of a bucket, served from the
+  one-deep thread-local cache.
+- **Locked** (`RentLocked`): a second same-bucket rental taken while the first is
+  still checked out, so it falls to the per-core locked stack. Its marginal cost
+  is `RentLocked - RentTls`.
+
+Measured means (ns); the rental rows are essentially flat across size, the
+`ZeroStack` row rises with it:
+
+| Bytes | net481 ZeroStack | net481 RentTls | net481 RentLocked | net10 ZeroStack | net10 RentTls | net10 RentLocked |
+|--:|--:|--:|--:|--:|--:|--:|
+| 64   |   2.1 |  21.4 | 43.3 |   2.3 | 4.9 | 30.2 |
+| 128  |   3.3 |  21.3 | 42.9 |   3.7 | 4.9 | 31.1 |
+| 256  |   5.7 |  20.9 | 42.2 |   6.6 | 5.0 | 31.2 |
+| 512  |   7.3 |  21.1 | 41.8 |  12.4 | 4.9 | 30.9 |
+| 1024 |  16.0 |  20.7 | 41.6 |  22.4 | 5.0 | 30.9 |
+| 2048 |  30.9 |  20.8 | 41.6 |  33.9 | 4.9 | 31.7 |
+| 4096 |  53.8 |  20.7 | 41.9 |  56.9 | 4.8 | 30.8 |
+| 8192 | 100.2 |  20.5 | 41.0 | 103.8 | 5.0 | 31.2 |
+
+> **Why net10's `ZeroStack` here is ~4x its section 2.1 figure.** This sweep uses
+> a runtime-variable `stackalloc byte[size]` (the size is a benchmark parameter),
+> which is the realistic shape of the "should I rent?" question. RyuJIT emits its
+> fast vectorized clear only for a **compile-time-constant** size, so net10's
+> variable-size zeroing (~57 ns at 4 KB) is roughly 4x its constant-size cost
+> (~14.5 ns in section 2.1) and lands right on top of net481. For a
+> runtime-determined size the two TFMs zero at nearly the same rate; net10's
+> ~3.6x advantage applies only to constant sizes. A constant-size buffer
+> therefore pushes net10's crossover well above the figures below.
+
+The rental floors are roughly constant - net481 ~21 ns (TLS) / ~42 ns (locked),
+net10 ~5 ns (TLS) / ~31 ns (locked) - confirming a rental does not scale with
+size, only the zeroing does. The crossover sizes (where `ZeroStack` overtakes the
+flat rental line):
+
+| Rental kind | net481 crossover | net10 crossover |
+|---|--:|--:|
+| TLS hit (first rental) | ~1.3 KB | ~190 bytes |
+| Locked (second rental) | ~3 KB | ~1.8 KB |
+
+How to read it:
+
+- **Below the crossover, the zeroed `stackalloc` is cheaper** than even a warm
+  TLS rental - so for small fixed buffers, do not rent; stack-allocate and (if
+  the write-before-read invariant holds) add `[SkipLocalsInit]` to drop the
+  zeroing entirely.
+- **net10's TLS rental is remarkably cheap (~5 ns)**, so on modern .NET the bar
+  for "rent instead of zero" is low - anything past ~190 bytes that you would
+  otherwise zero is a candidate. **net481's rental is ~4x that floor (~21 ns)**,
+  so on Framework you have to be allocating roughly **1.3 KB** before a rental
+  beats zeroing, and **3 KB** before it beats zeroing if the rental collides on a
+  busy bucket.
+- **The locked (second-rental) floor is the realistic one for hot, concurrent
+  paths** where the one-deep TLS slot is frequently already drained. Against that
+  floor zeroing wins up to ~1.8 KB on net10 and ~3 KB on net481.
+- These crossovers assume the rental memory is **uninitialized-safe** (you write
+  every slot before reading). If you would have to `Clear()` the rented array,
+  add the zeroing cost back to the rental side and the crossover moves much
+  higher - usually past any sane stack size, i.e. just stack-allocate.
+
+---
+
+## 4. Suppressing the zeroing instead
+
+If the buffer is a fixed, stack-friendly size and the code writes every slot
+before reading it, the best move is to keep it on the stack and turn the zeroing
+off. There are two ways; one is clearly better.
+
+### 4.1 `[SkipLocalsInit]` on the method (preferred)
+
+Annotate the method that contains the `stackalloc` with
+`[System.Runtime.CompilerServices.SkipLocalsInit]`. The C# compiler omits the
+`localsinit` flag, and both runtimes skip the clear. Requires
+`<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` in the project.
+
+`[SkipLocalsInit]` is a **compiler + CLR** mechanism, not a BCL feature. Per the
+[C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute),
+the attribute "prevents the compiler from setting the `.locals init` flag when
+emitting to metadata," and "the `.locals init` flag causes the CLR to initialize
+all of the local variables." The desktop .NET Framework CLR honors the absence
+of that flag exactly as CoreCLR does - which is why the net481 column above
+shows the zeroing disappearing.
+
+A common source of confusion: the
+[`SkipLocalsInitAttribute` API page](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute)
+lists "Applies to: .NET 5-11" and does **not** list .NET Framework. That only
+means the attribute *type* does not ship in the Framework BCL - it says nothing
+about whether the runtime honors the flag. Because the attribute is just a
+marker the compiler reads, you supply the type yourself downlevel; you can
+source-generate it with **PolySharp** (`PolySharpIncludeRuntimeSupportedAttributes`
+in the project), so `[SkipLocalsInit]` compiles and takes effect on net481.
+
+There is a real caveat, but it does **not** apply to `stackalloc`. The attribute
+only skips zero-init that is otherwise redundant; the JIT still zeroes (and
+GC-tracks) any local that contains **managed references**, for GC safety - see
+the GC-reference note in
+[Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices).
+But `stackalloc T[]` requires `T` to be an
+[unmanaged type](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/unmanaged-types),
+and `fixed` buffers are likewise unmanaged, so a stack scratch buffer has no
+managed references and the zeroing is fully elided. The caveat would only bite
+if you applied `[SkipLocalsInit]` expecting it to skip a plain local (or a
+struct) that holds object references - that is still zeroed.
+
+| 4 KB scratch | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| zeroed `stackalloc` | 53.0 ns | 14.8 ns |
+| `[SkipLocalsInit]` `stackalloc` | **1.7 ns** | **1.3 ns** |
+
+The zeroing essentially vanishes on both TFMs - a ~30x win on net481, ~11x on
+net10. This is the cleanest option: one attribute, one code path, no pool
+bookkeeping, allocation-free.
+
+### 4.2 `BufferScope<T>`: stack buffer with a pool fallback
+
+The size sweep in section 3.2 assumes you know the size up front. Often you do
+not: the common size is small and stack-friendly, but a rare large input must
+still be handled without overflowing the stack. A stack-with-pool-fallback
+wrapper - `Touki.Buffers.BufferScope<T>` from the `KlutzyNinja.Touki` package -
+is built for exactly this: **start on a `stackalloc` buffer, transparently fall
+back to an `ArrayPool<T>` rental only when the requested capacity exceeds it**:
+
+```csharp
+[SkipLocalsInit]
+static int Process(ReadOnlySpan<char> input)
+{
+    // Common case stays on the stack; large input rents from the pool.
+    using BufferScope<char> buffer = new(stackalloc char[256], input.Length);
+    // ... use buffer as a Span<char> ...
+}
+```
+
+`BufferScope<T>` is a `ref struct` that wraps the caller's `stackalloc` span and
+only rents when `minimumLength` overflows it; `Dispose` returns the rental (and
+is a no-op on the stack-only path). Crucially, **the `stackalloc` lives in the
+caller**, so the caller's `[SkipLocalsInit]` controls whether that buffer is
+zeroed - the wrapper never clears stack memory itself.
+
+The `BufferScopeOverhead` benchmark measures the wrapper against the hand-written
+equivalent on each path. The 256-byte stack buffer either satisfies the request
+(`StackOnly`) or is overflowed by a 1024-byte request that forces a rental
+(`Rent`):
+
+| Path | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| direct `stackalloc`, `[SkipLocalsInit]` | 7.7 ns | 0.90 ns |
+| `BufferScope` stack-only, `[SkipLocalsInit]` | 8.8 ns | 1.23 ns |
+| `BufferScope` stack-only, **zeroed** (no SkipLocalsInit) | 11.6 ns | 2.26 ns |
+| direct pool Rent/Return | 25.3 ns | 4.99 ns |
+| `BufferScope` grow-to-rental | 28.6 ns | 5.20 ns |
+
+Two things to take from this:
+
+- **The wrapper overhead is small** - about +1 ns on net481 / +0.3 ns on net10
+  for the stack-only path, and +3 ns / +0.2 ns for the rental path. You are
+  paying a constructor and a `Dispose` branch on top of the underlying
+  stackalloc-or-rent cost, nothing more.
+- **`BufferScope` is `[SkipLocalsInit]`-friendly.** Compare the stack-only rows:
+  with `[SkipLocalsInit]` on the calling method the scope costs 8.8 ns (net481)
+  / 1.23 ns (net10); without it, the same scope pays the 256-byte zeroing and
+  rises to 11.6 ns / 2.26 ns. The wrapper passes the localsinit decision
+  straight through to the caller's `stackalloc`, so you keep the zeroing-
+  suppression win on the common path **and** get a safe pool fallback for the
+  rare large input. This is the recommended shape whenever the size is variable
+  or unbounded but usually small.
+
+### 4.3 Risks of skipping init (and the inlining trap)
+
+`[SkipLocalsInit]` is `unsafe` for a reason: it hands you **uninitialized
+memory**. The
+[best-practices guidance](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices)
+is to use it only where a profile shows the zeroing is hot. Specific risks:
+
+- **You must write before you read.** With the `localsinit` flag gone, a
+  `stackalloc` (or any local) contains whatever was previously on the stack.
+  Reading a slot you have not assigned yields a garbage value - and worse, it is
+  *non-deterministic*: it passes in tests where the stack happened to be zero and
+  fails in production. Only apply `[SkipLocalsInit]` to a buffer whose every read
+  slot is provably written first (e.g. you fill `[0..count]` and only ever read
+  `[0..count]`).
+- **It is a potential information-disclosure vector.** Uninitialized stack memory
+  can contain remnants of previous frames (other callers' data). If any unwritten
+  portion of the buffer can be observed - returned, copied out, hashed, or
+  serialized - you may leak unrelated data. The `<AllowUnsafeBlocks>` requirement
+  exists precisely to flag this.
+- **The attribute's scope follows inlining, which you do not fully control.**
+  `[SkipLocalsInit]` applied to a method also covers its nested local functions
+  and lambdas, but it does **not** transfer across a normal call boundary: a
+  helper you call keeps its own localsinit setting. The subtle part is the
+  interaction with the JIT inliner:
+  - If method `A` is `[SkipLocalsInit]` and the JIT **inlines** a non-attributed
+    helper `B` into `A`, `B`'s `stackalloc`/locals do **not** retroactively
+    become skip-init - the localsinit decision is fixed by the compiler per
+    method at IL-emit time, before the JIT inlines. So you cannot rely on
+    inlining to "spread" the attribute. Put `[SkipLocalsInit]` on the method that
+    physically contains the `stackalloc`.
+  - Conversely, inlining can move where the zeroing *appears* to happen. A tiny
+    `stackalloc` helper that is **not** `[NoInlining]` may be inlined into a
+    caller, and if that caller is also hot the zeroing folds into the caller's
+    prologue. This is why the benchmarks here force `[NoInlining]` on the touch
+    helpers: to measure the buffer cost in isolation rather than have the JIT
+    relocate or eliminate it. In real code the opposite is true - **let the small
+    helper inline**, and put `[SkipLocalsInit]` on whichever method ends up
+    owning the `stackalloc` after inlining (the one with the attribute, since the
+    compiler honored it there).
+  - On net481 the inliner is weaker (no tiered JIT, no dynamic PGO), so a helper
+    that inlines on net10 may stay a real call on net481, changing where the
+    zeroing lands and how much the surrounding code can be folded. Always verify
+    the win on **both** TFMs rather than assuming the net10 inlining shape
+    carries over.
+
+The safe default remains: prefer plain zeroed `stackalloc` (or `BufferScope`
+without `[SkipLocalsInit]`); reach for `[SkipLocalsInit]` only when a profile
+shows the clear is hot, the write-before-read invariant is guaranteed, and no
+unwritten bytes can escape.
+
+---
+
+## 5. Is the buffer stack-safe? Sizing guidance
+
+Suppressing the zeroing only makes sense if the buffer belongs on the stack at
+all. The constraint is the thread's stack budget. On both .NET Framework and
+modern .NET on Windows the default managed thread stack is **1 MB** (set in the
+executable's PE header; the
+[`Thread` constructor docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)
+state "the default stack size (1 megabyte)" and warn against raising it). But
+library code may run on threads with smaller stacks: under partial trust on
+.NET Framework the minimum is **256 KB**
+([same docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)),
+and some hosts constrain it further. The C# reference for
+[`stackalloc`](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc)
+adds two rules of its own: cap the allocation at a conservative limit (its
+example uses 1024 bytes) and **never `stackalloc` inside a loop** (analyzer
+[CA2014](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops)).
+So the working rule is **keep a single frame's `stackalloc` to a few KB and
+never put a `stackalloc` on a recursive or unbounded-loop path.**
+
+Apply this to a multi-buffer rental seed. A concrete example - the per-run seed
+of a small bytecode matching engine that rents five buffers in a single frame:
+
+| Buffer | Element size | Count | Bytes |
+|---|--:|--:|--:|
+| `Frame[]` | 28 B | 32 | 896 |
+| `ProgramRange[]` (arena) | 16 B | 128 | 2048 |
+| `ProgramRange[]` (work) | 16 B | 18 | 288 |
+| `ProgramRange[]` (rest) | 16 B | 18 | 288 |
+| `int[]` (key) | 4 B | 57 | 228 |
+| **Total** | | | **3748 (~3.7 KB)** |
+
+This is safe to keep on the stack because:
+
+- **It is a single frame, ~3.7 KB.** Well under any reasonable per-call budget.
+- **It is not on a recursive path.** The seed is allocated once per run.
+  Any bounded re-entry goes through a separate core routine that reuses
+  caller-supplied probe buffers and does **not** `stackalloc` again, so
+  the 3.7 KB never multiplies with recursion depth.
+- **Every slot is written before it is read** (the work/rest/key buffers are
+  seeded by `CopyTo` and the per-element builders; frames/arena are written
+  before use and spill to `ArrayPool` only when an adversarial input outgrows
+  the seed). So it does not depend on zero-init and is a correct candidate for
+  `[SkipLocalsInit]`.
+
+Had the aggregate been tens of KB, or had the buffer sat on the recursive
+re-entry path, the answer would flip to a pool rental (rented once and reused
+across the recursion) despite the per-call overhead, to avoid stack overflow.
+
+---
+
+## 6. Decision procedure
+
+```text
+Need a short-lived scratch buffer on a hot path?
+│
+├─ Is the size fixed and small (single frame ≲ a few KB),
+│  and NOT on a recursive / unbounded-loop path?
+│  │
+│  ├─ YES ──> stackalloc.
+│  │         Does the code write every slot before reading it?
+│  │         ├─ YES ──> add [SkipLocalsInit]. (best: ~1-2 ns, both TFMs)
+│  │         └─ NO  ──> plain zeroed stackalloc, OR zero only the
+│  │                    prefix you read. (net481 zeroing ~3.6x net10)
+│  │
+│  ├─ Usually small but occasionally large (variable / unbounded
+│  │  size, common case stack-friendly)? ──>
+│  │            BufferScope<T>(stackalloc T[N], minimumLength):
+│  │            stays on the stack for the common case, rents from the
+│  │            pool only when it overflows. Wrapper overhead ~1 ns
+│  │            net481 / ~0.3 ns net10. Put [SkipLocalsInit] on the
+│  │            CALLING method to drop the stack-buffer zeroing; the
+│  │            scope passes it through.
+│  │
+│  └─ NO (large, unbounded, recursive, or must escape the frame) ──>
+│            ArrayPool<T>.Shared, rented ONCE and reused across the
+│            loop/recursion. Accept the per-call Rent/Return floor
+│            (~10 ns/op net481, ~4 ns/op net10); minimize the number
+│            of distinct rentals and avoid two same-bucket rentals
+│            colliding in the TLS cache.
+```
+
+Key rules of thumb:
+
+- **Measure the zeroing before assuming it is the cost.** Sampling profilers
+  attribute stack zeroing to `System.Buffer.ZeroMemoryInternal` (or `memset`);
+  if that frame is hot, a `[SkipLocalsInit]` experiment is the first thing to
+  try. But scope the profile to the measured workload - warmup/JIT dilute the
+  percentage and a tiny hot frame can be over-attributed by the sampler.
+- **net481 amplifies both costs.** Constant-size zeroing is ~3.6x and pool
+  overhead ~2.5x more expensive than net10. A buffer strategy that looks free on
+  net10 can dominate on Framework; always check both TFMs.
+- **Element type does not change zeroing cost** - only byte count does.
+- **Know the crossover size before choosing rent vs zero** (section 3.2): for a
+  runtime-variable size, a zeroed `stackalloc` is cheaper than a rental below
+  roughly **190 bytes on net10 / 1.3 KB on net481** against a warm TLS rental,
+  and below roughly **1.8 KB on net10 / 3 KB on net481** against a contended
+  (locked) rental. Above those sizes a rental's flat floor wins - provided you
+  can use the uninitialized memory without clearing it. A compile-time-constant
+  size zeroes far cheaper on net10, pushing its crossover higher.
+- **A pool rental is not free even when warm.** Prefer suppressing the zeroing on
+  a stack buffer over renting, whenever the size and lifetime allow it.
+- **For variable sizes, reach for `BufferScope<T>` instead of choosing up front.**
+  It stays on the stack for the common case and rents only when overflowed, for
+  a ~1 ns (net481) / ~0.3 ns (net10) wrapper cost, and forwards the calling
+  method's `[SkipLocalsInit]` to the stack buffer.
+- **`[SkipLocalsInit]` hands you uninitialized memory - use it carefully.** Only
+  where a profile shows the clear is hot, every read slot is written first, and
+  no unwritten bytes can escape. Place it on the method that physically holds the
+  `stackalloc`; the JIT inliner will not spread it for you, and net481's weaker
+  inliner can change where the zeroing lands, so verify on both TFMs.
+
+---
+
+## 7. References
+
+- [`SkipLocalsInit` attribute - C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute) - the compiler/CLR `.locals init` mechanism.
+- [`SkipLocalsInitAttribute` class](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute) - the "Applies to: .NET 5-11" type-availability note (polyfilled downlevel by PolySharp).
+- [Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices) - `[SkipLocalsInit]` guidance and the GC-reference caveat.
+- [`stackalloc` expression](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc) - unmanaged-type requirement, undefined initial contents, sizing and loop rules.
+- [CA2014: Do not use `stackalloc` in loops](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops).
+- [`Thread` constructor](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor) - 1 MB default stack, 256 KB partial-trust minimum on .NET Framework.
+- Benchmarks backing the numbers: the `StackZeroInit`, `ArrayPoolSeedRent`, `ArrayPoolCrossover` (the size sweep in section 3.2), and `BufferScopeOverhead` (the `BufferScope` overhead in section 4.2) BenchmarkDotNet classes.
+
+---
+
+## 8. Common mistake: `Unsafe.SkipInit` does not suppress `.locals init`
+
+It is easy to assume that `Unsafe.SkipInit(out T value)` is what turns off the
+zero-initialization of a local - the name reads like "skip the init of this
+value." It does not, and a benchmark of the "uninitialized fixed-buffer scratch"
+pattern was wrong for exactly this reason until `[SkipLocalsInit]` was added.
+
+Two different mechanisms are at play, and only one of them clears memory:
+
+- **`Unsafe.SkipInit<T>(out T value)` is a compile-time trick, not a runtime
+  one.** Its body is a bare `ret` - it emits no code. Its only job is to satisfy
+  the C# compiler's *definite-assignment* analysis so you may read a local
+  without first writing it (or writing `= default`), avoiding the "use of
+  unassigned local variable" error. It never touches memory at run time.
+- **The actual zeroing comes from the method's `.locals init` flag.** The C#
+  compiler stamps that flag on every method that declares locals, and the CLR
+  honors it by zeroing **all** of the method's locals on entry - before any of
+  your code, including the `Unsafe.SkipInit` call, runs. The only way to strip
+  that flag is `[SkipLocalsInit]` on the method (or `[module: SkipLocalsInit]`).
+
+So `Unsafe.SkipInit` lets you legally *read* an unassigned local, but the runtime
+has already zeroed it. Without `[SkipLocalsInit]` on the enclosing method, a
+4 KB fixed buffer "left uninitialized" with `Unsafe.SkipInit` is still fully
+zeroed on entry, and a benchmark of that shape measures the zeroing it claims to
+avoid. The two work together: `[SkipLocalsInit]` removes the runtime clear, and
+`Unsafe.SkipInit` makes the resulting un-zeroed read well-formed at compile time.
+Neither one replaces the other.
+
+The practical rule: to actually skip the zeroing, put `[SkipLocalsInit]` on the
+method that physically contains the `stackalloc` (or fixed-buffer local). Reach
+for `Unsafe.SkipInit` only when you additionally need to read a local the
+compiler would otherwise reject as unassigned - and never treat its presence as
+evidence that the zeroing is gone.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+compatibility: Requires the repository's test runner; timing and allocation checks should run on every supported target framework.
+description: Security-focused review of pending changes. Audit any change that could affect safety or correctness under abusive input or unchecked preconditions - oversized values, malformed structures, integer/length overflow, catastrophic backtracking, allocation pressure, other denial-of-service shapes, and any use of `unsafe` code or the `Unsafe` / `MemoryMarshal` / `Marshal` static helpers (which trade compiler safety guarantees for speed and need extra scrutiny). Add regression tests that pin safe behavior even when the current implementation already handles the input correctly. Use when asked to "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling", or before publishing any change that adds or modifies code that parses, decodes, encodes, compiles, marshals, or reinterprets memory.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/security-review
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 883a99623b74cd6f5bfc2e0706b71a1513d1c62f
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review, performance-testing, fuzz-testing
+    requires: none
+    risk: local-write
+name: security-review
+---
+# Security review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Surface and pin behavior under **malformed input** and **caller-validated
+APIs** (everything the C# compiler doesn't check for you).
+
+## When to run
+
+- The user asks for a security assessment / vulnerability review.
+- A change adds or modifies a member that accepts caller-supplied data
+  (function args, file contents, network bytes, env vars, anything
+  upstream of those).
+- A change introduces or modifies `unsafe` code, calls into
+  `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, `fixed`, raw pointers,
+  unbounded `stackalloc`, or any BCL API whose XML doc says "unsafe"
+  or "caller must". Applies even when inputs are fully internal -
+  preconditions drift across refactors.
+- A CVE in a comparable library prompts "do we have the same shape?".
+
+## The discipline in one paragraph
+
+Write tests that pin the **safe property** (terminates within a bound,
+returns a defined error for malformed input, never reads/writes past the
+buffer) - and make them pass against *current* code as a regression lock.
+Never pin observable wrong output; that locks the bug in. Test the input
+*shape*, not a specific exploit pattern. Boundary tests come in pairs (at
+the limit, just over). When a finding needs a production change, surface
+the options report and **end your turn** before patching. The full
+principles and the High/Medium/Low rubric are in [principles.md](principles.md).
+
+## Review procedure
+
+1. **Inventory.** `git status --short`; tag each new/modified member that
+   takes external input or uses a caller-validated API.
+2. **Walk each tagged member** through the [checklist.md](checklist.md)
+   categories. The largest category - `unsafe` / `Unsafe.*` /
+   `MemoryMarshal.*` and other caller-validated APIs - has its own
+   per-API table in [unsafe-apis.md](unsafe-apis.md).
+3. **Place tests in `<TypeName>.Security.cs`** beside the production type.
+4. **Add safe-property tests now; report findings that need a production
+   change before patching.** See [reporting.md](reporting.md) for the
+   options-report format and the don'ts.
+5. **Run tests on every target framework** - timing bounds and allocation
+   behavior differ across BCL versions.
+
+When attention is limited, allocate it by tier (detail in
+[checklist.md](checklist.md)):
+
+- **Critical (never skip):** length/size bounds, algorithmic complexity,
+  and the caller-validated-API audit.
+- **Standard (every member):** integer overflow, malformed structure,
+  argument validation.
+- **Conditional (when the shape matches):** allocation DoS, in-band
+  sentinels, path traversal.
+
+## Related skills
+
+Run alongside a broader pre-PR self-review before any publish. When you need
+to *measure* a worst-case input rather than just bound it with a `Stopwatch`,
+use the repository's performance-testing skill. (A consuming repository wires
+the concrete cross-references in its overlay.)
+
+## Sub-pages
+
+- [principles.md](principles.md) - the five core principles and the
+  High / Medium / Low severity rubric.
+- [checklist.md](checklist.md) - the nine audit categories with the test
+  shape each one demands.
+- [unsafe-apis.md](unsafe-apis.md) - the per-API precondition / failure /
+  test-shape table for `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, `fixed`,
+  `stackalloc`, and `[DllImport]`.
+- [reporting.md](reporting.md) - the review procedure, the options-report
+  format, and the don'ts that keep tests from pinning bugs.

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -1,0 +1,144 @@
+# Audit checklist
+
+Detail for the [security-review](SKILL.md) skill. Walk every new/modified
+member through the categories below. The question is whether the *input shape*
+or *unchecked precondition* could push the code into the failure mode, not
+whether it currently does.
+
+The largest category - `unsafe` / `Unsafe.*` / `MemoryMarshal.*` and other
+caller-validated APIs (section 7) - lives in [unsafe-apis.md](unsafe-apis.md).
+
+When attention is limited, allocate it by tier:
+
+- **Critical (never skip):** sections 1 and 4, [unsafe-apis.md](unsafe-apis.md).
+- **Standard (every member):** sections 2, 5, and 9.
+- **Conditional (when the code shape matches):** section 3 (allocates
+  proportional to input), section 6 (encoder uses in-band sentinels),
+  section 8 (path-handling API).
+
+## 1. Length / size of inputs
+
+- Is there an upper bound? What stops a caller from passing a
+  multi-MB / multi-GB value?
+- Is the bound at the API boundary, not buried in a helper?
+- For composed inputs (list of strings, stream of records), is the
+  **total** size bounded, not just per-element?
+- Is the default safe for untrusted callers, with an opt-out for
+  trusted ones? The standard shape is a `DefaultMaxLength` constant
+  plus a `maxLength` parameter where a sentinel (e.g. `-1`) disables
+  the check.
+
+**Tests:** at-limit success, over-limit failure with documented
+error, opt-out (e.g. `-1`) disables the check.
+
+## 2. Integer / length-field overflow
+
+- Are length sums (`a.Length + b.Length`, `count * elementSize`)
+  protected by `checked()` where crafted input can overflow?
+- Are running lengths cast to a narrower type (`(char)len`,
+  `(byte)count`)? Silent truncation lets oversized fields slip
+  through and be re-read as smaller values, misdecoding downstream
+  data as structural metadata. Check the counter *before* the cast.
+
+**Tests:** boundary inside the representable range plus boundary
+outside. Specialized fast paths often bypass the affected code
+- pick an input shape that **forces the general path**.
+
+## 3. Allocation pressure / memory DoS
+
+- Does work allocate proportional to (or worse than) input size?
+- Is the worst case bounded by an explicit cap (section 1) or only by
+  available memory?
+- Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
+  per call (acceptable if bounded), or grow without limit (red flag)?
+
+**Tests:** a "large but legitimate" input completes within a
+`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
+allocation count.
+
+## 4. Computational complexity / algorithmic DoS
+
+- Worst-case runtime: linear, polynomial, or exponential?
+- ReDoS shape: matcher with multiple wildcards (`*`, `**`, `?(...)`,
+  alternation) that retries every wildcard on mismatch. Safe shape:
+  **fixed savepoint slots** (each new wildcard overwrites the
+  previous slot of the same kind), bounding the worst case to
+  O(n * m).
+- Hashtable attacks: are user-controlled keys hashed with a
+  randomized hash (modern .NET `string.GetHashCode()` and
+  `Dictionary<,>` are per-process randomized), or a deterministic one
+  a caller could pre-image into a single bucket?
+
+**Tests** (pin the safe property):
+
+```csharp
+[Fact]
+public void Method_PathologicalInput_TerminatesPromptly()
+{
+    /* construct adversarial pattern + input */
+
+    Stopwatch sw = Stopwatch.StartNew();
+    bool result = m.IsMatch(input);
+    sw.Stop();
+
+    result.Should().Be(/* expected */);
+    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+}
+```
+
+Add one per "we use the safe algorithm" claim; the property is
+invisible to refactors, the test is the lock.
+
+## 5. Malformed structure / parser robustness
+
+- Truncated input handled gracefully (no `IndexOutOfRangeException`
+  past the end)?
+- Unmatched opens (`[`, `{`, `(`, dangling `\\` / `%`) produce a
+  defined error, not an unrelated runtime exception?
+
+**Tests:** one per malformed shape asserting the exact error type;
+empty, single-character, and "exactly the sentinel" inputs (`""`,
+`"["`, `"\\"`).
+
+## 6. Sentinel / in-band markers colliding with input
+
+- Encoder uses in-band sentinel values (opcode chars, length prefix
+  bytes, control chars)? If user input contains those same values,
+  are they distinguishable from real structure (escaping, length
+  framing, reserved noncharacter code points)?
+
+**Test:** input containing every sentinel value used as ordinary
+data; the member treats them as data.
+
+## 7. `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, and other caller-validated APIs
+
+Mandatory whenever a PR touches one of these. The compiler offloads
+safety to you; the review *is* the safety check. The per-API table
+(precondition, failure mode, required test shape) lives in
+[unsafe-apis.md](unsafe-apis.md).
+
+## 8. Path traversal / sandbox escape
+
+- API takes a root + relative input and returns paths - results
+  stay inside the root? Symlink behavior is the caller's documented
+  choice, not silently re-enabled?
+- Caller-supplied fragments concatenated without normalization?
+  `Path.Combine` honors absolute inner segments, which is a foot-gun.
+
+**Tests:** inputs with `..` segments, absolute paths, alternate
+separators, and symlink-style names; enumerator stays inside the
+configured root.
+
+## 9. Argument validation at the boundary
+
+- `ArgumentNullException.ThrowIfNull` on every reference-type
+  parameter the contract forbids `null` for.
+- `ArgumentOutOfRangeException.ThrowIfNegative` / `ThrowIfGreaterThan`
+  on numeric range checks.
+- Enum parameters: validated against the declared range, or
+  documented to accept any underlying value with explicit defaulting.
+
+**Test:** one per parameter for each forbidden violation mode. Don't
+trust the downstream BCL primitive to throw - the contract is
+yours.

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,0 +1,31 @@
+---
+core: security-review
+core-pin: v0.11.0
+---
+
+# Security review overlay
+
+Repository-specific bindings for thirtytwo.
+
+- Product and test code are mirrored under
+  [src/thirtytwo](../../../src/thirtytwo) and
+  [src/thirtytwo_tests](../../../src/thirtytwo_tests).
+- Treat all raw Win32 calls, COM vtables, CCWs, handles, native allocations,
+  `unsafe`, `Unsafe`, `MemoryMarshal`, pointer arithmetic, and stack or pooled
+  buffers as caller-validated surfaces.
+- Verify HRESULT and last-error behavior, owned versus borrowed handles and COM
+  references, allocator/deallocator pairing, byte-versus-element units,
+  checked size arithmetic, null and empty spans, and cleanup on every failure
+  path.
+- Place regression tests in the existing mirrored test area for the production
+  type. Use a dedicated `.Security.cs` file only when it improves the local
+  test organization.
+- Run focused tests first, then the Release suite:
+
+```pwsh
+dotnet test src/thirtytwo_tests/thirtytwo_tests.csproj --configuration Release --report-trx
+```
+
+Use [cswin32-interop](../cswin32-interop/SKILL.md) for general native
+signatures and [cswin32-com](../cswin32-com/SKILL.md) for COM-specific lifetime
+and ABI rules.

--- a/.agents/skills/security-review/principles.md
+++ b/.agents/skills/security-review/principles.md
@@ -1,0 +1,44 @@
+# Core principles and severity
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Core principles
+
+1. **Test safe properties, even when current code is already
+   correct.** A safe property = the method terminates within a stated
+   bound, returns a defined error for malformed input, returns the
+   documented default for empty input, doesn't read/write past the
+   buffer, or doesn't crash. These tests must pass against current
+   code; commit them as the regression lock.
+2. **Never write a test that pins observable wrong output.** A test
+   asserting "this silently truncates" locks the bug in. If current
+   code is wrong, skip the test until the fix lands and pin the
+   *corrected* output then.
+3. **Test the shape, not the specific exploit.** "Input at the
+   declared limit" lasts forever; "exact pattern that triggered CVE-X"
+   decays.
+4. **Boundary tests come in pairs.** One at the limit (succeeds), one
+   just over (fails in a defined way).
+5. **Surface findings before patching production code.** When a
+   finding needs a production change, output the options report,
+   **end your turn, and do not produce the patch or any failing test
+   on that turn**. Resume after the user replies with an approval
+   verb (`go`, `apply A`, `fix it`). Passing safe-property tests
+   (principle 1) may ship on the same turn as the report; failing
+   tests may not.
+
+## Severity rubric
+
+Label every finding before the report.
+
+- **High** - memory corruption, OOB read/write, type confusion,
+  lifetime escape, RCE, disclosure of secrets/addresses, auth bypass.
+  Fix on the same PR.
+- **Medium** - DoS (CPU, memory, stack, FDs), crashing unhandled
+  exception, parser accepting malformed input as valid, ambiguous
+  parsing that smuggles a different shape past validation. Usually
+  fix on the same PR; deferral needs a documented mitigation.
+- **Low** - silent truncation still bounded by a downstream BCL
+  slice check, documented contract violations on edge cases,
+  non-sensitive error-message leakage. Safe to defer; still pin the
+  *corrected* behavior with a regression test once the fix lands.

--- a/.agents/skills/security-review/reporting.md
+++ b/.agents/skills/security-review/reporting.md
@@ -1,0 +1,62 @@
+# Review procedure and reporting
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Review procedure
+
+1. **Inventory.** `git status --short` and read every new/modified
+   file. Tag each member that takes external input or uses a
+   caller-validated API.
+2. **Walk each tagged member through the tiered categories** in
+   [checklist.md](checklist.md). The test you'd write to prove it's
+   fine is the deliverable.
+3. **Place tests in `<TypeName>.Security.cs` partial-class files**
+   beside the production type. Create one if it doesn't exist.
+4. **Add safe-property tests now (principle 1); commit failing /
+   wrong-output tests only with the fix.**
+5. **If a test fails against current code, stop and report.** Don't
+   patch without surfacing first.
+6. **Run tests on every TFM.** Timing bounds and allocation behavior
+   differ across BCL versions.
+
+## Options report format
+
+When the report contains any finding that requires a production-code
+change: output the report and **end your turn**. Don't produce the
+patch, don't produce a failing test, don't run further tool calls
+beyond what's needed to classify the finding. Resume only after the
+user replies with an approval verb (`go`, `apply Option A`, `fix it`,
+or similar). Passing safe-property tests (principle 1) may be added
+on the same turn; they don't change production behavior.
+
+```text
+### Finding #N -- <one-line summary>
+
+<which file(s), which lines, what the failure mode is>
+**Severity:** High / Medium / Low (per rubric)
+
+**Option A -- <approach>**
+- <change shape, ~LoC>
+- Pro: ...
+- Con: ...
+
+**Option B -- ...**
+
+**My recommendation:** <one of the above, with rationale.>
+```
+
+Low-severity findings can be deferred entirely; Medium/High deferrals
+need an explicit reason in the PR body.
+
+## Don'ts
+
+- **Don't patch production code without surfacing the finding first.**
+- **Don't pin observable wrong output in a test.** That locks the bug
+  in. Either ship the corrected-behavior test *alongside* the fix, or
+  skip the test until the fix lands. Safe-property tests (principle 1)
+  are not this case.
+- **Don't claim "safe by construction" without a regression test.**
+  The safe property is invisible to a future refactor.
+- **Don't assume `internal` / `InternalsVisibleTo` members are out of
+  scope.** Tests reach them; refactors promote them. Audit them on
+  the same basis as `public`.

--- a/.agents/skills/security-review/unsafe-apis.md
+++ b/.agents/skills/security-review/unsafe-apis.md
@@ -1,0 +1,30 @@
+# Caller-validated APIs (`unsafe`, `Unsafe.*`, `MemoryMarshal.*`)
+
+Detail for section 7 of the [security-review](SKILL.md) audit
+[checklist.md](checklist.md). Mandatory whenever a PR touches one of these.
+The compiler offloads safety to you; the review *is* the safety check.
+
+For each use site answer:
+
+1. What precondition does the API require? (Read the XML doc.)
+2. Where in the calling code is it established? If it's a *different*
+   method, what stops a future refactor from desyncing them?
+3. Is the precondition still satisfied when the input is empty,
+   `null`, zero-length, or `default`? (Empty is the most common
+   blow-up.)
+
+Walk every use site against this table; rows are independent.
+
+| API pattern | Precondition (compiler does NOT check) | Failure mode if violated | Required test shape |
+| ----------- | -------------------------------------- | ------------------------ | ------------------- |
+| `MemoryMarshal.GetReference(span)` / `GetPinnableReference` / `Unsafe.AsPointer(ref span[0])` / `GetArrayDataReference` | Returned `ref` only valid when `span.Length > 0`; empty span yields the managed-null sentinel. | Crash or wild read at null. | `Method_EmptyInput_DoesNotDereferenceNullReference` returns documented default with no exception. |
+| `Unsafe.Add(ref T, int)` | Index `< span.Length` (or backing buffer element count). | OOB read leaks adjacent-page memory; OOB write corrupts heap. | One test at the last in-range index (loop guard's last iteration is the off-by-one site). |
+| `Unsafe.ReadUnaligned<T>` / `WriteUnaligned<T>` | `ref byte` points at `sizeof(T)` valid bytes; alignment is your problem. | OOB read or torn write. | Boundary tests at exactly `sizeof(T)` bytes and one less. |
+| `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **Older-JIT pitfall:** on .NET Framework RyuJIT, an `[AggressiveInlining]` method that reinterprets a signed-primitive parameter via `Unsafe.As<T, byte>(ref param)` can propagate the caller's int-promoted negative value into the comparison immediate; mask explicitly. | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
+| `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
+| `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
+| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime <= referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
+| `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
+| `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use a pooled / growable scratch-buffer helper when the input could exceed the stack budget. |
+| `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |
+| Any BCL API whose XML doc contains "unsafe" or "caller must" | Whatever the doc specifies. | Whatever the doc warns about. | Edge case where the precondition *almost* holds (one byte short, off-by-one alignment). |


### PR DESCRIPTION
## Summary

- vendor 13 applicable skill cores from `JeremyKuhne/agent-skills` at immutable release `v0.11.0`
- add thirtytwo-specific overlays for CsWin32, COM, build, test, review, and publishing workflows
- document the portfolio, selection boundary, update model, and validation contract

## Validation

- strict portfolio validation and `skills-ref@0.1.5` for all 13 skills
- markdownlint under the pinned source policy and full Markdown link check
- byte-for-byte comparison against fresh `v0.11.0` installs
- Debug and Release builds
- Debug and Release tests: 281 passed, 1 manual test skipped in each configuration