### PR TITLE
Harden native interop and repository foundations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a reproducible defect
+labels: bug
+---
+
+## Description
+
+Describe the observed behavior and its impact.
+
+## Reproduction
+
+Provide the smallest code sample or sequence of steps that reproduces the
+problem.
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Environment
+
+- Windows version:
+- .NET SDK or runtime version:
+- Thirtytwo commit or package version:
+- Process architecture:
+
+## Additional context
+
+Include relevant exception details, logs, screenshots, or native error codes.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a new capability or API
+labels: enhancement
+---
+
+## Problem
+
+Describe the Win32 scenario or limitation this proposal addresses.
+
+## Proposed API or behavior
+
+Describe the desired object model and include a usage example when possible.
+
+## Alternatives considered
+
+Describe existing Win32, CsWin32, or managed alternatives and why they are not
+sufficient.
+
+## Compatibility
+
+Call out native ownership, lifetime, platform, trimming, or API compatibility
+considerations.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+Describe what this pull request changes and why.
+
+## Changes
+
+-
+
+## Validation
+
+- [ ] `dotnet build --configuration Release` passes
+- [ ] `dotnet test --configuration Release --no-build --report-trx` passes
+- [ ] New or changed behavior has focused tests
+- [ ] Native ownership, size units, and failure cleanup were reviewed when applicable
+- [ ] Agent-file validation passes when `.agents/` changed
+
+## Related issues
+
+Fixes #

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Contributor Covenant Code of Conduct
+
+This project follows the
+[Contributor Covenant version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+We pledge to make participation in the project a harassment-free experience
+for everyone.
+
+## Enforcement
+
+Report abusive, harassing, or otherwise unacceptable behavior privately to
+`jeremy.kuhne@microsoft.com`. Reports will be reviewed by the project
+maintainer and handled as confidentially as practical.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to thirtytwo
+
+Thanks for your interest in contributing.
+
+## Prerequisites
+
+- Windows with an interactive desktop session
+- An x64 .NET SDK capable of targeting `net10.0-windows`
+- Git
+
+## Build and test
+
+```pwsh
+git clone https://github.com/JeremyKuhne/thirtytwo.git
+cd thirtytwo
+dotnet restore
+dotnet build --configuration Debug --no-restore
+dotnet build --configuration Release --no-restore
+dotnet test --configuration Release --no-build --report-trx
+```
+
+The file-dialog manual test is skipped during automated runs. Clipboard and
+other desktop-resource tests require an interactive Windows session.
+
+## Submitting changes
+
+1. Fork the repository and create a focused branch from `main`.
+2. Keep changes consistent with the existing object model and CsWin32
+   projections.
+3. Add or update tests for every behavior change and public API.
+4. Run the Release build and test commands above.
+5. Open a pull request against `main` and explain the behavior and validation.
+
+Changes under `.agents/` must also pass the validation commands documented in
+[the skills catalog](.agents/skills/README.md#validation).
+
+## License
+
+By submitting a pull request, you agree that your contribution is licensed
+under the [MIT License](LICENSE) that governs this project.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,5 +16,6 @@
     <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="KlutzyNinja.Madowaku" Version="0.4.0-alpha.1" />
     <PackageVersion Include="KlutzyNinja.Touki" Version="0.4.0-alpha.1" />
+    <PackageVersion Include="KlutzyNinja.Touki.TestSupport" Version="0.4.0-alpha.1" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,4 +2,40 @@
 
 [![Build](https://github.com/JeremyKuhne/thirtytwo/actions/workflows/dotnet.yml/badge.svg)](https://github.com/JeremyKuhne/thirtytwo/actions/workflows/dotnet.yml)
 
-An experiment wrapping Win32 into an object model, leveraging CsWin32 as the base interop layer. Builds on what I did with [WInterop](https://github.com/JeremyKuhne/WInterop), but focuses on the top level abstractions. Further details to come.
+An experimental .NET object model for Win32, built on
+[CsWin32](https://github.com/microsoft/CsWin32). It builds on the ideas in
+[WInterop](https://github.com/JeremyKuhne/WInterop) while focusing on
+higher-level abstractions for windows, controls, graphics, accessibility, and
+COM.
+
+## Status
+
+Thirtytwo is under active development and has not published a supported NuGet
+package or stable release. APIs may change without notice.
+
+## Requirements
+
+- Windows
+- An x64 .NET SDK capable of targeting `net10.0-windows`
+
+## Build and test
+
+```pwsh
+dotnet restore
+dotnet build --configuration Release --no-restore
+dotnet test --configuration Release --no-build --report-trx
+```
+
+The solution includes Win32 sample applications under `src/samples/`. Some
+tests interact with desktop resources such as the clipboard and therefore
+require an interactive Windows session.
+
+## Contributing and security
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a change. Report
+security issues privately as described in [SECURITY.md](SECURITY.md).
+
+## License
+
+Thirtytwo is licensed under the [MIT License](LICENSE). Third-party attribution
+notices are listed in [THIRD-PARTY-NOTICES.TXT](THIRD-PARTY-NOTICES.TXT).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Report security concerns privately to `jeremy.kuhne@microsoft.com`. Include the
+affected API, the failure mode, reproduction details, and any proposed
+mitigation. Please allow time to investigate and coordinate disclosure before
+publishing details.
+
+## Supported versions
+
+Thirtytwo has not published a stable release. Security fixes currently target
+the latest commit on `main`.

--- a/src/thirtytwo/Clipboard.cs
+++ b/src/thirtytwo/Clipboard.cs
@@ -143,10 +143,15 @@ public unsafe class Clipboard
                 data.CopyTo(buffer);
                 buffer[^1] = default;
             }
-            finally
+            catch
             {
-                // FALSE with NO_ERROR is expected when the lock count reaches zero.
                 PInvoke.GlobalUnlock(global);
+                throw;
+            }
+
+            if (!PInvoke.GlobalUnlock(global))
+            {
+                WIN32_ERROR.ERROR_SUCCESS.ThrowIfLastErrorNot();
             }
 
             HANDLE result = PInvoke.SetClipboardData(format, (HANDLE)(nint)global);

--- a/src/thirtytwo/Clipboard.cs
+++ b/src/thirtytwo/Clipboard.cs
@@ -118,16 +118,52 @@ public unsafe class Clipboard
     public static unsafe void SetClipboardData<T>(ReadOnlySpan<T> data, uint format)
         where T : unmanaged
     {
+        int bufferLength = checked(data.Length + 1);
         HGLOBAL global = PInvoke.GlobalAlloc(
             GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE,
-            (nuint)((data.Length + 1) * sizeof(T)));
+            checked((nuint)bufferLength * (nuint)sizeof(T)));
 
-        Span<T> buffer = new(PInvoke.GlobalLock(global), data.Length + 1);
-        data.CopyTo(buffer);
-        buffer[^1] = default;
+        if (global.IsNull)
+        {
+            Error.GetLastError().ThrowThirtyTwoException();
+        }
 
-        PInvoke.GlobalUnlock(global);
-        PInvoke.SetClipboardData(format, (HANDLE)(nint)global);
+        bool ownershipTransferred = false;
+        try
+        {
+            void* memory = PInvoke.GlobalLock(global);
+            if (memory is null)
+            {
+                Error.GetLastError().ThrowThirtyTwoException();
+            }
+
+            try
+            {
+                Span<T> buffer = new(memory, bufferLength);
+                data.CopyTo(buffer);
+                buffer[^1] = default;
+            }
+            finally
+            {
+                // FALSE with NO_ERROR is expected when the lock count reaches zero.
+                PInvoke.GlobalUnlock(global);
+            }
+
+            HANDLE result = PInvoke.SetClipboardData(format, (HANDLE)(nint)global);
+            if (result.IsNull)
+            {
+                Error.GetLastError().ThrowThirtyTwoException();
+            }
+
+            ownershipTransferred = true;
+        }
+        finally
+        {
+            if (!ownershipTransferred)
+            {
+                PInvoke.GlobalFree(global);
+            }
+        }
     }
 
     /// <summary>

--- a/src/thirtytwo/Win32/Foundation/UNICODE_STRING.cs
+++ b/src/thirtytwo/Win32/Foundation/UNICODE_STRING.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32.Foundation;
 public unsafe partial struct UNICODE_STRING
 {
     public readonly int LengthInChars => Length / sizeof(char);
-    public readonly int MaximumLengthInChars => Length / sizeof(char);
+    public readonly int MaximumLengthInChars => MaximumLength / sizeof(char);
 
     [UnscopedRef]
     public readonly ReadOnlySpan<char> CurrentValue => new(Buffer, LengthInChars);

--- a/src/thirtytwo/Win32/Graphics/Imaging/ComponentInfo.cs
+++ b/src/thirtytwo/Win32/Graphics/Imaging/ComponentInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Windows.Support;
+
 namespace Windows.Win32.Graphics.Imaging;
 
 public unsafe class ComponentInfo : DirectDrawBase<IWICComponentInfo>
@@ -26,9 +28,19 @@ public unsafe class ComponentInfo : DirectDrawBase<IWICComponentInfo>
         {
             uint length;
             Pointer->GetFriendlyName(0, null, &length).ThrowOnFailure();
-            char* name = stackalloc char[(int)length];
-            Pointer->GetFriendlyName(length, name, &length).ThrowOnFailure();
-            return new string(name);
+            using BufferScope<char> name = new(stackalloc char[256]);
+            name.EnsureCapacity(checked((int)length));
+            fixed (char* namePointer = name)
+            {
+                Pointer->GetFriendlyName((uint)name.Length, namePointer, &length).ThrowOnFailure();
+                int characterCount = checked((int)length);
+                if (characterCount == 0 || name[characterCount - 1] != '\0')
+                {
+                    throw new InvalidDataException("The WIC component returned an invalid friendly name.");
+                }
+
+                return name[..(characterCount - 1)].ToString();
+            }
         }
     }
 

--- a/src/thirtytwo/Win32/System/Com/Lifetime.cs
+++ b/src/thirtytwo/Win32/System/Com/Lifetime.cs
@@ -58,12 +58,19 @@ public unsafe struct Lifetime<TVTable, TObject> where TVTable : unmanaged
     /// </remarks>
     public static unsafe Lifetime<TVTable, TObject>* Allocate(TObject @object, TVTable* vtable)
     {
+        GCHandle handle = GCHandle.Alloc(@object);
+
         // Manually allocate a native instance of this struct.
         var wrapper = (Lifetime<TVTable, TObject>*)PInvoke.CoTaskMemAlloc((nuint)sizeof(Lifetime<TVTable, TObject>));
+        if (wrapper is null)
+        {
+            handle.Free();
+            throw new OutOfMemoryException();
+        }
 
-        // Assign a pointer to the vtable, allocate a GCHandle for the related object, and set the initial ref count.
+        // Assign a pointer to the vtable, store the GCHandle for the related object, and set the initial ref count.
         wrapper->VTable = vtable;
-        wrapper->Handle = (IUnknown*)GCHandle.ToIntPtr(GCHandle.Alloc(@object));
+        wrapper->Handle = (IUnknown*)GCHandle.ToIntPtr(handle);
         wrapper->RefCount = 1;
 
         return wrapper;

--- a/src/thirtytwo/Win32/System/Registry/Registry.cs
+++ b/src/thirtytwo/Win32/System/Registry/Registry.cs
@@ -209,8 +209,13 @@ public static unsafe partial class Registry
             case REG_VALUE_TYPE.REG_SZ:
             case REG_VALUE_TYPE.REG_EXPAND_SZ:
             case REG_VALUE_TYPE.REG_LINK:
-                // Size includes the null
-                return MemoryMarshal.Cast<byte, char>(buffer)[..^1].ToString();
+                ReadOnlySpan<char> stringCharacters = MemoryMarshal.Cast<byte, char>(buffer);
+                if (!stringCharacters.IsEmpty && stringCharacters[^1] == '\0')
+                {
+                    stringCharacters = stringCharacters[..^1];
+                }
+
+                return stringCharacters.ToString();
             case REG_VALUE_TYPE.REG_MULTI_SZ:
                 ReadOnlySpan<char> characters = MemoryMarshal.Cast<byte, char>(buffer);
                 List<string> values = [];

--- a/src/thirtytwo_tests/GlobalUsings.cs
+++ b/src/thirtytwo_tests/GlobalUsings.cs
@@ -4,4 +4,5 @@
 global using FluentAssertions;
 global using Touki;
 global using Touki.Buffers;
+global using Touki.TestSupport;
 global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/thirtytwo_tests/Win32/Foundation/UNICODE_STRINGTests.cs
+++ b/src/thirtytwo_tests/Win32/Foundation/UNICODE_STRINGTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Win32.Foundation;
+
+[TestClass]
+public unsafe class UNICODE_STRINGTests
+{
+    [TestMethod]
+    public void MaximumLengthInChars_UsesMaximumLength()
+    {
+        char* buffer = stackalloc char[4];
+        UNICODE_STRING value = new()
+        {
+            Buffer = (PWSTR)buffer,
+            Length = 2 * sizeof(char),
+            MaximumLength = 4 * sizeof(char)
+        };
+
+        value.LengthInChars.Should().Be(2);
+        value.MaximumLengthInChars.Should().Be(4);
+        value.CurrentValue.Length.Should().Be(2);
+        value.FullBuffer.Length.Should().Be(4);
+    }
+}

--- a/src/thirtytwo_tests/Win32/System/Registry/RegistryTests.cs
+++ b/src/thirtytwo_tests/Win32/System/Registry/RegistryTests.cs
@@ -6,6 +6,11 @@ namespace Windows.Win32.System.Registry;
 [TestClass]
 public class RegistryTests
 {
+    private delegate object ReadValueDelegate(ReadOnlySpan<byte> buffer, REG_VALUE_TYPE valueType);
+
+    private static readonly ReadValueDelegate s_readValue =
+        typeof(Registry).TestAccessor.CreateDelegate<ReadValueDelegate>("ReadValue");
+
     [TestMethod]
     public void QueryKeyName_NameExceedsInitialBuffer_ReturnsFullName()
     {
@@ -162,5 +167,29 @@ public class RegistryTests
             @"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
         object? productName = Registry.QueryValue(key, "ProductName");
         productName.Should().BeOfType<string>().Which.Should().StartWith("Windows");
+    }
+
+    [TestMethod]
+    public void ReadValue_ZeroBytesStringData_ReturnsEmptyString()
+    {
+        s_readValue([], REG_VALUE_TYPE.REG_SZ).Should().Be(string.Empty);
+    }
+
+    [TestMethod]
+    public void ReadValue_NullOnlyStringData_ReturnsEmptyString()
+    {
+        s_readValue(new byte[sizeof(char)], REG_VALUE_TYPE.REG_SZ).Should().Be(string.Empty);
+    }
+
+    [TestMethod]
+    public void ReadValue_UnterminatedStringData_ReturnsCompleteString()
+    {
+        s_readValue([(byte)'A', 0], REG_VALUE_TYPE.REG_SZ).Should().Be("A");
+    }
+
+    [TestMethod]
+    public void ReadValue_TerminatedStringData_StripsTerminator()
+    {
+        s_readValue([(byte)'A', 0, 0, 0], REG_VALUE_TYPE.REG_SZ).Should().Be("A");
     }
 }

--- a/src/thirtytwo_tests/thirtytwo_tests.csproj
+++ b/src/thirtytwo_tests/thirtytwo_tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="KlutzyNinja.Touki.TestSupport" PrivateAssets="all" />
     <PackageReference Include="MSTest" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- harden clipboard memory allocation, native error handling, and ownership transfer
- fix COM, WIC, `UNICODE_STRING`, and registry edge cases with focused tests using Touki TestSupport for private access
- add security, contribution, conduct, issue, and pull-request guidance for the pre-release repository

## Validation

- Debug and Release solution builds
- Debug and Release tests: 286 passed, 1 manual test skipped in each configuration
- Markdown lint and link validation
- NuGet vulnerability audit: no known vulnerable packages