### PR TITLE
Revendor agent skills v0.14.0

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -2,7 +2,7 @@
 
 This repository carries 13 portable skill cores from the
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills)
-commons, pinned to the immutable `v0.11.0` release. The installed core files
+commons, pinned to the immutable `v0.14.0` release. The installed core files
 carry `metadata.github-*` provenance injected by `gh skill install` and must
 remain exact upstream mirrors. Repository-specific paths and conventions live
 in each sibling `overlay.md`.
@@ -20,9 +20,9 @@ in each sibling `overlay.md`.
 | [engineering-baseline](engineering-baseline/SKILL.md) | Audit repository engineering and supply-chain practices. | Assesses the existing Windows-only repository; it does not scaffold over it. |
 | [github-actions-cost-optimization](github-actions-cost-optimization/SKILL.md) | Analyze GitHub Actions cost without weakening required checks. | Preserves the Windows runner required by product and test behavior. |
 | [il-copy-inspection](il-copy-inspection/SKILL.md) | Inspect emitted IL for copies and boxing of structs and ref structs. | Focuses on handles, COM scopes, message views, and buffer scopes. |
-| [manage-skills](manage-skills/SKILL.md) | Find, add, update, and reconcile skills. | Owns the pinned-core plus local-overlay lifecycle for this catalog. |
+| [manage-skills](manage-skills/SKILL.md) | Find, build, review, update, retire, and reconcile skills. | Owns the pinned-core plus local-overlay lifecycle for this catalog. |
 | [pre-pr-self-review](pre-pr-self-review/SKILL.md) | Review the working diff before publishing. | Runs Debug and Release checks and invokes security review for unsafe changes. |
-| [scratch-buffer-strategy](scratch-buffer-strategy/SKILL.md) | Choose among stack, pooled, and heap scratch buffers. | Binds to `StackBufferScope16<T>`, `ValueBuffer<T>`, and the modern-only TFM. |
+| [scratch-buffer-strategy](scratch-buffer-strategy/SKILL.md) | Choose among stack, pooled, and heap scratch buffers. | Binds to `BstrBuffer`, `ValueBuffer<T>`, and the modern-only TFM. |
 | [security-review](security-review/SKILL.md) | Audit unsafe code, native boundaries, malformed input, and resource ownership. | Uses the mirrored product/test layout and Windows interop threat surface. |
 
 ## Selection boundary
@@ -84,9 +84,10 @@ overlay:
 gh skill install JeremyKuhne/agent-skills skills/<name> --pin vX.Y.Z --agent github-copilot --scope project --force
 ```
 
-Install `cswin32-interop` before `cswin32-com`, update every affected
-overlay's `core-pin`, and review the resulting diff. Never hand-edit a vendored
-core to resolve drift.
+Install hard dependencies before their consumers: `agent-files-review` before
+`manage-skills`, and `cswin32-interop` before `cswin32-com`. Update every
+affected overlay's `core-pin` and review the resulting diff. Never hand-edit a
+vendored core to resolve drift.
 
 ## Validation
 

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/address-pr-feedback
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
+    github-tree-sha: 7db8903886f6ce4509f97eae6f72fca6c883abe0
     maturity: canary
     portability: portable
     related: create-pr, pre-pr-self-review, agent-files-review
@@ -33,10 +33,9 @@ authorizes you to *edit*:
 - This skill authorizes editing files in response to review feedback or
   CI failures on an existing PR. Same approval gate before commit/push.
 
-Your repo's agent guidance (the "Working with the user on changes" rules in
-`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
-at the start of every invocation; this skill is the decision-point reminder, not
-a replacement.
+Repository guidance is the source of truth for commit/push approval. Re-read it
+at the start of every invocation when present; this skill is a reminder, not a
+replacement.
 
 ## Recognizing approval
 
@@ -65,11 +64,15 @@ Stop and ask one short yes/no question.
 
 ## Workflow
 
-1. **Fetch the feedback.** Read review comments, PR conversation, and check-run
-   logs via the GitHub PR tools (or `Invoke-RestMethod` against
-   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`). With multiple
-   review passes, fetch the **latest** review's comments (filter by the newest
-   review id) so you act on the current round.
+1. **Confirm the PR is open, then fetch feedback.** If it was merged, stop and
+    propose a user-approved follow-up such as a revert or new PR. If it was closed
+    without merging, stop and propose reopening it or creating a new PR. Do not
+    mutate the old branch in either case. Read every unresolved review thread
+    across all review passes, including replies, plus the PR conversation and
+    compact check statuses. Fetch logs only for failed checks being investigated.
+    Do not filter by newest review id - older unresolved threads remain
+    actionable. Prefer a PR tool; use
+    [thread-workflow.md](thread-workflow.md) for the `gh` fallback.
 
    Automated reviewers (e.g. Copilot) post asynchronously - on open, on push, or
    when requested - a minute or two after the trigger. If one was requested but
@@ -92,27 +95,33 @@ Stop and ask one short yes/no question.
    commit`, or `git push`.
 5. **Wait** for an explicit publishing verb (see "Recognizing approval"
    above).
-6. **Only then** stage by path, commit with a message that summarizes the
-   round of changes, and push. The staging/commit/push mechanics are the
-   same as in the `create-pr` skill (its "Commit changes" and "Push the
-   branch" steps).
-7. **Resolve the threads, with explanations.** Replying and resolving are remote
-   actions, so they ride in the same approved publish step as the push; honor
-   explicit scoping ("push and resolve only", "don't re-request") and report
-   what you did. For each comment, reply then resolve:
-   - **Fixed** - one line on what changed (reference the commit or behavior).
-   - **False positive / won't-fix** - the rationale or the evidence. Leave a
-     thread open only to invite a human onto a contested point, and say so.
-   With the PR tool, use its resolve action; with `gh`, resolve via the GraphQL
-   `resolveReviewThread` mutation on the thread node id (not the comment id).
-8. **Re-request review when non-trivial.** After real code changes, request a
-   fresh pass from the same reviewer - also a remote action in the publish step.
-   Skip it for trivial rounds (typo, reword, one-line nit) to avoid an endless
-   trickle, and say which you did.
+6. **Only then** recheck that the PR is open before staging or committing. Commit
+    the round, then confirm the PR is still open immediately before each remote
+    write in steps 6-8; abort and report if it is not. Push using the mechanics in
+    the `create-pr` skill.
+7. **Reply in-thread, then resolve.** These are PR write actions. Follow repository
+    guidance; when it does not bundle them with push/update approval, get explicit
+    approval. Refresh each targeted thread before writing: skip one already
+    resolved, and reclassify one with new replies. Write one scoped reply per
+    thread: state what changed for a fix, or give the evidence for a false positive
+    or won't-fix. Do not combine answers across threads or post the review summary
+    to the PR conversation. Leave a thread open only to invite a human onto a
+    contested point, and say so.
+    Verify both operations; a reply does not resolve a thread. Report what you did.
+8. **Get the next review when non-trivial.** If the repository automatically
+    reviews pushes, never request or re-request review; let the automatic pass run
+    without polling. Otherwise, after real code changes, request a fresh pass from
+    the same reviewer using the repository's PR-write approval policy. Skip a
+    manual request for trivial rounds (typo, reword, one-line nit), and say which
+    path applies.
 
 **When to stop.** Later auto-review passes drift toward nits and false positives.
-Once comments stop being substantive, stop re-requesting, say so, and let the
-user merge.
+Before calling the PR ready, confirm it is open, non-draft, mergeable, required
+checks and reviews are satisfied, no review threads remain unresolved, and the
+latest requested or automatic review has completed. Account for every actionable
+PR-conversation comment with a response or recorded disposition as well.
+Otherwise report what is pending. Once comments stop being substantive, stop
+requesting additional manual reviews and let the user merge.
 
 ## When you've already violated the rule
 
@@ -123,7 +132,7 @@ force-push, or leave the commit in place.
 
 ## Related
 
-- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- Repository agent guidance, when present - the local approval rule.
 - The `create-pr` skill - opening the initial PR (same publish gate,
   different edit scope).
 - The `pre-pr-self-review` skill - the validation checklist that applies

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: address-pr-feedback
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Address PR feedback overlay

--- a/.agents/skills/address-pr-feedback/thread-workflow.md
+++ b/.agents/skills/address-pr-feedback/thread-workflow.md
@@ -1,0 +1,103 @@
+# GitHub review-thread fallback
+
+Use this only when the PR tool cannot list, reply to, or resolve review threads.
+Target the repository that owns the PR explicitly; the checkout may be a fork.
+
+Create each query and reply file below with a unique name in the OS temporary
+directory, never in the repository. Delete it immediately after use.
+
+## Fetch all unresolved feedback
+
+Save the thread query:
+
+```graphql
+query(
+  $owner: String!
+  $repo: String!
+  $number: Int!
+  $endCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        nodes { id isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Replace the uppercase tokens below with actual values and temporary-file paths.
+Run the query with pagination and keep unresolved thread node IDs:
+
+```text
+gh api graphql --paginate -F owner=BASE_OWNER -F repo=BASE_REPO -F number=PULL_NUMBER -F query=@THREADS_QUERY_FILE --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id'
+```
+
+For each unresolved thread, save and run this paginated comments query:
+
+```graphql
+query($threadId: ID!, $endCursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $endCursor) {
+        nodes {
+          id
+          body
+          url
+          path
+          line
+          author { login }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+```text
+gh api graphql --paginate -F threadId=THREAD_NODE_ID -F query=@COMMENTS_QUERY_FILE --jq '.data.node.comments.nodes[]'
+```
+
+Classify every unresolved thread after reading all its replies.
+
+## Reply in-thread
+
+Write the response to a unique temporary Markdown file, then use the thread node
+ID to reply. This cannot create a top-level PR comment:
+
+```graphql
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(
+    input: { pullRequestReviewThreadId: $threadId, body: $body }
+  ) {
+    comment { id url body }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F body=@REPLY_FILE -F query=@REPLY_QUERY_FILE --jq '.data.addPullRequestReviewThreadReply.comment'
+```
+
+Require a non-null comment `id` before reporting that the reply was posted.
+
+## Resolve separately
+
+Save and run the resolve mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F query=@RESOLVE_QUERY_FILE --jq '.data.resolveReviewThread.thread'
+```
+
+Require `isResolved: true` before reporting success.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: agent-customization
     binding: optional-overlay
     github-path: skills/agent-files-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
     maturity: canary

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: agent-files-review
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Agent files review overlay

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -5,8 +5,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/code-comprehension
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
     maturity: canary

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: code-comprehension
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Code comprehension overlay

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/create-pr
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
+    github-tree-sha: 6fef038602c67d66b0c8278e8f7681b56803a95f
     maturity: canary
     portability: portable
     related: pre-pr-self-review, address-pr-feedback
@@ -34,6 +34,12 @@ once the user supplies an explicit publishing verb - `commit`, `push`,
 `ship it`, or equivalent. See your repo's agent guidance (the "Working with
 the user on changes" rules in `AGENTS.md`) for the canonical rule and the
 recurring not-approval phrasings.
+
+Branch-name confirmation is a separate prerequisite, not part of publish
+approval. If the current branch is `main`, do not choose or create a branch
+until the user confirms its name. In a non-interactive run where confirmation
+cannot be requested, stop and report the proposed name; never infer confirmation
+from the request to open a PR.
 
 Before running this workflow, walk through the `pre-pr-self-review` checklist -
 it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
@@ -67,6 +73,9 @@ Decide the PR base:
   before creating it. Offer the suggested kebab-case name and a way to enter a
   different name. If the host has no structured question tool, ask in chat.
   Known client adapters are in [host-adapters.md](host-adapters.md).
+- **Do not run `git switch -c`, `git checkout -b`, or `git branch <name>` until
+  that confirmation is received.** If the host cannot ask in the current mode,
+  stop with the proposed branch name.
 - Use `git switch -c <branch>` to move uncommitted changes onto the new
   branch.
 - If already on a non-`main` branch, keep using it.

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: create-pr
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Create PR overlay

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/cswin32-com
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 16f0e262ed5b4a11f90a91b70cb4b9ab473a3d1a
     maturity: canary

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: cswin32-com
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # CsWin32 COM overlay

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/cswin32-interop
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 14960bec081ff29eaa9bf5593b7a6ca9d5201ae8
     maturity: canary

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: cswin32-interop
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # CsWin32 interop overlay

--- a/.agents/skills/engineering-baseline/SKILL.md
+++ b/.agents/skills/engineering-baseline/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/engineering-baseline
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: b0e52e484192142c2b3083ee181b4f7a5b61b0d6
     maturity: canary

--- a/.agents/skills/engineering-baseline/overlay.md
+++ b/.agents/skills/engineering-baseline/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: engineering-baseline
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Engineering baseline overlay

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/github-actions-cost-optimization
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
     maturity: canary

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: github-actions-cost-optimization
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # GitHub Actions cost optimization overlay

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/il-copy-inspection
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
     maturity: canary

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: il-copy-inspection
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # IL copy inspection overlay

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -1,19 +1,19 @@
 ---
 compatibility: Requires gh 2.90 or later for install and update operations; manual file comparison remains available without gh.
-description: Find, add, update, and share agent skills in this repo. Use when asked to "find a skill" for a task, "build a skill" or "create a skill" (this skill checks whether one already exists - in the repo, the shared commons, or a public catalog - before authoring a new one), "update a skill", or reconcile a local skill change against the upstream commons vs a repo-local overlay. Covers the find-first build path, the tiered search, and the pull/push update flow. Not for validating one agent file's syntax - that is `agent-files-review`.
+description: Find, build, review, update, retire, and share agent skills in this repo. Use when asked to find a skill, build/create one (find runs first), review its trigger routing or workflow effectiveness, update/sync it, retire/remove it, or reconcile a local change against the commons vs an overlay. Covers tiered search, find-first building, semantic invocation/workflow review, pull/push updates, and safe retirement. For frontmatter/schema/link diagnostics, use `agent-files-review`.
 license: MIT
 metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/manage-skills
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 5b881e8d4c0a1d5e9bdf3d48cb91d515088e44d2
+    github-tree-sha: 6bc60008f36bf9686bbfedb42a87a1b8c85bf103
     maturity: canary
     portability: portable
-    related: agent-files-review
-    requires: none
+    related: none
+    requires: agent-files-review
     risk: remote-write
 name: manage-skills
 ---
@@ -23,9 +23,10 @@ If `overlay.md` exists beside this file, read it before acting; it contains
 repository-specific bindings. This core remains usable without it.
 
 The lifecycle skill for the skills under a repo's `.agents/skills/`: discover one,
-add one, update one, and keep local changes in sync with the shared set. It turns
-"find a skill", "build a skill", and "update the skill" into actions aligned with
-the sharing model instead of ad-hoc edits.
+add one, review whether it guides agents effectively, update or retire it, and keep
+local changes in sync with the shared set. It turns "find a skill", "build a skill",
+"is this skill effective", "update the skill", and "remove this skill" into actions
+aligned with the sharing model instead of ad-hoc edits.
 
 The model in one paragraph: skills are authored once as a portable **core** and
 shared through a common skills repo (the **commons**); each consuming repo holds a
@@ -33,16 +34,21 @@ pinned, provenance-stamped **copy** plus a thin repo-specific **overlay**. The
 commons is bidirectional - a generic improvement made in any repo flows back
 upstream, while a repo-specific tweak lives only in that repo's overlay.
 
-## The three verbs
+## The five verbs
 
 | Ask | Do | Detail |
 | --- | --- | ------ |
 | "find a skill for X", "is there a skill that does X" | Tiered search (local -> commons -> public), with an applicability check for this repo. | [find.md](find.md) |
 | "build a skill for X", "create a skill" | **Run find first.** Only author new if it exists nowhere; otherwise vendor or tweak the existing one. | [build.md](build.md) |
+| "review this skill", "is this skill effective" | Review invocation, workflow closure, progressive disclosure, portability, and lifecycle placement; then hand file validation to `agent-files-review`. | [review.md](review.md) |
 | "update the skill", "sync my change", "pull skill updates" | Pull upstream drift; or push a local improvement, classified common (ask before upstreaming) vs deviation (overlay). | [update.md](update.md) |
+| "retire this skill", "remove this skill" | Find dependents and replacements first, then deprecate or remove without leaving stale routing, catalog, packaging, or validation state. | [retire.md](retire.md) |
 
-These chain: `build` always begins by running `find`, and a `find` that turns up a
-local skill needing a tweak hands off to the overlay path in `build`.
+These chain: `build` always begins with `find`; `build` and `update` finish with
+`review`; and `review` finishes with `agent-files-review` for file-level validation.
+A local skill that needs a tweak follows `update` so core/overlay ownership stays
+explicit. `retire` begins with a dependency/routing inventory and finishes with a
+review of the replacement path plus `agent-files-review`.
 
 ## The golden rule
 
@@ -88,13 +94,19 @@ path and concrete cross-reference in that overlay.
   recommendation report.
 - [build.md](build.md) - the find-first decision tree, the security gate for
   public sources, and authoring a new skill (born-local vs born-shared).
+- [review.md](review.md) - semantic and lifecycle review: invocation, agent
+  execution, progressive disclosure, portability, overlap, and maintenance.
 - [update.md](update.md) - the pull (drift) and push (common vs deviation)
   flows and the provenance mechanics behind the golden rule.
+- [retire.md](retire.md) - dependency-first deprecation or removal without stale
+  routing, catalog, packaging, or validation state.
 
 ## Disambiguation
 
-`manage-skills` operates on the **catalog lifecycle** - discover, add, vendor,
-sync. It is not `agent-files-review`, which
-validates the **syntax and conventions** of one agent file (frontmatter, mirror
-sync, whitespace). The normal order is: run `manage-skills` to bring a skill in
-or push one out, then `agent-files-review` to validate the file you ended up with.
+`manage-skills` operates on **skill lifecycle and effectiveness**: discover, add,
+review semantic workflow quality, vendor, and sync. It is not
+`agent-files-review`, which validates **agent-file correctness**: frontmatter,
+schema/conventions, mirror sync, whitespace, links, and diagnostics. A complete
+skill review uses both in that order; neither substitutes for the other. For an
+overlay, `manage-skills` decides what belongs there, while `agent-files-review`
+validates the resulting overlay file.

--- a/.agents/skills/manage-skills/build.md
+++ b/.agents/skills/manage-skills/build.md
@@ -19,9 +19,21 @@ catalog - is the failure mode this path exists to prevent. Always run
    gh skill install JeremyKuhne/agent-skills <skill> --pin vX.Y.Z
    ```
 
+    Read the selected revision's `metadata.requires` and install its complete
+    transitive requirement closure at the same pin; `gh skill install` installs
+    only the named skill. Review each requirement's applicability and source before
+    installing it.
+
    `--pin` records the exact version so later `update --all` runs skip it until
    you deliberately re-pin. The install writes provenance frontmatter (source
    repo, ref, and tree SHA); commit it.
+
+   Without `gh`, check out or download the exact tag/commit, copy the complete
+  directory for the skill and each transitive requirement (not only each
+  `SKILL.md`), preserve or add provenance metadata for that immutable revision, add
+  the local overlay, and compare every copied file list and hash against the source
+  before running the validators. If an exact revision or complete file set cannot
+  be obtained, keep vendoring blocked.
 4. **In a public catalog** -> do not build from scratch. Apply the security gate
    below. If it is good, vendor it; if it is close but imperfect, fork it into the
    commons and vendor that. A mediocre public skill is usually worth adapting over
@@ -66,6 +78,12 @@ Author it to the repo's `FORMAT.md`:
   mode, then run the repo's remaining agent-file checks (the installed-artifact
   link check, markdown lint, and generated catalog check).
 
+Before calling the skill complete, run the semantic workflow review in
+[review.md](review.md), then hand the resulting files to `agent-files-review` for
+frontmatter, links, whitespace, and repository diagnostics. A validator pass does
+not establish that the skill will invoke at the right time or lead an agent to a
+finished outcome.
+
 ### Born-local vs born-shared
 
 Decide where the skill's home is before writing much:
@@ -73,12 +91,16 @@ Decide where the skill's home is before writing much:
 - **Born-local** - the skill is specific to this repo (its paths, projects, or
   one-off workflow). Author it here under `.agents/skills/` and leave it; it never
   goes to the commons.
-- **Born-shared** - the skill is generic and other repos will want it. Author the
-  portable core directly in the commons, then vendor it back here with an overlay.
-  Keep repo-specific paths, cross-references, and example links out of the core
-  from the start - they belong in the overlay. Leave a short prose cue in the core
-  telling the agent to read `overlay.md` when present; that stable loader contract
-  is what gets the overlay read.
+- **Born-shared** - the skill is generic and other repos will want it. First ask the
+  user whether to pursue commons authoring, as required by [update.md](update.md).
+  Prepare and validate the portable core in a commons checkout or local staging
+  branch, but do not create a remote branch, push, or open a PR without the
+  repository's explicit approvals. Once the shared change is merged and released,
+  vendor that immutable revision back here with an overlay. Keep repo-specific
+  paths, cross-references, and example links out of the core from the start - they
+  belong in the overlay. Leave a short prose cue in the core telling the agent to
+  read `overlay.md` when present; that stable loader contract is what gets the
+  overlay read.
 
 A skill that is mostly generic but needs a few local specifics is still
 born-shared: the generic part is the core, the specifics are the overlay. The test

--- a/.agents/skills/manage-skills/find.md
+++ b/.agents/skills/manage-skills/find.md
@@ -20,8 +20,10 @@ because a local hit changes the recommendation entirely.
    gh skill search <terms> --repo JeremyKuhne/agent-skills
    ```
 
-   Anything here is curated and pre-vetted. When `gh` is unavailable, browse the
-   commons repo directly and note that the install path will be manual.
+    Anything here is curated and pre-vetted. When `gh` is unavailable, browse the
+    commons repository's `skills/` directory, read candidate descriptions and
+    metadata, and record the release tag or commit for a later pinned manual install.
+    Do not treat the moving default branch as the pin.
 
 3. **Public catalogs.** Search the wider ecosystem - the awesome-copilot
    collection, `anthropics/skills`, and the registry:
@@ -32,8 +34,8 @@ because a local hit changes the recommendation entirely.
 
    Public results are **untrusted by default**. Do not recommend installing one
    without the security gate in [build.md](build.md). When `gh` is unavailable,
-   fall back to browsing the catalogs in a browser and note that the install path
-   will be manual.
+   browse the same catalogs manually, record the exact source revision, and keep
+   installation blocked until every source file and script can be reviewed.
 
 ## Applicability check
 

--- a/.agents/skills/manage-skills/overlay.md
+++ b/.agents/skills/manage-skills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: manage-skills
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Manage skills overlay
@@ -15,7 +15,7 @@ Repository-specific bindings for thirtytwo.
 - Put thirtytwo paths, commands, examples, and cross-skill links in
   `overlay.md`. The local [catalog](../README.md) and
   [format contract](../FORMAT.md) are also downstream-owned.
-- The current portfolio is reviewed against the immutable `v0.11.0` release.
+- The current portfolio is reviewed against the immutable `v0.14.0` release.
 
 ## Pulling a commons release
 
@@ -25,9 +25,10 @@ Use the exact source path and an immutable pin:
 gh skill install JeremyKuhne/agent-skills skills/<name> --pin vX.Y.Z --agent github-copilot --scope project --force
 ```
 
-Install `cswin32-interop` before its required consumer `cswin32-com`. Preserve
-the local overlay, update its `core-pin`, update the catalog when the portfolio
-changes, and review the normal diff.
+Install hard dependencies before their consumers: `agent-files-review` before
+`manage-skills`, and `cswin32-interop` before `cswin32-com`. Preserve the local
+overlay, update its `core-pin`, update the catalog when the portfolio changes,
+and review the normal diff.
 
 ## Validation
 

--- a/.agents/skills/manage-skills/retire.md
+++ b/.agents/skills/manage-skills/retire.md
@@ -1,0 +1,94 @@
+# Retire a skill
+
+Detail for the [manage-skills](SKILL.md) skill. Use for "retire this skill",
+"remove this skill", or when a review finds that a skill is obsolete, duplicated,
+or replaced.
+
+Retirement is dependency-first. Deleting a directory before rerouting its consumers
+leaves stale triggers, broken `requires`/`related` metadata, catalog entries,
+packaging lists, validators, and generated instructions.
+
+## 1. Establish the reason and replacement
+
+Record why the skill is leaving and choose one disposition:
+
+| Disposition | Use when | Outcome |
+| --- | --- | --- |
+| Replace | Another skill owns the workflow better | Reroute consumers, then remove the old skill. |
+| Deprecate first | External consumers need migration time | Document the replacement and migration in the source catalog/release before later removal. |
+| Remove now | The skill is local, unused, unsafe, or never applicable | Delete it after proving no live dependency remains. |
+
+Do not invent unsupported `deprecated` frontmatter. Express deprecation through the
+source catalog/release and narrowed routing until removal.
+
+## 2. Inventory dependents and ownership
+
+Search for the skill name, directory path, and workflow vocabulary in:
+
+- catalog inventory and disambiguation;
+- `requires`, `related`, descriptions, overlays, prompts, agents, and instructions;
+- CI/validator expected-skill lists, generated catalogs, packaging include/remove
+  lists, docs, tests, and eval tasks;
+- repository scripts or examples that invoke the skill directly.
+
+Use repository text/reference search rather than relying on a fixed path list. Skill
+catalogs and expected inventories are commonly under `.agents/`, `.github/`, `tools/`,
+package/project files, and contribution docs, but consuming repositories may bind
+different locations in their overlays.
+
+Classify ownership before acting:
+
+- Removing a vendored skill from one consuming repo is a local reversible edit, but
+  still requires the user's current request to authorize removal; it does not remove
+  the upstream skill.
+- Retiring a commons core is a shared breaking/lifecycle decision. Stop and obtain
+  explicit user approval before creating an upstream branch or deleting shared
+  source; pushing, opening a PR, releasing, or merging each remains separately gated
+  by the repository's publishing policy.
+- Remove any pending-upstream divergence record for the skill when the local copy
+  leaves.
+
+## 3. Reroute before deletion
+
+Update callers and neighboring skill boundaries first. The replacement description
+and catalog disambiguation must cover valid requests previously owned by the retiring
+skill without broadening into unrelated work. Remove or replace dependency metadata;
+do not leave a `related` or `requires` edge to a missing skill.
+
+If there is no replacement, state which requests become unsupported and why. For an
+unsafe public import, remove execution permissions and references in the same change.
+
+## 4. Remove lifecycle state
+
+After rerouting is reviewable:
+
+If the disposition is **Deprecate first**, publish the approved migration notice and
+validate the replacement path, then stop. Keep the deprecated skill and its required
+lifecycle state until the separately approved removal milestone.
+
+For **Replace** or **Remove now**:
+
+1. delete the skill core and overlay from the consuming repo;
+2. remove catalog rows and obsolete disambiguation;
+3. update expected-skill lists, package manifests, generated collateral, docs, tests,
+   and evals;
+4. remove pin/provenance and pending-divergence records owned only by that skill;
+5. regenerate mirrors/catalogs through their owning tools rather than hand-editing
+   generated files.
+
+Do not remove unrelated historical release notes merely because they mention the
+skill; preserve history unless it still acts as live routing or instructions.
+
+## 5. Prove closure
+
+Run a semantic review of the replacement and neighboring trigger domains using
+[review.md](review.md). Exercise one request formerly owned by the retired skill and
+one near-neighbor that should not route to the replacement. Then invoke
+`agent-files-review` for file-level validation and run repository validators, link
+checks, generated-catalog checks, packaging checks, and upstream mirror checks.
+
+The retirement is complete when no live dependency or routing reference points to
+the removed skill, the replacement path reaches an observable outcome, and the
+repository's expected skill inventory matches disk. Report the disposition,
+replacement or unsupported scope, validation evidence, and any external migration
+still pending.

--- a/.agents/skills/manage-skills/review.md
+++ b/.agents/skills/manage-skills/review.md
@@ -1,0 +1,144 @@
+# Review a skill
+
+Detail for the [manage-skills](SKILL.md) skill. Use this workflow for "review this
+skill", "is this skill effective", or as the semantic review pass after building or
+updating a skill.
+
+This page reviews whether a skill will invoke appropriately and lead an autonomous
+agent through a complete, maintainable workflow. It deliberately does **not** repeat
+frontmatter, schema, whitespace, link, or diagnostic checks. Those belong to
+`agent-files-review`, which runs after this review.
+
+## Choose the review scope
+
+| Change | Review emphasis |
+| --- | --- |
+| New skill | Need, trigger boundaries, full workflow, born-local/shared placement |
+| Existing skill effectiveness | Missed/false invocation, agent stalls, excessive context, missing stop/recovery paths |
+| Vendored update | Behavioral drift, new dependencies, overlay compatibility, provenance/pin disposition |
+| Local core edit | Common vs local classification and upstream/overlay/pending-divergence outcome |
+| Portfolio review | Trigger overlap, catalog disambiguation, duplicate skills, missing prerequisites |
+
+Review the smallest relevant surface: catalog row and neighboring trigger domains,
+`SKILL.md`, overlay, then only the detail pages/scripts reached by the workflow under
+review. Do not map every sibling file when one branch is changing.
+
+- **New skill:** use every section.
+- **Effectiveness issue:** emphasize evidence, routing, execution, and progressive
+  disclosure; use portability/validation only where the fix touches them.
+- **Vendored update or local core edit:** emphasize routing drift, portability,
+  ownership disposition, overlay compatibility, and validation.
+- **Portfolio review:** repeat routing/applicability checks across neighboring skills;
+  do not deep-read unrelated recipes.
+
+## 1. Establish evidence before judging prose
+
+Start from the concrete reason for review: user feedback, a missed invocation, an
+agent transcript, a changed file, validator failure, or a workflow that stalled.
+Write one falsifiable hypothesis (for example, "the description never names the
+user's phrase" or "the update path does not dispose of local core drift") and the
+cheapest check that can disprove it.
+
+When no failure prompted the review, exercise representative requests mentally or
+with the repository's eval harness:
+
+- one request that should invoke the skill;
+- one near-neighbor that should route elsewhere;
+- one ordinary happy path;
+- one missing prerequisite or failed tool path;
+- one completion path that proves the user's outcome, not merely file creation.
+
+## 2. Review invocation and portfolio routing
+
+- **Description:** names concrete user phrases and outcomes, not only the domain.
+- **Boundaries:** says what routes elsewhere when adjacent skills overlap.
+- **Catalog:** inventory and disambiguation agree with the description.
+- **Applicability:** project-gated prerequisites are present or explicitly separate
+  setup work; irrelevant skills are not vendored "just in case".
+- **Dependencies:** `requires` and `related` match actual workflow routing; optional
+  skills have a local fallback instead of a dead end.
+
+Treat false positives and false negatives separately. Broader trigger wording is not
+automatically better: it may steal work from a more precise skill.
+
+## 3. Review agent execution
+
+An effective skill lets an agent decide, act, validate, and stop without inventing
+missing policy.
+
+- The entry point exposes a fast decision path; deep detail is linked, not front-loaded.
+- Preconditions, permissions, irreversible actions, and secret boundaries are explicit.
+- Decision branches name the next action and the evidence that selects it.
+- Happy path, absent dependency, malformed/failed output, and cleanup/recovery paths
+  are distinguishable where policy differs.
+- Expensive workflows (for example performance runs or repository-wide audits) have
+  budgets, escalation gates, and hard stop conditions.
+- Validation follows the first edit and scales with risk.
+- Completion is an observable user outcome with a concise report of evidence and
+  remaining gaps.
+
+Flag instructions that only say "consider", "review", or "ensure" without naming a
+check, owner, or next action. Also flag unconditional guarantees whose invariant is
+not stated or tested.
+
+## 4. Review progressive disclosure and cognitive load
+
+- Keep `SKILL.md` focused on triggers, non-negotiable rules, workflow selection, and
+  links to detail.
+- Put long recipes, references, platform variants, and uncommon recovery procedures
+  in purpose-named sibling pages.
+- Prefer one canonical rule with short pointers over duplicated checklists that can
+  drift.
+- Use tables for routing/selection, numbered steps for sequence, and checklists for
+  independent gates.
+- Keep vocabulary stable across the core, overlay, catalog, scripts, and output.
+- Remove historical narrative unless it changes a current decision; retain durable
+  lessons as rules with the boundary that makes them true.
+
+Detail is useful when it changes agent behavior. It is harmful when an agent must
+retain unrelated branches in working memory before choosing the first action.
+
+## 5. Review portability and lifecycle placement
+
+- Portable behavior belongs in the core; repository paths, commands, defaults, and
+  local policy belong in the overlay.
+- A new skill is born-shared when another repository would want the core unchanged;
+  otherwise it is born-local.
+- A vendored core edit ends upstreamed, moved to the overlay, or recorded as a
+  pending-upstream divergence with its files, base pin, reason, and upstream status.
+  Never accept unexplained drift.
+- Re-review overlays when a core pin changes; a syntactically valid overlay can bind
+  obsolete assumptions.
+- Public-source imports pass the security gate in [build.md](build.md), retain an
+  immutable pin, and do not inherit third-party tool permissions blindly.
+
+## 6. Review validation and maintenance
+
+Require the narrowest semantic check that can fail the changed behavior: routing
+examples, eval tasks, fake adapters, script contract tests, or a representative dry
+run. Then invoke `agent-files-review` for file-level validation and run the consuming
+repository's validator, link checker, markdown checks, generated-catalog checks, and
+upstream mirror check as applicable.
+
+For a changed vendored skill, verify both sides:
+
+- local comparison against the provenance pin makes additional drift visible;
+- upstream comparison shows whether each recorded divergence remains at the candidate
+  pin, and records are removed once that artifact contains the change.
+
+## Review output
+
+Lead with findings ordered by severity and grounded in file/section references.
+Separate:
+
+1. invocation/routing defects;
+2. workflow, safety, or completion defects;
+3. portability/lifecycle defects;
+4. progressive-disclosure and maintainability issues;
+5. missing semantic tests or evidence.
+
+Then state the ownership disposition (core, overlay, upstream, or pending divergence),
+the `agent-files-review` result, commands run, and residual risk. If no issues remain,
+say so explicitly rather than manufacturing style churn: "Semantic review complete;
+no invocation, workflow, portability, or lifecycle defects found. Proceeding to
+agent-files-review."

--- a/.agents/skills/manage-skills/update.md
+++ b/.agents/skills/manage-skills/update.md
@@ -52,9 +52,11 @@ common, and the options:
 - **Upstream it now** - prepare the PR to the commons; *creating* it still needs an
   explicit publish verb from the user. Once merged, re-vendor here at the new pin.
 - **Not now / not plausible** - keep the change in the local core as a *tracked
-  pending-upstream divergence*: record it (in the commit message and a short note)
-  so the drift check's later alarm is expected, not a surprise. Re-attempt
-  upstreaming when it becomes plausible; re-pinning clears the divergence.
+  pending-upstream divergence*: record it in the commit message and the repository's
+  divergence ledger or a short note. Identify the skill, affected files, base pin,
+  reason, and upstream status so the drift check's later alarm is expected, not a
+  surprise. Re-attempt upstreaming when it becomes plausible; remove the record when
+  the pinned upstream artifact contains the change.
 - **Reclassify** - if discussion shows the change is actually repo-specific, move
   it to the overlay instead and restore the core.
 
@@ -89,7 +91,10 @@ core.
 
 ## After any update
 
-Re-run the validators and the link check, and if the change touched the catalog
-or a skill's trigger phrasing, reconcile the catalog `README.md` (inventory row,
-disambiguation) in the same change. Then hand off to the repository's
-`agent-files-review` skill to validate the resulting files.
+Run [review.md](review.md) against the changed routing, workflow, and ownership
+surface. Re-run the validators and link check, and if the change touched the catalog
+or trigger phrasing, reconcile the catalog `README.md` (inventory row and
+disambiguation) in the same change. Then hand off to `agent-files-review` to validate
+the resulting files; semantic lifecycle review does not replace file-level review.
+If the skill is obsolete rather than changed, follow [retire.md](retire.md) instead
+of forcing removal into the update path.

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/pre-pr-self-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: c172ca7a01a7368bb4fee88b4d0b756442d38976
     maturity: canary

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: pre-pr-self-review
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Pre-PR self-review overlay

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/scratch-buffer-strategy
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
     maturity: canary

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,14 +1,14 @@
 ---
 core: scratch-buffer-strategy
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Scratch buffer strategy overlay
 
 Repository-specific bindings for thirtytwo.
 
-- [StackBufferScope16<T>](../../../src/thirtytwo/Support/StackBufferScope16.cs)
-  provides 16 inline elements and falls back through `BufferScope<T>`.
+- [BstrBuffer](../../../src/thirtytwo/Win32/Foundation/BstrBuffer.cs) seeds a
+  `BufferScope<BSTR>` from inline storage and disposes each populated element.
 - [ValueBuffer<T>](../../../src/thirtytwo/Support/ValueBuffer.cs) grows from a
   caller-supplied span into an `ArrayPool<byte>` rental and is explicitly
   experimental.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/security-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.14.0
+    github-ref: refs/tags/v0.14.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 883a99623b74cd6f5bfc2e0706b71a1513d1c62f
+    github-tree-sha: 8f2b820c678065733b6582b6dcb1685bd49854f3
     maturity: canary
     portability: portable
     related: pre-pr-self-review, performance-testing, fuzz-testing

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -52,8 +52,8 @@ outside. Specialized fast paths often bypass the affected code
 - Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
   per call (acceptable if bounded), or grow without limit (red flag)?
 
-**Tests:** a "large but legitimate" input completes within a
-`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+**Tests:** a "large but legitimate" input completes within a `Stopwatch`
+bound (`Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2))`).
 Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
 allocation count.
 
@@ -73,17 +73,17 @@ allocation count.
 **Tests** (pin the safe property):
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Method_PathologicalInput_TerminatesPromptly()
 {
-    /* construct adversarial pattern + input */
+    /* construct adversarial pattern, input, matcher, and expected result */
 
-    Stopwatch sw = Stopwatch.StartNew();
-    bool result = m.IsMatch(input);
-    sw.Stop();
+    Stopwatch stopwatch = Stopwatch.StartNew();
+    bool result = matcher.IsMatch(input);
+    stopwatch.Stop();
 
-    result.Should().Be(/* expected */);
-    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+    Assert.AreEqual(expectedResult, result);
+    Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
 }
 ```
 

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: security-review
-core-pin: v0.11.0
+core-pin: v0.14.0
 ---
 
 # Security review overlay


### PR DESCRIPTION
## Summary

Revendor the repository's applicable agent skills from the latest immutable `JeremyKuhne/agent-skills` release, `v0.14.0`, and reconcile the local overlays and catalog.

## Changes

- update all 13 applicable portable skill cores and overlays from `v0.11.0` to `v0.14.0`
- add the upstream review, retirement, and review-thread workflow pages
- document hard-dependency installation order for `manage-skills` and `cswin32-com`
- refresh the skill catalog for the expanded manage-skills lifecycle and current scratch-buffer surfaces
- retain the five documented exclusions: two .NET Framework-only skills and three project-gated skills without perf, fuzz, or analyzer projects

## Validation

- [x] `dotnet build --configuration Release` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (286 passed, 1 manual test skipped)
- [x] New or changed behavior has focused tests (not applicable; no product behavior changes)
- [x] Native ownership, size units, and failure cleanup were reviewed when applicable (not applicable; no product code changes)
- [x] Agent-file validation passes when `.agents/` changed
  - strict portfolio validation: 13/13
  - `skills-ref@0.1.5`: 13/13
  - relative Markdown links and whitespace checks pass
  - semantic vendored-update review found no invocation, workflow, portability, lifecycle, or applicability defects

## Related issues

None.