### PR TITLE
Add UI dispatcher and thread context

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,9 +28,6 @@ dotnet_diagnostic.SA1307.severity = none
 # SA1313: Parameter names should begin with lower-case letter
 dotnet_diagnostic.SA1313.severity = none
 
-# IDE1006: Naming Styles
-dotnet_diagnostic.IDE1006.severity = none
-
 # CS0649:
 dotnet_diagnostic.CS0649.severity = none
 
@@ -40,6 +37,12 @@ dotnet_diagnostic.SA1313.severity = none
 
 # C# files
 [*.cs]
+
+# IDE1006: Naming Styles (replaced by TOUKI0041)
+dotnet_diagnostic.IDE1006.severity = none
+
+# TOUKI0041: Naming rule violation
+dotnet_diagnostic.TOUKI0041.severity = warning
 
 #### Core EditorConfig Options ####
 
@@ -193,40 +196,52 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
-# interfaces should being with I
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+# interfaces should begin with I
+touki_naming_rule.interface_should_begin_with_i.severity = warning
+touki_naming_rule.interface_should_begin_with_i.symbols = interface
+touki_naming_rule.interface_should_begin_with_i.style = begins_with_i
+touki_naming_symbols.interface.applicable_kinds = interface
+touki_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+touki_naming_style.begins_with_i.required_prefix = I
+touki_naming_style.begins_with_i.capitalization = pascal_case
 
 # name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+touki_naming_rule.constant_fields_should_be_pascal_case.severity = warning
+touki_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+touki_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+touki_naming_symbols.constant_fields.applicable_kinds = field
+touki_naming_symbols.constant_fields.required_modifiers = const
+touki_naming_style.pascal_case_style.capitalization = pascal_case
+
+# thread-static fields should have t_ prefix
+touki_naming_rule.thread_static_fields_should_have_prefix.severity = warning
+touki_naming_rule.thread_static_fields_should_have_prefix.symbols = thread_static_fields
+touki_naming_rule.thread_static_fields_should_have_prefix.style = thread_static_prefix_style
+touki_naming_symbols.thread_static_fields.applicable_kinds = field
+touki_naming_symbols.thread_static_fields.required_modifiers = static
+touki_naming_symbols.thread_static_fields.required_attributes = System.ThreadStaticAttribute
+touki_naming_symbols.thread_static_fields.applicable_accessibilities = private, internal, private_protected
+touki_naming_style.thread_static_prefix_style.required_prefix = t_
+touki_naming_style.thread_static_prefix_style.capitalization = camel_case
 
 # static fields should have s_ prefix
-dotnet_naming_rule.static_fields_should_have_prefix.severity = warning
-dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
-dotnet_naming_symbols.static_fields.applicable_kinds = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = camel_case
+touki_naming_rule.static_fields_should_have_prefix.severity = warning
+touki_naming_rule.static_fields_should_have_prefix.symbols = static_fields
+touki_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
+touki_naming_symbols.static_fields.applicable_kinds = field
+touki_naming_symbols.static_fields.required_modifiers = static
+touki_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+touki_naming_style.static_prefix_style.required_prefix = s_
+touki_naming_style.static_prefix_style.capitalization = camel_case
 
 # internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+touki_naming_rule.camel_case_for_private_internal_fields.severity = warning
+touki_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+touki_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+touki_naming_symbols.private_internal_fields.applicable_kinds = field
+touki_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+touki_naming_style.camel_case_underscore_style.required_prefix = _
+touki_naming_style.camel_case_underscore_style.capitalization = camel_case
 
 # Analyzer doesn't seem to respect the TFM coming from our Directory.Build.props
 # and complains about using "windows" specific APIs
@@ -449,6 +464,18 @@ dotnet_style_qualification_for_method = false:silent
 # Test .cs files
 [**/*Tests.cs]
 
+# Test names use Method_State_Expected words separated by underscores.
+touki_naming_rule.test_methods_should_use_pascal_words.severity = warning
+touki_naming_rule.test_methods_should_use_pascal_words.symbols = test_methods
+touki_naming_rule.test_methods_should_use_pascal_words.style = test_method_style
+touki_naming_symbols.test_methods.applicable_kinds = method
+touki_naming_style.test_method_style.word_separator = _
+touki_naming_style.test_method_style.capitalization = pascal_case
+
 # This doesn't work well with TheoryData
 # CA1861: Avoid constant arrays as arguments
 dotnet_diagnostic.CA1861.severity = none
+
+# Authored Win32 projections preserve native metadata and ABI names.
+[**/Win32/**/*.cs]
+dotnet_diagnostic.TOUKI0041.severity = none

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,23 @@ dotnet test --configuration Release --no-build --report-trx
 The file-dialog manual test is skipped during automated runs. Clipboard and
 other desktop-resource tests require an interactive Windows session.
 
+## Design principles
+
+### No test-only production code
+
+Never add a member, overload, factory, branch, dependency-injection hook, or
+abstraction to production code solely for testing, regardless of whether it is
+private, internal, or public. Production structure and member visibility are
+determined only by product behavior and product call sites.
+
+Tests should exercise the public contract when possible. When a focused test
+must reach existing non-public implementation, use `TestAccessor` from
+`KlutzyNinja.Touki.TestSupport`; do not create a production seam for it.
+
+Test-only production code creates unintended coupling for later product
+changes, obscures the real production surface during review, and leaves
+shipping code that has no product responsibility.
+
 ## Submitting changes
 
 1. Fork the repository and create a focused branch from `main`.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The solution includes Win32 sample applications under `src/samples/`. Some
 tests interact with desktop resources such as the clipboard and therefore
 require an interactive Windows session.
 
+## Documentation
+
+Start with [Writing a thirtytwo Application](docs/writing-a-thirtytwo-application.md)
+for guides to creating an application and dispatching work to its UI thread.
+
 ## Contributing and security
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a change. Report

--- a/docs/creating-and-running-an-application.md
+++ b/docs/creating-and-running-an-application.md
@@ -1,0 +1,154 @@
+# Creating and running an Application
+
+This guide covers the structure and lifetime of a thirtytwo application: create
+a Windows executable, construct a root window, run the UI message loop, handle
+window messages, and choose who disposes the window.
+
+## Create the executable project
+
+Use a Windows executable that targets the framework supported by thirtytwo and
+references the thirtytwo project or package. A minimal project file contains:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="path\to\thirtytwo.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+Replace the project-reference path with the path from the application project
+to `src/thirtytwo/thirtytwo.csproj`.
+
+## Create and run a root window
+
+Mark the entry point with `[STAThread]` and give `Application.Run` a factory for
+the top-level `MainWindow`:
+
+```csharp
+using Windows;
+
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+    {
+        Application.UseVisualStyles = true;
+        Application.Run(
+            () => new MainWindow(title: "My thirtytwo application"));
+    }
+}
+```
+
+`Application.Run` starts the dispatcher before invoking the factory. The root
+window and any controls it creates can therefore use `Window.Dispatcher` during
+construction and synchronous creation messages. `Application.Run` then shows
+and updates the root window and processes messages until that window is
+destroyed. Finally, it shuts down the dispatcher and disposes the window.
+
+`UseVisualStyles` defaults to `true`; set it before `Application.Run` when an
+application needs a different policy.
+
+`[STAThread]` is required by common Windows UI facilities such as COM dialogs
+and clipboard operations.
+
+## Customize the root window
+
+Derive from `MainWindow` to create controls, retain application state, or handle
+native messages. Override `WindowProcedure` for messages owned by the window and
+delegate unhandled messages to the base implementation:
+
+```csharp
+using Windows;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+
+internal sealed class ApplicationWindow : MainWindow
+{
+    public ApplicationWindow()
+        : base(title: "Paint example")
+    {
+    }
+
+    protected override LRESULT WindowProcedure(
+        HWND window,
+        MessageType message,
+        WPARAM wParam,
+        LPARAM lParam)
+    {
+        if (message == MessageType.Paint)
+        {
+            using DeviceContext deviceContext = window.BeginPaint();
+            deviceContext.DrawText(
+                "Hello from thirtytwo",
+                window.GetClientRectangle(),
+                DrawTextFormat.SingleLine
+                    | DrawTextFormat.Center
+                    | DrawTextFormat.VerticallyCenter);
+
+            return (LRESULT)0;
+        }
+
+        return base.WindowProcedure(window, message, wParam, lParam);
+    }
+}
+```
+
+Run the derived window in the same way:
+
+```csharp
+Application.Run(() => new ApplicationWindow());
+```
+
+Dispose child controls, brushes, fonts, and other resources owned by the window
+from its `Dispose(bool)` override before calling the base implementation.
+
+## Use a WindowClass directly
+
+For lower-level scenarios, `Application.Run` can create the root `Window` from
+a `WindowClass`:
+
+```csharp
+using Windows;
+
+WindowClass windowClass = new();
+Application.Run(windowClass, windowTitle: "WindowClass application");
+```
+
+Derive from `WindowClass` and override its `WindowProcedure` when the behavior
+belongs to the registered native window class rather than one managed `Window`
+instance. The overload that accepts a `Rectangle` also sets the initial bounds.
+
+## Control window ownership
+
+By default, `Application.Run` disposes the supplied window. Pass
+`disposeWindow: false` when the caller owns its managed lifetime:
+
+```csharp
+using MainWindow window = new(title: "Caller-owned window");
+Application.Run(window, disposeWindow: false);
+```
+
+Closing the root window still destroys its native handle and ends the message
+loop. The option changes who disposes the managed object; it does not keep the
+native window alive after it is closed.
+
+## Run applications sequentially
+
+Only one outer message loop can run on a thread at a time. After one call
+returns, the same thread can run another window with a fresh dispatcher:
+
+```csharp
+Application.Run(() => new MainWindow(title: "First window"));
+Application.Run(() => new MainWindow(title: "Second window"));
+```
+
+Do not call `Application.Run` recursively from a window callback. Use dialogs
+for modal UI and use the [dispatcher](dispatching.md) to schedule later work on
+the active UI thread.

--- a/docs/dispatching.md
+++ b/docs/dispatching.md
@@ -1,0 +1,376 @@
+# Dispatching to the UI Thread
+
+Each window and control belongs to the thread that created it, called the UI
+thread. Windows runs input, painting, and lifetime message handlers on that
+thread. Requiring all access to UI objects on that same thread is their
+synchronization contract: message handlers and dispatched callbacks are
+serialized, so UI state is not changed concurrently by a worker thread while a
+message handler is actively using it. Worker threads must queue UI access to
+the owning thread rather than access UI objects directly.
+
+The UI thread must also return to its message loop promptly. Slow or blocking
+work prevents it from processing input and painting, making the application
+appear frozen. Run such work elsewhere, then queue only the UI update back.
+
+Thirtytwo provides one `Dispatcher` for each active `Application.Run` message
+loop. It performs that handoff by queueing a callback on the UI thread. A
+window retains its dispatcher as a stable affinity reference; whether the
+dispatcher still accepts work is decided atomically when work is submitted.
+
+## In this guide
+
+- **[Basic usage](#basic-usage):** [get a dispatcher](#get-a-dispatcher),
+  [queue a synchronous callback](#queue-a-synchronous-callback),
+  [queue an asynchronous callback](#queue-an-asynchronous-callback), and
+  [return a value](#return-a-value).
+- **[Recipes](#recipes):** [cancel work](#cancel-work),
+    [post a best-effort update](#post-a-best-effort-update),
+  [schedule delayed work](#schedule-delayed-work),
+  [run a repeating timer](#run-a-repeating-timer),
+    and [handle fire-and-forget exceptions](#handle-fire-and-forget-exceptions).
+- **[Optimizations](#optimizations):**
+  [skip dispatch when already on the UI thread](#skip-dispatch-when-already-on-the-ui-thread),
+  [enforce UI-thread access](#enforce-ui-thread-access), and
+  [reduce queue pressure](#reduce-queue-pressure).
+- **[Shutdown behavior](#shutdown-behavior):** [developer summary](#developer-summary),
+    [lifecycle signals](#lifecycle-signals), [submission races](#submission-during-shutdown),
+    and [outstanding work](#work-outstanding-at-shutdown).
+
+## Basic usage
+
+### Get a dispatcher
+
+A window retains the dispatcher for its owning UI thread. The property may be
+read from any thread and does not become `null` when shutdown starts:
+
+```csharp
+using Windows.Threading;
+
+Dispatcher dispatcher = window.Dispatcher;
+```
+
+`Application.Run` associates existing windows before showing the root window.
+Its factory overload also makes the dispatcher available while the root window
+is being constructed. Reading `Window.Dispatcher` before either association
+throws `InvalidOperationException`.
+
+When code has no window, `Dispatcher.Current` discovers the active dispatcher
+for the calling thread:
+
+```csharp
+Dispatcher? dispatcher = Dispatcher.Current;
+```
+
+Code that has only a raw `HWND` can discover its owning thread's active
+dispatcher:
+
+```csharp
+Dispatcher? dispatcher = Dispatcher.FromHandle(windowHandle);
+```
+
+`Dispatcher.Current` and `Dispatcher.FromHandle` are optional discovery APIs.
+They return `null` before the message loop starts or after admission closes;
+`FromHandle` also returns `null` for a destroyed or invalid handle. Never use a
+successful lookup as a shutdown check. A captured dispatcher remains safe to
+call, and submission reports whether shutdown won the race.
+
+### Queue a synchronous callback
+
+Use `InvokeAsync(Action)` for work whose callback completes synchronously.
+The call queues the callback and returns immediately; await its task to observe
+completion and exceptions:
+
+```csharp
+await dispatcher.InvokeAsync(
+    () => window.SetWindowText("Ready"));
+```
+
+`InvokeAsync` always queues the callback, even when called by the dispatcher
+thread. Immediate callbacks run in FIFO admission order. Do not synchronously
+wait on the returned task from the dispatcher thread: the queued callback
+cannot run while that thread is blocked. Use `await` instead.
+
+### Queue an asynchronous callback
+
+Use an async callback overload when the UI operation itself must await other
+work. The returned task represents the callback's complete lifetime, and an
+ordinary `await` inside the callback resumes on the dispatcher thread:
+
+```csharp
+await dispatcher.InvokeAsync(async effectiveToken =>
+{
+    await Task.Delay(TimeSpan.FromSeconds(1), effectiveToken);
+    window.SetWindowText("Async work complete");
+});
+```
+
+The effective token observes dispatcher shutdown. When the caller also supplies
+a cancellation token, it observes caller cancellation as well.
+
+Exceptions from synchronous and asynchronous callbacks are stored on the
+returned task and re-thrown by `await`.
+
+### Return a value
+
+Use a generic overload to return a synchronous or asynchronous result from the
+UI thread:
+
+```csharp
+int clientWidth = await dispatcher.InvokeAsync(
+    () => window.GetClientRectangle().Width);
+```
+
+```csharp
+string title = await dispatcher.InvokeAsync(async effectiveToken =>
+{
+    await Task.Delay(TimeSpan.FromMilliseconds(100), effectiveToken);
+    return window.GetWindowText();
+});
+```
+
+## Recipes
+
+### Cancel work
+
+Pass a cancellation token as the final argument:
+
+```csharp
+using CancellationTokenSource cancellationSource = new();
+
+Task operation = dispatcher.InvokeAsync(
+    async effectiveToken =>
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10), effectiveToken);
+        window.SetWindowText("Finished");
+    },
+    cancellationSource.Token);
+
+cancellationSource.Cancel();
+await operation;
+```
+
+Cancellation before a callback starts prevents it from running. After an async
+callback starts, cancellation is cooperative: the task does not complete until
+the callback exits. A running synchronous callback is not interrupted.
+
+### Post a best-effort update
+
+Use `TryPost` when an update may be dropped during shutdown and no caller needs
+its completion or result:
+
+```csharp
+bool accepted = window.Dispatcher.TryPost(
+    () => window.SetWindowText("Background update"));
+
+if (!accepted)
+{
+    // Dispatcher shutdown already closed admission. The update was not queued.
+}
+```
+
+The Boolean is the atomic admission result, not a dispatcher-state pre-check.
+`true` means the callback entered the queue, although shutdown may still discard
+it before execution. Callback exceptions are reported through
+`UnhandledException`. Use `InvokeAsync` instead when completion matters.
+
+### Schedule delayed work
+
+Pass a `TimeSpan` before the callback to make it eligible after a monotonic
+delay:
+
+```csharp
+await dispatcher.InvokeAsync(
+    TimeSpan.FromMilliseconds(250),
+    () => window.SetWindowText("Delay complete"));
+```
+
+Synchronous, result-returning, and asynchronous callback shapes have delayed
+overloads. Delayed callbacks are ordered by deadline and then by admission
+order when their deadlines are equal. The ordinary cancellation, completion,
+and exception rules apply.
+
+### Run a repeating timer
+
+Create, start, stop, and dispose a `DispatcherTimer` on its dispatcher thread.
+Retain the timer for as long as it should run:
+
+```csharp
+private DispatcherTimer? _clockTimer;
+
+private void StartClock(Window window)
+{
+    Dispatcher dispatcher = window.Dispatcher;
+
+    _clockTimer = dispatcher.CreateTimer(TimeSpan.FromSeconds(1));
+    _clockTimer.Tick += (_, _) =>
+        window.SetWindowText(DateTime.Now.ToLongTimeString());
+    _clockTimer.Start();
+}
+
+private void StopClock()
+{
+    _clockTimer?.Dispose();
+    _clockTimer = null;
+}
+```
+
+Changing `Interval` while the timer is running restarts its deadline from the
+current time. A timer skips missed intervals rather than replaying a burst. It
+is stopped during application shutdown, but code should still dispose it when
+its owner no longer needs it.
+
+### Handle fire-and-forget exceptions
+
+Exceptions from `InvokeAsync` belong to the returned task. The
+`UnhandledException` event is for fire-and-forget work, such as a callback
+posted through the installed `SynchronizationContext`:
+
+```csharp
+dispatcher.UnhandledException += (_, arguments) =>
+{
+    System.Diagnostics.Debug.WriteLine(arguments.Exception);
+    arguments.Handled = true;
+};
+```
+
+Set `Handled` only when the application can continue safely. An unhandled
+exception stops the dispatcher and is re-thrown from `Application.Run` after
+cleanup.
+
+## Optimizations
+
+### Skip dispatch when already on the UI thread
+
+Use `CheckAccess` when a method can safely run inline on the UI thread and only
+needs dispatching for callers on other threads:
+
+```csharp
+static async Task SetTitleAsync(Window window, string title)
+{
+    Dispatcher dispatcher = window.Dispatcher;
+
+    if (dispatcher.CheckAccess())
+    {
+        window.SetWindowText(title);
+        return;
+    }
+
+    await dispatcher.InvokeAsync(() => window.SetWindowText(title));
+}
+```
+
+Running inline avoids one queue operation, but it also changes ordering and
+reentrancy compared with always calling `InvokeAsync`. Use this optimization
+only when immediate execution on the UI thread is part of the method's
+contract.
+
+### Enforce UI-thread access
+
+Use `VerifyAccess` at the start of a method that may only be called by the
+dispatcher thread:
+
+```csharp
+private void UpdateUiState()
+{
+    _dispatcher.VerifyAccess();
+    // Read or update UI-bound state.
+}
+```
+
+It returns normally on the dispatcher thread and throws
+`InvalidOperationException` from another thread. This check exposes an invalid
+caller early; it does not marshal the call.
+
+### Reduce queue pressure
+
+The dispatcher queue has no fixed capacity or backpressure. When a producer can
+outpace the UI thread:
+
+- combine related UI changes into one callback;
+- avoid posting an update when a newer one replaces it;
+- throttle high-frequency producers; and
+- await operations when later production depends on their completion.
+
+These measures bound retained callback state and leave the UI thread time to
+process input, painting, and other native messages.
+
+## Shutdown behavior
+
+### Developer summary
+
+For most dispatched code, these are the rules that matter:
+
+- Keep the dispatcher reference. Do not check whether it is active before
+    submitting work; submission itself safely resolves a race with shutdown.
+- Await every `InvokeAsync` task. If shutdown prevents the callback from
+    completing, the task faults with `ObjectDisposedException`.
+- Use `TryPost` only when it is acceptable for the callback never to run. A
+    `false` result means shutdown rejected it; even an accepted callback may be
+    discarded by later teardown.
+- Once a synchronous callback starts, it runs to completion. Keep it short so
+    the UI remains responsive.
+- Async callbacks should honor their effective cancellation token. Do not rely
+    on code after an `await`, including a UI-thread `finally`, running during
+    shutdown. Leave UI state consistent before yielding and put required lifetime
+    cleanup in the object that owns the resource.
+
+The remaining sections define the lifecycle and race behavior behind these
+rules.
+
+Shutdown starts when the `Application.Run` message loop exits or the dispatcher
+faults. At that point the dispatcher stops accepting work and is removed from
+`Dispatcher.Current` and `Dispatcher.FromHandle` discovery. A previously
+associated `Window.Dispatcher` still returns the same dispatcher, including
+after the window's handle is destroyed. If a window survives into a later
+`Application.Run` on the same thread, that run associates it with its fresh
+dispatcher after the previous dispatcher's `Completion` task has completed.
+
+### Lifecycle signals
+
+Use the dispatcher's two stable lifetime signals for coordination:
+
+```csharp
+CancellationToken shutdownToken = dispatcher.ShutdownToken;
+Task completion = dispatcher.Completion;
+```
+
+- `ShutdownToken` is canceled when admission closes. Background producers can
+    use it to stop generating updates, and asynchronous dispatcher callbacks
+    receive an effective token that includes this signal.
+- `Completion` completes after dispatcher shutdown releases its native wake
+    resources. It signals that teardown finished; it does not report whether the
+    message loop ended successfully.
+
+A token check can race shutdown, so it is advisory rather than permission to
+enqueue. Submit the operation and use the returned task or Boolean as the
+authoritative result.
+
+### Submission during shutdown
+
+`InvokeAsync` and `TryPost` synchronize admission with shutdown under the same
+lock:
+
+- If submission wins, the operation is admitted. An `InvokeAsync` task tracks
+    what subsequently happens. `TryPost` returns `true`.
+- If shutdown wins, `InvokeAsync` returns an already-faulted task containing an
+    `ObjectDisposedException`. `TryPost` returns `false`.
+
+Do not write `if (!dispatcher.ShutdownToken.IsCancellationRequested)` or check
+some other status before submitting work; shutdown can begin immediately after
+that check.
+
+### Work outstanding at shutdown
+
+- A synchronous callback already running on the UI thread finishes before
+    normal shutdown can proceed.
+- An asynchronous callback is asked to stop through its effective cancellation
+    token. If it finishes before final teardown, its task records its actual
+    result, exception, or cooperative cancellation.
+- Queued, delayed, or still-active asynchronous work detached by final teardown
+    faults with `ObjectDisposedException`. A late async completion is observed but
+    cannot change that terminal task.
+- Fire-and-forget work discarded during shutdown has no completion result.
+
+Always observe tasks returned by `InvokeAsync`. Use `ShutdownToken` to stop
+producers promptly and `Completion` when an external coordinator must wait for
+the dispatcher to release its resources.

--- a/docs/writing-a-thirtytwo-application.md
+++ b/docs/writing-a-thirtytwo-application.md
@@ -1,0 +1,17 @@
+# Writing a thirtytwo Application
+
+These guides explain how to create a thirtytwo desktop application, run its UI
+message loop, and safely schedule work on the UI thread.
+
+## Guides
+
+1. [Creating and running an Application](creating-and-running-an-application.md)
+   describes the executable project, root window, message handling, application
+   lifetime, and window ownership.
+2. [Dispatching to the UI Thread](dispatching.md) describes how to find a UI
+   dispatcher, queue synchronous or asynchronous work, use cancellation and
+   delays, create timers, optimize thread checks, and handle failures and
+   shutdown.
+
+The complete sample applications under [`src/samples`](../src/samples/) provide
+larger examples of windows, controls, graphics, dialogs, and layout.

--- a/src/samples/Layout/Program.LayoutWindow.cs
+++ b/src/samples/Layout/Program.LayoutWindow.cs
@@ -65,10 +65,10 @@ internal partial class Program
                     (.3f, Layout.FixedPercent(.5f, _buttonControl))))));
 
             MouseHandler handler = new(_buttonControl);
-            handler.MouseUp += Handler_MouseUp;
+            handler.MouseUp += MouseUpHandler;
         }
 
-        private void Handler_MouseUp(Window window, Point position, MouseButton button, MouseKey mouseState)
+        private void MouseUpHandler(Window window, Point position, MouseButton button, MouseKey mouseState)
         {
             if (_replaceableLayout.Handler == _staticControl)
             {

--- a/src/samples/Petzold/5th/BtnLook/Program.OwnerDraw.cs
+++ b/src/samples/Petzold/5th/BtnLook/Program.OwnerDraw.cs
@@ -16,8 +16,8 @@ internal static partial class Program
         private int _cxClient, _cyClient;
         private int _btnWidth, _btnHeight;
         private Size _baseUnits;
-        private const int ID_SMALLER = 1;
-        private const int ID_LARGER = 2;
+        private const int SmallerId = 1;
+        private const int LargerId = 2;
 
         public OwnerDraw(string title) : base(title: title)
         {
@@ -38,12 +38,12 @@ internal static partial class Program
                         style: WindowStyles.Child | WindowStyles.Visible,
                         buttonStyle: ButtonControl.Styles.OwnerDrawn,
                         parentWindow: this,
-                        buttonId: ID_SMALLER);
+                        buttonId: SmallerId);
                     _hwndLarger = new ButtonControl(
                         style: WindowStyles.Child | WindowStyles.Visible,
                         buttonStyle: ButtonControl.Styles.OwnerDrawn,
                         parentWindow: this,
-                        buttonId: ID_LARGER);
+                        buttonId: LargerId);
 
                     return (LRESULT)0;
 
@@ -66,10 +66,10 @@ internal static partial class Program
                     // Make the window 10% smaller or larger
                     switch ((int)(uint)wParam)
                     {
-                        case ID_SMALLER:
+                        case SmallerId:
                             rc.Inflate(rc.Width / -10, rc.Height / -10);
                             break;
-                        case ID_LARGER:
+                        case LargerId:
                             rc.Inflate(rc.Width / 10, rc.Height / 10);
                             break;
                     }
@@ -97,7 +97,7 @@ internal static partial class Program
 
                         switch ((int)drawItemMessage.ControlId)
                         {
-                            case ID_SMALLER:
+                            case SmallerId:
                                 pt[0].X = 3 * cx / 8; pt[0].Y = 1 * cy / 8;
                                 pt[1].X = 5 * cx / 8; pt[1].Y = 1 * cy / 8;
                                 pt[2].X = 4 * cx / 8; pt[2].Y = 3 * cy / 8;
@@ -115,7 +115,7 @@ internal static partial class Program
                                 pt[2].X = 3 * cx / 8; pt[2].Y = 4 * cy / 8;
                                 Triangle(dc, pt);
                                 break;
-                            case ID_LARGER:
+                            case LargerId:
                                 pt[0].X = 5 * cx / 8; pt[0].Y = 3 * cy / 8;
                                 pt[1].X = 3 * cx / 8; pt[1].Y = 3 * cy / 8;
                                 pt[2].X = 4 * cx / 8; pt[2].Y = 1 * cy / 8;

--- a/src/samples/Petzold/5th/Clock/Clock.cs
+++ b/src/samples/Petzold/5th/Clock/Clock.cs
@@ -44,8 +44,8 @@ internal class Clock : MainWindow
         {
             pt[i] = new Point
             (
-                (int)(pt[i].X * Math.Cos(TWOPI * iAngle / 360) + pt[i].Y * Math.Sin(TWOPI * iAngle / 360)),
-                (int)(pt[i].Y * Math.Cos(TWOPI * iAngle / 360) - pt[i].X * Math.Sin(TWOPI * iAngle / 360))
+                (int)(pt[i].X * Math.Cos(TwoPi * iAngle / 360) + pt[i].Y * Math.Sin(TwoPi * iAngle / 360)),
+                (int)(pt[i].Y * Math.Cos(TwoPi * iAngle / 360) - pt[i].X * Math.Sin(TwoPi * iAngle / 360))
             );
         }
     }
@@ -120,8 +120,8 @@ internal class Clock : MainWindow
         }
     }
 
-    private const int ID_TIMER = 1;
-    private const double TWOPI = Math.PI * 2;
+    private const int TimerId = 1;
+    private const double TwoPi = Math.PI * 2;
     private Size _clientSize;
     private SYSTEMTIME _previousTime;
 
@@ -130,7 +130,7 @@ internal class Clock : MainWindow
         switch (message)
         {
             case MessageType.Create:
-                window.SetTimer(ID_TIMER, 1000);
+                window.SetTimer(TimerId, 1000);
                 PInvoke.GetLocalTime(out _previousTime);
                 return (LRESULT)0;
             case MessageType.Size:

--- a/src/samples/Petzold/5th/Clover/Clover.cs
+++ b/src/samples/Petzold/5th/Clover/Clover.cs
@@ -12,7 +12,7 @@ internal class Clover : MainWindow
 {
     private int _cxClient, _cyClient;
     private HRGN _hrgnClip;
-    private const double TWO_PI = Math.PI * 2;
+    private const double TwoPi = Math.PI * 2;
 
     public Clover() : base(title: "Draw a Clover", backgroundColor: Color.White) { }
 
@@ -47,7 +47,7 @@ internal class Clover : MainWindow
 
                     double fRadius = Hypotenuse(_cxClient / 2.0, _cyClient / 2.0);
 
-                    for (double fAngle = 0.0; fAngle < TWO_PI; fAngle += TWO_PI / 360)
+                    for (double fAngle = 0.0; fAngle < TwoPi; fAngle += TwoPi / 360)
                     {
                         dc.MoveTo(default);
                         dc.LineTo(

--- a/src/samples/Petzold/5th/HelloWin/Program.HelloWindow.cs
+++ b/src/samples/Petzold/5th/HelloWin/Program.HelloWindow.cs
@@ -23,7 +23,7 @@ internal unsafe static partial class Program
             {
                 case MessageType.Create:
                     PInvoke.PlaySound(
-                        (char*)SND_ALIAS_SYSTEMHAND,
+                        (char*)SoundAliasSystemHand,
                         HMODULE.Null,
                         SND_FLAGS.SND_ASYNC | SND_FLAGS.SND_NODEFAULT | SND_FLAGS.SND_ALIAS_ID);
                     return (LRESULT)0;

--- a/src/samples/Petzold/5th/HelloWin/Program.cs
+++ b/src/samples/Petzold/5th/HelloWin/Program.cs
@@ -19,7 +19,7 @@ namespace HelloWin;
 internal unsafe static partial class Program
 {
     // Windows metadata doesn't currently define this as it is a macro.
-    const uint SND_ALIAS_SYSTEMHAND = 'S' | (((uint)'H') << 8);
+    const uint SoundAliasSystemHand = 'S' | (((uint)'H') << 8);
 
     [STAThread]
     private static void Main()
@@ -86,7 +86,7 @@ internal unsafe static partial class Program
         {
             case Interop.WM_CREATE:
                 PInvoke.PlaySound(
-                    (char*)SND_ALIAS_SYSTEMHAND,
+                    (char*)SoundAliasSystemHand,
                     HMODULE.Null,
                     SND_FLAGS.SND_ASYNC | SND_FLAGS.SND_NODEFAULT | SND_FLAGS.SND_ALIAS_ID);
                 return (LRESULT)0;

--- a/src/thirtytwo/Application.cs
+++ b/src/thirtytwo/Application.cs
@@ -4,6 +4,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Support;
+using Windows.Threading;
 using Windows.Win32.Graphics.Direct2D;
 using Windows.Win32.Graphics.DirectWrite;
 using Windows.Win32.Graphics.Imaging;
@@ -15,6 +16,13 @@ namespace Windows;
 /// </summary>
 public static unsafe class Application
 {
+    // Keep all framework-owned WM_APP identifiers together so new allocations cannot silently overlap.
+
+    /// <summary>
+    ///  Identifies the dispatcher queue wake message.
+    /// </summary>
+    internal const uint DispatcherWakeMessage = Interop.WM_APP + 1;
+
     private static ActivationContext? s_visualStylesContext;
     private static Direct2dFactory? s_direct2dFactory;
     private static DirectWriteFactory? s_directWriteFactory;
@@ -129,7 +137,7 @@ public static unsafe class Application
         string? windowTitle = null,
         WindowStyles style = WindowStyles.OverlappedWindow,
         ExtendedWindowStyles extendedStyle = ExtendedWindowStyles.Default,
-        HMENU menuHandle = default) => Run(new Window(
+        HMENU menuHandle = default) => Run(() => new Window(
             bounds,
             windowTitle,
             style,
@@ -137,39 +145,67 @@ public static unsafe class Application
             windowClass: windowClass,
             menuHandle: menuHandle));
 
+    /// <summary>
+    ///  Creates the root window with an active dispatcher, then shows it and runs the UI message loop.
+    /// </summary>
+    /// <param name="windowFactory">Creates the root window on the current UI thread.</param>
+    public static void Run(Func<Window> windowFactory)
+    {
+        ArgumentNullException.ThrowIfNull(windowFactory);
+        Run(windowFactory, disposeWindow: true);
+    }
+
+    /// <summary>
+    ///  Associates and shows an existing root window, then runs the UI message loop.
+    /// </summary>
+    /// <param name="window">The root window.</param>
+    /// <param name="disposeWindow">Whether to dispose the window after the message loop exits.</param>
     public static void Run(Window window, bool disposeWindow = true)
     {
+        ArgumentNullException.ThrowIfNull(window);
+        Run(() => window, disposeWindow);
+    }
+
+    private static void Run(Func<Window> windowFactory, bool disposeWindow)
+    {
+        using ThreadContext threadContext = ThreadContext.Create();
+        Window? window = null;
+
         try
         {
-            window.MessageHandler += Window_QuitHandler;
-
-            window.ShowWindow(ShowWindowCommand.Normal);
-            window.UpdateWindow();
-
-            while (PInvoke.GetMessage(out MSG message, HWND.Null, 0, 0))
+            threadContext.RunMessageLoop(() =>
             {
-                if (Window.FromHandle(message.hwnd) is { } target && target.PreProcessMessage(ref message))
-                {
-                    continue;
-                }
+                window = windowFactory()
+                    ?? throw new InvalidOperationException("The window factory returned null.");
+                window.AttachDispatcher(threadContext.Dispatcher);
+                window.MessageHandler += Window_QuitHandler;
 
-                PInvoke.TranslateMessage(&message);
-                PInvoke.DispatchMessage(&message);
-            }
+                window.ShowWindow(ShowWindowCommand.Normal);
+                window.UpdateWindow();
+            });
 
             // Make sure our window doesn't get collected while we're pumping messages
             GC.KeepAlive(window);
         }
         catch
         {
-            PInvoke.DestroyWindow(window);
+            if (window is not null && !window.Handle.IsNull)
+            {
+                PInvoke.DestroyWindow(window);
+            }
+
             throw;
         }
         finally
         {
+            if (window is not null)
+            {
+                window.MessageHandler -= Window_QuitHandler;
+            }
+
             if (disposeWindow)
             {
-                window.Dispose();
+                window?.Dispose();
             }
         }
 
@@ -177,7 +213,7 @@ public static unsafe class Application
         {
             if (message == MessageType.Destroy)
             {
-                PInvoke.PostQuitMessage(0);
+                ThreadContext.RequestExitCurrentThread();
             }
 
             return null;
@@ -195,6 +231,20 @@ public static unsafe class Application
     ///  scope is disposed.
     /// </summary>
     public static ThreadModalScope EnterThreadModalScope() => new();
+
+    /// <summary>
+    ///  Adds a message filter to the current UI thread. Filters run in registration order.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A message loop is not active on this thread.</exception>
+    public static MessageFilterRegistration AddMessageFilter(IMessageFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        ThreadContext context = ThreadContext.CurrentContext
+            ?? throw new InvalidOperationException("A message loop is not running on this thread.");
+
+        return context.AddMessageFilter(filter);
+    }
 
     /// <summary>
     ///  Enumerates thread windows for the current thread.

--- a/src/thirtytwo/DotNet/IManagedObject.Vtbl.cs
+++ b/src/thirtytwo/DotNet/IManagedObject.Vtbl.cs
@@ -7,12 +7,12 @@ public unsafe partial struct IManagedObject
 {
     public struct Vtbl
     {
-#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable TOUKI0041 // Native vtable field names mirror their ABI slots.
         internal delegate* unmanaged[Stdcall]<IManagedObject*, Guid*, void**, HRESULT> QueryInterface_1;
         internal delegate* unmanaged[Stdcall]<IManagedObject*, uint> AddRef_2;
         internal delegate* unmanaged[Stdcall]<IManagedObject*, uint> Release_3;
         internal delegate* unmanaged[Stdcall]<IManagedObject*, BSTR*, HRESULT> GetSerializedBuffer_4;
         internal delegate* unmanaged[Stdcall]<IManagedObject*, BSTR*, int*, int*, HRESULT> GetObjectIdentity_5;
-#pragma warning restore IDE1006
+#pragma warning restore TOUKI0041
     }
 }

--- a/src/thirtytwo/GlobalSuppressions.cs
+++ b/src/thirtytwo/GlobalSuppressions.cs
@@ -14,7 +14,7 @@
 [assembly: SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Matches Windows", Scope = "type", Target = "~T:Windows.VirtualKey")]
 [assembly: SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Matches Windows", Scope = "type", Target = "~T:Windows.Win32.Graphics.GdiPlus.PixelFormat")]
 [assembly: SuppressMessage("Usage", "CA2231:Overload operator equals on overriding value type Equals", Justification = "CsWin32", Scope = "type", Target = "~T:Windows.Win32.Foundation.PCWSTR")]
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread Local", Scope = "member", Target = "~F:Windows.WindowClass.t_initializeProcedure")]
+[assembly: SuppressMessage("Naming", "TOUKI0041:Naming rule violation", Justification = "Mirrors the native IManagedObject interface shape.", Scope = "type", Target = "~T:Windows.DotNet.IManagedObject.Interface")]
 [assembly: SuppressMessage("Maintainability", "TOUKI0020:Declare one type per file", Justification = "Generic arities intentionally share one conceptual interface family.", Scope = "type", Target = "~T:Windows.Win32.System.Com.IManagedWrapper`1")]
 [assembly: SuppressMessage("Maintainability", "TOUKI0020:Declare one type per file", Justification = "Generic arities intentionally share one conceptual interface family.", Scope = "type", Target = "~T:Windows.Win32.System.Com.IManagedWrapper`2")]
 [assembly: SuppressMessage("Maintainability", "TOUKI0020:Declare one type per file", Justification = "Generic arities intentionally share one conceptual interface family.", Scope = "type", Target = "~T:Windows.Win32.System.Com.IManagedWrapper`3")]

--- a/src/thirtytwo/Layout/LayoutBinder.cs
+++ b/src/thirtytwo/Layout/LayoutBinder.cs
@@ -20,10 +20,10 @@ public class LayoutBinder
     public LayoutBinder(Window window, ILayoutHandler handler)
     {
         _handler = handler;
-        window.MessageHandler += Window_MessageHandler;
+        window.MessageHandler += WindowMessageHandler;
     }
 
-    private LRESULT? Window_MessageHandler(
+    private LRESULT? WindowMessageHandler(
         object sender,
         HWND window,
         MessageType message,

--- a/src/thirtytwo/Messages/EnterIdleHandler.cs
+++ b/src/thirtytwo/Messages/EnterIdleHandler.cs
@@ -9,10 +9,10 @@ public partial class EnterIdleHandler
 
     public EnterIdleHandler(Window window)
     {
-        window.MessageHandler += Window_MessageHandler;
+        window.MessageHandler += WindowMessageHandler;
     }
 
-    private LRESULT? Window_MessageHandler(
+    private LRESULT? WindowMessageHandler(
         object sender,
         HWND window,
         MessageType message,

--- a/src/thirtytwo/Messages/MouseHandler.cs
+++ b/src/thirtytwo/Messages/MouseHandler.cs
@@ -14,11 +14,11 @@ public class MouseHandler : IMouseMessageHandler
 
     public MouseHandler(Window window)
     {
-        window.MessageHandler += Window_MessageHandler;
+        window.MessageHandler += WindowMessageHandler;
         _attachedWindow = window;
     }
 
-    private unsafe LRESULT? Window_MessageHandler(
+    private unsafe LRESULT? WindowMessageHandler(
         object sender,
         HWND window,
         MessageType message,

--- a/src/thirtytwo/Messaging/IMessageFilter.cs
+++ b/src/thirtytwo/Messaging/IMessageFilter.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>
+///  Preprocesses messages retrieved by the current UI thread before managed window lookup and native dispatch.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This interface is a per-thread integration point for components whose HWNDs are not represented by a managed
+///   <see cref="Window"/>. Such components can perform required message translation without adding a dependency on
+///   their UI technology to the core message loop.
+///  </para>
+///  <para>
+///   Register filters with <see cref="Application.AddMessageFilter"/>. They run in registration order against a stable
+///   snapshot; adding or removing a filter during a callback affects the next retrieved message.
+///  </para>
+///  <para>
+///   Changes made to the message are visible to later filters and normal message processing. Returning
+///   <see langword="true"/> stops later filters, managed-window preprocessing, translation, and dispatch for that
+///   message.
+///  </para>
+/// </remarks>
+public interface IMessageFilter
+{
+    /// <summary>
+    ///  Returns <see langword="true"/> when the message has been handled and must not be dispatched.
+    /// </summary>
+    /// <param name="message">The message to inspect or modify.</param>
+    /// <returns><see langword="true"/> when the message was handled; otherwise, <see langword="false"/>.</returns>
+    bool PreFilterMessage(ref MSG message);
+}

--- a/src/thirtytwo/Messaging/MessageFilterEntry.cs
+++ b/src/thirtytwo/Messaging/MessageFilterEntry.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Associates a message filter with its registration identifier.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="ThreadContext"/> assigns the next identifier from its per-context sequence when a filter is registered.
+///   The returned <see cref="MessageFilterRegistration"/> retains that identifier and uses it to remove this exact
+///   entry when disposed.
+///  </para>
+/// </remarks>
+/// <param name="Id">The identifier assigned by the owning thread context when the filter was registered.</param>
+/// <param name="Filter">The registered message filter.</param>
+internal sealed record MessageFilterEntry(long Id, IMessageFilter Filter);

--- a/src/thirtytwo/Messaging/MessageFilterRegistration.cs
+++ b/src/thirtytwo/Messaging/MessageFilterRegistration.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Threading;
+
+namespace Windows;
+
+/// <summary>
+///  Represents a message filter registered with a UI thread.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="Application.AddMessageFilter"/> adds the filter and returns this handle. Disposing the handle removes
+///   that registration. This follows the same pattern as <see cref="CancellationTokenRegistration"/>.
+///  </para>
+/// </remarks>
+public readonly struct MessageFilterRegistration : IDisposable
+{
+    private readonly ThreadContext? _context;
+    private readonly long _id;
+
+    /// <summary>
+    ///  Creates a handle for a filter that the thread context has already registered.
+    /// </summary>
+    /// <param name="context">The thread context that owns the filter.</param>
+    /// <param name="id">The registration identifier.</param>
+    internal MessageFilterRegistration(ThreadContext context, long id)
+    {
+        _context = context;
+        _id = id;
+    }
+
+    /// <summary>
+    ///  Removes the represented filter registration. Disposal from a different thread throws.
+    /// </summary>
+    public void Dispose() => _context?.RemoveMessageFilter(_id);
+}

--- a/src/thirtytwo/NativeMethods.txt
+++ b/src/thirtytwo/NativeMethods.txt
@@ -191,6 +191,7 @@ GetWindowRect
 GetWindowRgn
 GetWindowText
 GetWindowTextLength
+GetWindowThreadProcessId
 GetWorldTransform
 GlobalAlloc
 GlobalFree
@@ -201,6 +202,7 @@ GUID_WICPixelFormat32bppPBGRA
 HFONT
 HKEY_*
 HRESULT
+HWND_MESSAGE
 IAccessible
 IAccessibleEx
 IAccIdentity
@@ -306,6 +308,7 @@ PolyBezier
 Polygon
 Polyline
 PostMessage
+PostThreadMessage
 PostQuitMessage
 PROPVARIANT
 PropVariantClear

--- a/src/thirtytwo/Threading/Dispatcher.cs
+++ b/src/thirtytwo/Threading/Dispatcher.cs
@@ -1,0 +1,1303 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using Windows.Support;
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Queues work to the UI thread owned by an active <see cref="Application.Run(Window, bool)"/> message loop.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Admission has no capacity limit or backpressure. Sustained producers can grow the queue until the dispatcher
+///   catches up; queue depth and its high-water mark are available through the dispatcher event source.
+///  </para>
+/// </remarks>
+public sealed class Dispatcher
+{
+    // Raw HWND discovery maps the window's native owner thread to the dispatcher that currently accepts work.
+    private static readonly ConcurrentDictionary<uint, Dispatcher> s_dispatchersByThreadId = [];
+
+    // Protects lifecycle state, registry ownership, queue membership, wake reservation, and operation counters.
+    private readonly Lock _lock = new();
+
+    // A callback that returned an incomplete ValueTask is no longer in _queue. Track its work item until the callback
+    // finishes so Stop or Fault can fault the operation's public Task if teardown happens first.
+    private readonly HashSet<DispatcherWorkItem> _activeAsyncWork = [];
+
+    // Holds immediate work and delayed work whose deadlines have elapsed; canceled entries are skipped when dequeued.
+    private readonly Queue<DispatcherWorkItem> _queue = [];
+
+    // Orders delayed work by deadline, then operation ID to preserve admission order for equal deadlines.
+    private readonly PriorityQueue<DispatcherWorkItem, (long DueTicks, long Id)> _scheduledWork = new();
+
+    // Cancels the effective tokens supplied to asynchronous callbacks when the dispatcher starts stopping or faults.
+    private readonly CancellationTokenSource _shutdownSource = new();
+
+    // Remains usable after shutdown without accessing the retained source through CancellationTokenSource.Token.
+    private readonly CancellationToken _shutdownToken;
+
+    // Completes asynchronously after dispatcher-owned native wake resources have been released.
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    // Captures managed thread identity for CheckAccess and VerifyAccess.
+    private readonly Thread _thread = Thread.CurrentThread;
+
+    // Supplies monotonic elapsed time for delayed work and dispatcher timers.
+    private readonly TimeProvider _timeProvider;
+
+    // Anchors TimeProvider elapsed-time calculations to dispatcher construction.
+    private readonly long _timestampOrigin;
+
+    // Keys HWND discovery and identifies the owner in diagnostics and cross-thread fault signaling.
+    private readonly uint _nativeThreadId = PInvoke.GetCurrentThreadId();
+
+    // Delivers immediate and delayed queue-processing signals.
+    private readonly IDispatcherWake _wake;
+
+    // All reads and writes are protected by _lock.
+    private DispatcherState _state = DispatcherState.Created;
+
+    // Set before posting a queue wake and cleared when ProcessQueue begins handling it. While set, additional
+    // enqueues rely on that outstanding wake instead of posting another message.
+    private bool _wakeRequested;
+
+    // Tracks ownership of this dispatcher's native-thread registry entry so it is removed exactly once.
+    private bool _registered;
+
+    // Records the largest combined immediate, delayed, and active-async operation count observed at admission.
+    private int _highWatermark;
+
+    // Counts operations that reached a terminal state.
+    private long _completedCount;
+
+    // Generates operation IDs unique within this dispatcher lifetime.
+    private long _nextOperationId;
+
+    // Counts operations admitted to either the immediate queue or delayed heap.
+    private long _postedCount;
+
+    // Stores the current fatal failure for rethrow at a managed message-loop boundary. Later cancellation or
+    // fault-signaling errors are combined with the existing exception in an AggregateException.
+    private ExceptionDispatchInfo? _fault;
+
+    /// <summary>
+    ///  Initializes a dispatcher owned by the current thread.
+    /// </summary>
+    internal Dispatcher()
+    {
+        _timeProvider = TimeProvider.System;
+        _timestampOrigin = _timeProvider.GetTimestamp();
+        _shutdownToken = _shutdownSource.Token;
+        SynchronizationContext = new DispatcherSynchronizationContext(this);
+
+        try
+        {
+            _wake = new DispatcherWakeWindow(this);
+        }
+        catch
+        {
+            _shutdownSource.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///  Gets the dispatcher for the running message loop on the current thread, or <see langword="null"/>.
+    /// </summary>
+    public static Dispatcher? Current => ThreadContext.CurrentDispatcher;
+
+    /// <summary>
+    ///  Gets the active dispatcher for the thread that owns the given window handle.
+    /// </summary>
+    /// <typeparam name="T">A type that exposes an <see cref="HWND"/>.</typeparam>
+    /// <param name="handle">The window handle or wrapper to inspect.</param>
+    /// <returns>
+    ///  The owning thread's active dispatcher, or <see langword="null"/> when the handle is null or invalid, or its
+    ///  thread does not have a running dispatcher.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   This method does not create a dispatcher and may be called from any thread. The result is a snapshot: shutdown
+    ///   can begin after this method returns, in which case a subsequent operation is rejected through its task.
+    ///  </para>
+    /// </remarks>
+    public static unsafe Dispatcher? FromHandle<T>(T handle)
+        where T : IHandle<HWND>
+    {
+        if (handle is null)
+        {
+            return null;
+        }
+
+        HWND windowHandle = handle.Handle;
+        if (windowHandle.IsNull)
+        {
+            return null;
+        }
+
+        uint nativeThreadId = PInvoke.GetWindowThreadProcessId(windowHandle, null);
+        return nativeThreadId != 0
+            && s_dispatchersByThreadId.TryGetValue(nativeThreadId, out Dispatcher? dispatcher)
+                ? dispatcher
+                : null;
+    }
+
+    /// <summary>
+    ///  Occurs when fire-and-forget work throws. Unhandled exceptions terminate the message loop.
+    /// </summary>
+    public event EventHandler<DispatcherUnhandledExceptionEventArgs>? UnhandledException;
+
+    /// <summary>
+    ///  Gets a token that is canceled when the dispatcher stops accepting work or faults.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The token lets producers stop proactively. Cancellation is advisory; queue admission remains authoritative
+    ///   because shutdown can race a token check.
+    ///  </para>
+    /// </remarks>
+    public CancellationToken ShutdownToken => _shutdownToken;
+
+    /// <summary>
+    ///  Gets a task that completes after dispatcher shutdown releases its native wake resources.
+    /// </summary>
+    public Task Completion => _completion.Task;
+
+    /// <summary>
+    ///  Gets the synchronization context installed while this dispatcher runs.
+    /// </summary>
+    internal DispatcherSynchronizationContext SynchronizationContext { get; }
+
+    /// <summary>
+    ///  Gets elapsed monotonic time since this dispatcher was constructed, in <see cref="TimeSpan"/> ticks.
+    /// </summary>
+    internal long MonotonicTicks => GetMonotonicTicks();
+
+    /// <summary>
+    ///  Returns whether the calling thread owns this dispatcher.
+    /// </summary>
+    public bool CheckAccess() => ReferenceEquals(Thread.CurrentThread, _thread);
+
+    /// <summary>
+    ///  Throws when the calling thread does not own this dispatcher.
+    /// </summary>
+    public void VerifyAccess()
+    {
+        if (!CheckAccess())
+        {
+            throw new InvalidOperationException("The calling thread does not own this dispatcher.");
+        }
+    }
+
+    /// <summary>
+    ///  Creates a repeating timer whose ticks run on this dispatcher. Must be called by the owning thread.
+    /// </summary>
+    public DispatcherTimer CreateTimer(TimeSpan interval)
+    {
+        VerifyAccess();
+        return new DispatcherTimer(this, interval);
+    }
+
+    /// <summary>
+    ///  Queues a synchronous callback. The callback is deferred even when called by the owning thread.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Cancellation prevents a queued callback from starting but does not interrupt one already running.
+    ///  </para>
+    /// </remarks>
+    public Task InvokeAsync(Action callback, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        return Enqueue(callback, fireAndForget: false, cancellationToken);
+    }
+
+    /// <summary>
+    ///  Attempts to queue a fire-and-forget callback.
+    /// </summary>
+    /// <param name="callback">The callback to execute.</param>
+    /// <returns><see langword="true"/> when the callback was admitted; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    ///  <para>
+    ///   Admission and shutdown are synchronized, so the result is not a state pre-check. An admitted callback can
+    ///   still be discarded if shutdown begins before it runs. Callback exceptions use <see cref="UnhandledException"/>.
+    ///  </para>
+    /// </remarks>
+    public bool TryPost(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        DispatcherActionWorkItem workItem;
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                return false;
+            }
+
+            workItem = new DispatcherActionWorkItem(
+                this,
+                ++_nextOperationId,
+                callback,
+                CancellationToken.None,
+                fireAndForget: true)
+            {
+                State = DispatcherWorkItemState.Queued
+            };
+
+            _queue.Enqueue(workItem);
+            CaptureAdmissionMetricsLocked(workItem);
+        }
+
+        PublishAdmission(workItem);
+        return true;
+    }
+
+    /// <summary>
+    ///  Queues a synchronous callback for deferred execution.
+    /// </summary>
+    /// <param name="callback">The callback to execute.</param>
+    /// <param name="fireAndForget">
+    ///  <see langword="true"/> to report callback exceptions through <see cref="UnhandledException"/> instead of
+    ///  storing them on the returned task; otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">The token that can prevent the callback from starting.</param>
+    /// <returns>A task that tracks the queued work.</returns>
+    private Task Enqueue(Action callback, bool fireAndForget, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        DispatcherActionWorkItem workItem;
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                return Task.FromException(CreateUnavailableException(_state));
+            }
+
+            workItem = new DispatcherActionWorkItem(
+                this,
+                ++_nextOperationId,
+                callback,
+                cancellationToken,
+                fireAndForget)
+            {
+                State = DispatcherWorkItemState.Queued
+            };
+
+            _queue.Enqueue(workItem);
+            CaptureAdmissionMetricsLocked(workItem);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.Task;
+    }
+
+    /// <summary>
+    ///  Queues a fire-and-forget <see cref="SynchronizationContext"/> callback for deferred execution.
+    /// </summary>
+    /// <param name="callback">The callback to execute.</param>
+    /// <param name="state">The state passed to <paramref name="callback"/>.</param>
+    internal void Post(SendOrPostCallback callback, object? state)
+    {
+        Task task = Enqueue(() => callback(state), fireAndForget: true, CancellationToken.None);
+        if (task.IsFaulted)
+        {
+            task.GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    ///  Queues a fire-and-forget callback after a monotonic delay.
+    /// </summary>
+    /// <param name="delay">The delay before the callback becomes eligible to run.</param>
+    /// <param name="callback">The callback to execute.</param>
+    /// <param name="cancellationToken">The token that can prevent the callback from starting.</param>
+    internal void PostDelayed(TimeSpan delay, Action callback, CancellationToken cancellationToken)
+    {
+        if (!TrySchedule(
+            delay,
+            id => new DispatcherActionWorkItem(
+                this,
+                id,
+                callback,
+                cancellationToken,
+                fireAndForget: true),
+            out DispatcherActionWorkItem? workItem,
+            out ObjectDisposedException? exception))
+        {
+            throw exception;
+        }
+
+        PublishAdmission(workItem);
+    }
+
+    /// <summary>
+    ///  Queues a synchronous function and returns its result.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(Func<TResult> callback, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        DispatcherFuncWorkItem<TResult> workItem;
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                return Task.FromException<TResult>(CreateUnavailableException(_state));
+            }
+
+            workItem = new DispatcherFuncWorkItem<TResult>(this, ++_nextOperationId, callback, cancellationToken)
+            {
+                State = DispatcherWorkItemState.Queued
+            };
+
+            _queue.Enqueue(workItem);
+            CaptureAdmissionMetricsLocked(workItem);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.GetTask();
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous callback and completes after its full <see cref="ValueTask"/> lifetime.
+    /// </summary>
+    public Task InvokeAsync(Func<ValueTask> callback, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return InvokeAsync(_ => callback(), cancellationToken);
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous function and completes after its full <see cref="ValueTask{TResult}"/> lifetime.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(
+        Func<ValueTask<TResult>> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return InvokeAsync(_ => callback(), cancellationToken);
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous callback with an effective token linked to caller cancellation and dispatcher shutdown.
+    /// </summary>
+    public Task InvokeAsync(
+        Func<CancellationToken, ValueTask> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        DispatcherAsyncActionWorkItem workItem;
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                return Task.FromException(CreateUnavailableException(_state));
+            }
+
+            workItem = new DispatcherAsyncActionWorkItem(
+                this,
+                ++_nextOperationId,
+                callback,
+                cancellationToken)
+            {
+                State = DispatcherWorkItemState.Queued
+            };
+
+            _queue.Enqueue(workItem);
+            CaptureAdmissionMetricsLocked(workItem);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.Task;
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous function with an effective token linked to caller cancellation and dispatcher shutdown.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(
+        Func<CancellationToken, ValueTask<TResult>> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        DispatcherAsyncFuncWorkItem<TResult> workItem;
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                return Task.FromException<TResult>(CreateUnavailableException(_state));
+            }
+
+            workItem = new DispatcherAsyncFuncWorkItem<TResult>(
+                this,
+                ++_nextOperationId,
+                callback,
+                cancellationToken)
+            {
+                State = DispatcherWorkItemState.Queued
+            };
+
+            _queue.Enqueue(workItem);
+            CaptureAdmissionMetricsLocked(workItem);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.GetTask();
+    }
+
+    /// <summary>
+    ///  Queues a synchronous callback after a monotonic delay.
+    /// </summary>
+    public Task InvokeAsync(
+        TimeSpan delay,
+        Action callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ValidateDelay(delay);
+
+        if (delay == TimeSpan.Zero)
+        {
+            return InvokeAsync(callback, cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        if (!TrySchedule(
+            delay,
+            id => new DispatcherActionWorkItem(this, id, callback, cancellationToken),
+            out DispatcherActionWorkItem? workItem,
+            out ObjectDisposedException? exception))
+        {
+            return Task.FromException(exception);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.Task;
+    }
+
+    /// <summary>
+    ///  Queues a synchronous function after a monotonic delay.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(
+        TimeSpan delay,
+        Func<TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ValidateDelay(delay);
+
+        if (delay == TimeSpan.Zero)
+        {
+            return InvokeAsync(callback, cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        if (!TrySchedule(
+            delay,
+            id => new DispatcherFuncWorkItem<TResult>(this, id, callback, cancellationToken),
+            out DispatcherFuncWorkItem<TResult>? workItem,
+            out ObjectDisposedException? exception))
+        {
+            return Task.FromException<TResult>(exception);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.GetTask();
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous callback after a monotonic delay.
+    /// </summary>
+    public Task InvokeAsync(
+        TimeSpan delay,
+        Func<ValueTask> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return InvokeAsync(delay, _ => callback(), cancellationToken);
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous function after a monotonic delay.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(
+        TimeSpan delay,
+        Func<ValueTask<TResult>> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return InvokeAsync(delay, _ => callback(), cancellationToken);
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous callback with an effective cancellation token after a monotonic delay.
+    /// </summary>
+    public Task InvokeAsync(
+        TimeSpan delay,
+        Func<CancellationToken, ValueTask> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ValidateDelay(delay);
+
+        if (delay == TimeSpan.Zero)
+        {
+            return InvokeAsync(callback, cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        if (!TrySchedule(
+            delay,
+            id => new DispatcherAsyncActionWorkItem(this, id, callback, cancellationToken),
+            out DispatcherAsyncActionWorkItem? workItem,
+            out ObjectDisposedException? exception))
+        {
+            return Task.FromException(exception);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.Task;
+    }
+
+    /// <summary>
+    ///  Queues an asynchronous function with an effective cancellation token after a monotonic delay.
+    /// </summary>
+    public Task<TResult> InvokeAsync<TResult>(
+        TimeSpan delay,
+        Func<CancellationToken, ValueTask<TResult>> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        ValidateDelay(delay);
+
+        if (delay == TimeSpan.Zero)
+        {
+            return InvokeAsync(callback, cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TResult>(cancellationToken);
+        }
+
+        if (!TrySchedule(
+            delay,
+            id => new DispatcherAsyncFuncWorkItem<TResult>(this, id, callback, cancellationToken),
+            out DispatcherAsyncFuncWorkItem<TResult>? workItem,
+            out ObjectDisposedException? exception))
+        {
+            return Task.FromException<TResult>(exception);
+        }
+
+        PublishAdmission(workItem);
+        return workItem.GetTask();
+    }
+
+    /// <summary>
+    ///  Transitions the dispatcher from created to running.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///  The calling thread does not own the dispatcher, or the dispatcher is not in the created state.
+    /// </exception>
+    internal void Start()
+    {
+        VerifyAccess();
+
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Created)
+            {
+                throw new InvalidOperationException($"The dispatcher cannot start from state '{_state}'.");
+            }
+
+            if (!s_dispatchersByThreadId.TryAdd(_nativeThreadId, this))
+            {
+                throw new InvalidOperationException("The current thread already has a running dispatcher.");
+            }
+
+            _registered = true;
+            _state = DispatcherState.Running;
+        }
+
+        DispatcherEventSource.Log.Started((int)_nativeThreadId);
+    }
+
+    /// <summary>
+    ///  Stops accepting work by transitioning a running dispatcher to stopping.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own the dispatcher.</exception>
+    internal void BeginShutdown()
+    {
+        VerifyAccess();
+
+        bool unregister = false;
+        bool cancel = false;
+        lock (_lock)
+        {
+            if (_state == DispatcherState.Running)
+            {
+                _state = DispatcherState.Stopping;
+                unregister = _registered;
+                _registered = false;
+                cancel = true;
+            }
+        }
+
+        if (unregister)
+        {
+            Unregister();
+        }
+
+        if (cancel)
+        {
+            _shutdownSource.Cancel();
+        }
+    }
+
+    /// <summary>
+    ///  Stops the dispatcher and faults all queued, scheduled, and active asynchronous work that remains.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own the dispatcher.</exception>
+    internal void Stop()
+    {
+        VerifyAccess();
+
+        List<DispatcherWorkItem> pending = [];
+        bool unregister;
+        DispatcherState terminalState;
+        lock (_lock)
+        {
+            if (_state == DispatcherState.Stopped)
+            {
+                return;
+            }
+
+            unregister = _registered;
+            _registered = false;
+
+            if (_state != DispatcherState.Faulted)
+            {
+                _state = DispatcherState.Stopping;
+            }
+
+            _wakeRequested = false;
+            DetachPendingWorkLocked(pending);
+
+            if (_state != DispatcherState.Faulted)
+            {
+                _state = DispatcherState.Stopped;
+            }
+
+            terminalState = _state;
+        }
+
+        if (unregister)
+        {
+            Unregister();
+        }
+
+        foreach (DispatcherWorkItem workItem in pending)
+        {
+            workItem.CompleteFaulted(CreateUnavailableException(terminalState, workItem.Id));
+            EmitOperationCompleted(workItem);
+        }
+
+        Exception? cleanupException = null;
+
+        try
+        {
+            _wake.CancelDelayedWake();
+        }
+        catch (Exception cancelWakeException)
+        {
+            cleanupException = cancelWakeException;
+        }
+
+        try
+        {
+            _shutdownSource.Cancel();
+        }
+        catch (Exception cancellationException)
+        {
+            cleanupException = cleanupException is null
+                ? cancellationException
+                : new AggregateException(cleanupException, cancellationException);
+        }
+
+        DispatcherEventSource.Log.Stopped(
+            (int)_nativeThreadId,
+            _highWatermark,
+            _postedCount,
+            _completedCount);
+
+        if (cleanupException is not null)
+        {
+            ExceptionDispatchInfo.Capture(cleanupException).Throw();
+        }
+    }
+
+    /// <summary>
+    ///  Cancels a work item if it has not started.
+    /// </summary>
+    /// <param name="workItem">The queued work item to cancel.</param>
+    internal void Cancel(DispatcherWorkItem workItem)
+    {
+        lock (_lock)
+        {
+            if (workItem.State != DispatcherWorkItemState.Queued)
+            {
+                return;
+            }
+
+            workItem.State = DispatcherWorkItemState.Canceled;
+            _completedCount++;
+            workItem.Release();
+        }
+
+        workItem.CompleteCanceled();
+        EmitOperationCompleted(workItem);
+
+        // Let the pump discard the canceled tombstone and reschedule the next delayed wake.
+        RequestWake();
+    }
+
+    /// <summary>
+    ///  Transitions a running work item to a terminal state and records its completion.
+    /// </summary>
+    /// <param name="workItem">The running work item to transition.</param>
+    /// <param name="terminalState">The terminal state to assign.</param>
+    /// <returns><see langword="true"/> if the transition was applied.</returns>
+    internal bool TryTransitionToTerminal(DispatcherWorkItem workItem, DispatcherWorkItemState terminalState)
+    {
+        lock (_lock)
+        {
+            if (workItem.State != DispatcherWorkItemState.Running)
+            {
+                return false;
+            }
+
+            workItem.State = terminalState;
+            _completedCount++;
+            _activeAsyncWork.Remove(workItem);
+        }
+
+        EmitOperationCompleted(workItem);
+        return true;
+    }
+
+    /// <summary>
+    ///  Tracks a work item whose asynchronous callback has not completed.
+    /// </summary>
+    /// <param name="workItem">The running asynchronous work item.</param>
+    internal void MarkAsyncPending(DispatcherWorkItem workItem)
+    {
+        lock (_lock)
+        {
+            if (workItem.State == DispatcherWorkItemState.Running)
+            {
+                _activeAsyncWork.Add(workItem);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Stops tracking an asynchronous work item.
+    /// </summary>
+    /// <param name="workItem">The asynchronous work item to remove.</param>
+    internal void RemoveAsyncPending(DispatcherWorkItem workItem)
+    {
+        lock (_lock)
+        {
+            _activeAsyncWork.Remove(workItem);
+        }
+    }
+
+    /// <summary>
+    ///  Promotes due scheduled work and invokes at most one queued work item.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own the dispatcher.</exception>
+    private void ProcessQueue()
+    {
+        VerifyAccess();
+
+        PromoteScheduledWork();
+
+        DispatcherWorkItem? workItem = null;
+        lock (_lock)
+        {
+            // Accept the current wake before dequeueing so producers racing this turn can request the next one.
+            _wakeRequested = false;
+
+            while (_queue.TryDequeue(out DispatcherWorkItem? candidate))
+            {
+                if (candidate.State == DispatcherWorkItemState.Queued)
+                {
+                    candidate.State = DispatcherWorkItemState.Running;
+                    workItem = candidate;
+                    break;
+                }
+            }
+        }
+
+        if (workItem is not null)
+        {
+            DispatcherEventSource.Log.OperationStarted(
+                (int)_nativeThreadId,
+                workItem.Id,
+                Math.Max(0, GetMonotonicTicks() - workItem.AdmittedTicks));
+        }
+
+        workItem?.Invoke();
+
+        // One operation per wake yields back to USER32 between callbacks; post another turn only when work remains.
+        RearmWakeForQueuedWork();
+    }
+
+    /// <summary>
+    ///  Processes a dispatcher wake message and faults the dispatcher if processing fails.
+    /// </summary>
+    internal void ProcessWake()
+    {
+        try
+        {
+            ProcessQueue();
+        }
+        catch (Exception exception)
+        {
+            Fault(exception);
+        }
+    }
+
+    /// <summary>
+    ///  Cancels the delivered delayed wake, processes due work, and faults the dispatcher if processing fails.
+    /// </summary>
+    internal void ProcessDelayedWake()
+    {
+        try
+        {
+            _wake.CancelDelayedWake();
+            ProcessQueue();
+        }
+        catch (Exception exception)
+        {
+            Fault(exception);
+        }
+    }
+
+    /// <summary>
+    ///  Rethrows the exception that faulted the dispatcher, if any.
+    /// </summary>
+    internal void ThrowIfFaulted() => Volatile.Read(ref _fault)?.Throw();
+
+    /// <summary>
+    ///  Raises <see cref="UnhandledException"/> for a fire-and-forget callback and faults the dispatcher if unhandled.
+    /// </summary>
+    /// <param name="exception">The callback exception to report.</param>
+    internal void ReportUnhandledException(Exception exception)
+    {
+        DispatcherUnhandledExceptionEventArgs arguments = new(exception);
+
+        try
+        {
+            UnhandledException?.Invoke(this, arguments);
+        }
+        catch (Exception handlerException)
+        {
+            Fault(new AggregateException(exception, handlerException));
+            return;
+        }
+
+        if (!arguments.Handled)
+        {
+            Fault(exception);
+        }
+    }
+
+    private void RearmWakeForQueuedWork()
+    {
+        bool shouldPost;
+        lock (_lock)
+        {
+            shouldPost = _state == DispatcherState.Running && _queue.Count > 0 && !_wakeRequested;
+            if (shouldPost)
+            {
+                _wakeRequested = true;
+            }
+        }
+
+        if (shouldPost)
+        {
+            PostWake();
+        }
+    }
+
+    private void RequestWake()
+    {
+        bool shouldPost;
+        lock (_lock)
+        {
+            shouldPost = _state == DispatcherState.Running && !_wakeRequested;
+            if (shouldPost)
+            {
+                _wakeRequested = true;
+            }
+        }
+
+        if (shouldPost)
+        {
+            PostWake();
+        }
+    }
+
+    private bool TrySchedule<TWorkItem>(
+        TimeSpan delay,
+        Func<long, TWorkItem> createWorkItem,
+        [NotNullWhen(true)] out TWorkItem? workItem,
+        [NotNullWhen(false)] out ObjectDisposedException? exception)
+        where TWorkItem : DispatcherWorkItem
+    {
+        lock (_lock)
+        {
+            if (_state != DispatcherState.Running)
+            {
+                workItem = null;
+                exception = CreateUnavailableException(_state);
+                return false;
+            }
+
+            long id = ++_nextOperationId;
+            workItem = createWorkItem(id);
+            workItem.State = DispatcherWorkItemState.Queued;
+            _scheduledWork.Enqueue(workItem, (GetDueTicks(delay), id));
+            CaptureAdmissionMetricsLocked(workItem);
+            exception = null;
+            return true;
+        }
+    }
+
+    private void PromoteScheduledWork()
+    {
+        long currentTicks = GetMonotonicTicks();
+        long? nextDueTicks = null;
+
+        lock (_lock)
+        {
+            while (_scheduledWork.TryPeek(out DispatcherWorkItem? workItem, out (long DueTicks, long Id) priority))
+            {
+                // Cancellation leaves a tombstone in the priority queue; remove it lazily to avoid a linear search.
+                if (workItem.State != DispatcherWorkItemState.Queued)
+                {
+                    _scheduledWork.Dequeue();
+                    continue;
+                }
+
+                if (priority.DueTicks > currentTicks)
+                {
+                    nextDueTicks = priority.DueTicks;
+                    break;
+                }
+
+                _scheduledWork.Dequeue();
+                _queue.Enqueue(workItem);
+            }
+        }
+
+        if (nextDueTicks is long dueTicks)
+        {
+            uint delayMilliseconds = GetWakeDelayMilliseconds(dueTicks - currentTicks);
+            _wake.WakeAfter(delayMilliseconds);
+            DispatcherEventSource.Log.DelayedWakeScheduled((int)_nativeThreadId, delayMilliseconds);
+        }
+        else
+        {
+            _wake.CancelDelayedWake();
+        }
+    }
+
+    private long GetDueTicks(TimeSpan delay)
+    {
+        long currentTicks = GetMonotonicTicks();
+
+        // Saturation keeps very long delays ordered without allowing signed overflow to make them immediately due.
+        return delay.Ticks > long.MaxValue - currentTicks
+            ? long.MaxValue
+            : currentTicks + delay.Ticks;
+    }
+
+    private long GetMonotonicTicks() => _timeProvider.GetElapsedTime(_timestampOrigin).Ticks;
+
+    private static uint GetWakeDelayMilliseconds(long remainingTicks)
+    {
+        Debug.Assert(remainingTicks > 0);
+
+        // WakeAfter accepts whole milliseconds. Round up so a callback is never promoted before its deadline.
+        long milliseconds = remainingTicks / TimeSpan.TicksPerMillisecond;
+        if (remainingTicks % TimeSpan.TicksPerMillisecond != 0)
+        {
+            milliseconds++;
+        }
+
+        return (uint)Math.Clamp(milliseconds, 1, uint.MaxValue);
+    }
+
+    private static void ValidateDelay(TimeSpan delay) => ArgumentOutOfRangeException.ThrowIfLessThan(delay, TimeSpan.Zero);
+
+    private void PostWake()
+    {
+        try
+        {
+            _wake.Wake();
+        }
+        catch (Exception exception)
+        {
+            Fault(exception);
+        }
+    }
+
+    private void CaptureAdmissionMetricsLocked(DispatcherWorkItem workItem)
+    {
+        workItem.AdmittedTicks = GetMonotonicTicks();
+        workItem.QueueDepthAtAdmission = _queue.Count + _scheduledWork.Count + _activeAsyncWork.Count;
+        _highWatermark = Math.Max(_highWatermark, workItem.QueueDepthAtAdmission);
+        _postedCount++;
+    }
+
+    private void EmitOperationCompleted(DispatcherWorkItem workItem)
+        => DispatcherEventSource.Log.OperationCompleted(
+            (int)_nativeThreadId,
+            workItem.Id,
+            (int)workItem.State);
+
+    private void PublishAdmission(DispatcherWorkItem workItem)
+    {
+        // Register can cancel synchronously, so publish admission before a cancellation completion event can fire.
+        DispatcherEventSource.Log.OperationPosted(
+            (int)_nativeThreadId,
+            workItem.Id,
+            workItem.QueueDepthAtAdmission,
+            Volatile.Read(ref _highWatermark));
+        workItem.RegisterCancellation();
+
+        // Delayed admissions also wake immediately so ProcessQueue can schedule the earliest delayed wake.
+        RequestWake();
+    }
+
+    private void Fault(Exception exception)
+    {
+        List<DispatcherWorkItem> pending = [];
+        bool unregister;
+
+        lock (_lock)
+        {
+            if (_state == DispatcherState.Faulted)
+            {
+                return;
+            }
+
+            _state = DispatcherState.Faulted;
+            _wakeRequested = false;
+            unregister = _registered;
+            _registered = false;
+            Volatile.Write(ref _fault, ExceptionDispatchInfo.Capture(exception));
+            DetachPendingWorkLocked(pending);
+        }
+
+        if (unregister)
+        {
+            Unregister();
+        }
+
+        foreach (DispatcherWorkItem workItem in pending)
+        {
+            workItem.CompleteFaulted(exception);
+            EmitOperationCompleted(workItem);
+        }
+
+        DispatcherEventSource.Log.Faulted(
+            (int)_nativeThreadId,
+            exception.HResult,
+            exception.GetType().FullName ?? exception.GetType().Name);
+
+        try
+        {
+            _shutdownSource.Cancel();
+        }
+        catch (Exception cancellationException)
+        {
+            Volatile.Write(
+                ref _fault,
+                ExceptionDispatchInfo.Capture(new AggregateException(exception, cancellationException)));
+        }
+        finally
+        {
+            SignalFaultToOwner();
+        }
+    }
+
+    // Detach under the queue lock, then complete tasks outside it so arbitrary continuations cannot run under _lock.
+    private void DetachPendingWorkLocked(List<DispatcherWorkItem> pending)
+    {
+        while (_queue.TryDequeue(out DispatcherWorkItem? workItem))
+        {
+            if (workItem.State == DispatcherWorkItemState.Queued)
+            {
+                Detach(workItem);
+            }
+        }
+
+        while (_scheduledWork.TryDequeue(out DispatcherWorkItem? workItem, out _))
+        {
+            if (workItem.State == DispatcherWorkItemState.Queued)
+            {
+                Detach(workItem);
+            }
+        }
+
+        foreach (DispatcherWorkItem workItem in _activeAsyncWork)
+        {
+            if (workItem.State == DispatcherWorkItemState.Running)
+            {
+                Detach(workItem);
+            }
+        }
+
+        _activeAsyncWork.Clear();
+
+        void Detach(DispatcherWorkItem workItem)
+        {
+            workItem.State = DispatcherWorkItemState.Faulted;
+            _completedCount++;
+            workItem.Release();
+            pending.Add(workItem);
+        }
+    }
+
+    private void SignalFaultToOwner()
+    {
+        // Owner-thread faults return to a managed pump boundary, which calls ThrowIfFaulted directly.
+        if (CheckAccess())
+        {
+            return;
+        }
+
+        // A foreign thread must wake GetMessage. WM_QUIT is independent of the wake HWND and starts pump teardown.
+        if (PInvoke.PostThreadMessage(_nativeThreadId, Interop.WM_QUIT, default, default))
+        {
+            return;
+        }
+
+        Exception postThreadException =
+            new ThirtyTwoException(Error.GetLastError(), "Failed to post WM_QUIT to the dispatcher thread.");
+
+        try
+        {
+            // Preserve the PostThreadMessage failure, but use the ordinary wake HWND as a best-effort fallback.
+            _wake.Wake();
+            AddFaultException(postThreadException);
+        }
+        catch (Exception wakeException)
+        {
+            AddFaultException(new AggregateException(postThreadException, wakeException));
+        }
+    }
+
+    private void AddFaultException(Exception exception)
+    {
+        ExceptionDispatchInfo? existing = Volatile.Read(ref _fault);
+        Exception combined = existing is null
+            ? exception
+            : new AggregateException(existing.SourceException, exception);
+        Volatile.Write(ref _fault, ExceptionDispatchInfo.Capture(combined));
+    }
+
+    private void Unregister()
+    {
+        bool removed = s_dispatchersByThreadId.TryRemove(_nativeThreadId, out Dispatcher? dispatcher);
+        Debug.Assert(removed && ReferenceEquals(dispatcher, this));
+    }
+
+    private ObjectDisposedException CreateUnavailableException(DispatcherState state, long? operationId = null)
+    {
+        string operation = operationId is long id ? $" Operation {id}." : string.Empty;
+        return new ObjectDisposedException(
+            nameof(Dispatcher),
+            $"Dispatcher on native thread {_nativeThreadId} is in state '{state}'.{operation}");
+    }
+
+    /// <summary>
+    ///  Stops the dispatcher and releases its wake transport and shutdown token source.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own the dispatcher.</exception>
+    internal void Dispose()
+    {
+        VerifyAccess();
+        Exception? cleanupException = null;
+
+        try
+        {
+            Stop();
+        }
+        catch (Exception stopException)
+        {
+            cleanupException = stopException;
+        }
+
+        try
+        {
+            _wake.Dispose();
+        }
+        catch (Exception wakeException)
+        {
+            cleanupException = cleanupException is null
+                ? wakeException
+                : new AggregateException(cleanupException, wakeException);
+        }
+        finally
+        {
+            _completion.TrySetResult();
+        }
+
+        if (cleanupException is not null)
+        {
+            ExceptionDispatchInfo.Capture(cleanupException).Throw();
+        }
+    }
+}

--- a/src/thirtytwo/Threading/Dispatcher.cs
+++ b/src/thirtytwo/Threading/Dispatcher.cs
@@ -1292,7 +1292,14 @@ public sealed class Dispatcher
         }
         finally
         {
-            _completion.TrySetResult();
+            try
+            {
+                _shutdownSource.Dispose();
+            }
+            finally
+            {
+                _completion.TrySetResult();
+            }
         }
 
         if (cleanupException is not null)

--- a/src/thirtytwo/Threading/DispatcherActionWorkItem.cs
+++ b/src/thirtytwo/Threading/DispatcherActionWorkItem.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents an awaitable or fire-and-forget synchronous action.
+/// </summary>
+internal sealed class DispatcherActionWorkItem : DispatcherWorkItem
+{
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly bool _fireAndForget;
+    private Action? _callback;
+
+    /// <summary>
+    ///  Initializes a synchronous action work item.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher that owns the operation.</param>
+    /// <param name="id">The operation identifier.</param>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <param name="cancellationToken">The caller's cancellation token.</param>
+    /// <param name="fireAndForget">Whether callback exceptions use the dispatcher exception policy.</param>
+    internal DispatcherActionWorkItem(
+        Dispatcher dispatcher,
+        long id,
+        Action callback,
+        CancellationToken cancellationToken,
+        bool fireAndForget = false)
+        : base(dispatcher, id, cancellationToken)
+    {
+        _callback = callback;
+        _fireAndForget = fireAndForget;
+    }
+
+    /// <inheritdoc/>
+    internal override Task Task => _completion.Task;
+
+    /// <inheritdoc/>
+    protected override void InvokeCore()
+    {
+        Action callback = _callback!;
+        _callback = null;
+
+        try
+        {
+            callback();
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Succeeded))
+            {
+                CompleteCancellationRegistration();
+                _completion.TrySetResult();
+            }
+        }
+        catch (Exception exception)
+        {
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Faulted))
+            {
+                if (_fireAndForget)
+                {
+                    CompleteCancellationRegistration();
+                    _completion.TrySetResult();
+                    Dispatcher.ReportUnhandledException(exception);
+                }
+                else
+                {
+                    CompleteFaulted(exception);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteCanceled()
+    {
+        CompleteCancellationRegistration();
+        _completion.TrySetCanceled(CancellationToken);
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteFaulted(Exception exception)
+    {
+        CompleteCancellationRegistration();
+        if (_fireAndForget)
+        {
+            _completion.TrySetResult();
+        }
+        else
+        {
+            _completion.TrySetException(exception);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void ReleaseCallback() => _callback = null;
+}

--- a/src/thirtytwo/Threading/DispatcherAsyncActionWorkItem.cs
+++ b/src/thirtytwo/Threading/DispatcherAsyncActionWorkItem.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents an asynchronous action that receives an effective cancellation token.
+/// </summary>
+internal sealed class DispatcherAsyncActionWorkItem : DispatcherWorkItem
+{
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource? _linkedCancellationSource;
+    private readonly CancellationToken _effectiveCancellationToken;
+    private Func<CancellationToken, ValueTask>? _callback;
+    private bool _observerOwnsLinkedCancellationSource;
+
+    /// <summary>
+    ///  Initializes an asynchronous action work item.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher that owns the operation.</param>
+    /// <param name="id">The operation identifier.</param>
+    /// <param name="callback">The asynchronous callback to invoke.</param>
+    /// <param name="cancellationToken">The caller's cancellation token.</param>
+    internal DispatcherAsyncActionWorkItem(
+        Dispatcher dispatcher,
+        long id,
+        Func<CancellationToken, ValueTask> callback,
+        CancellationToken cancellationToken)
+        : base(dispatcher, id, cancellationToken)
+    {
+        _callback = callback;
+
+        // Running callbacks observe both caller cancellation and dispatcher shutdown. Avoid allocating a linked
+        // source when only shutdown can cancel the callback.
+        if (cancellationToken.CanBeCanceled)
+        {
+            _linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                dispatcher.ShutdownToken);
+            _effectiveCancellationToken = _linkedCancellationSource.Token;
+        }
+        else
+        {
+            _effectiveCancellationToken = dispatcher.ShutdownToken;
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override Task Task => _completion.Task;
+
+    /// <inheritdoc/>
+    protected override void InvokeCore()
+    {
+        Func<CancellationToken, ValueTask> callback = _callback!;
+        _callback = null;
+
+        ValueTask callbackTask;
+        try
+        {
+            callbackTask = callback(_effectiveCancellationToken);
+        }
+        catch (Exception exception)
+        {
+            CompleteFromException(exception);
+            DisposeLinkedCancellationSource();
+            return;
+        }
+
+        if (callbackTask.IsCompleted)
+        {
+            try
+            {
+                callbackTask.GetAwaiter().GetResult();
+                CompleteSucceeded();
+            }
+            catch (Exception exception)
+            {
+                CompleteFromException(exception);
+            }
+            finally
+            {
+                DisposeLinkedCancellationSource();
+            }
+
+            return;
+        }
+
+        // An incomplete callback may outlive dispatcher shutdown. Its observer retains and ultimately disposes the
+        // linked source even if shutdown makes the public Task terminal first.
+        _observerOwnsLinkedCancellationSource = true;
+        Dispatcher.MarkAsyncPending(this);
+        _ = ObserveAsync(callbackTask);
+    }
+
+    private async Task ObserveAsync(ValueTask callbackTask)
+    {
+        try
+        {
+            await callbackTask.ConfigureAwait(false);
+            CompleteSucceeded();
+        }
+        catch (Exception exception)
+        {
+            CompleteFromException(exception);
+        }
+        finally
+        {
+            Dispatcher.RemoveAsyncPending(this);
+            DisposeLinkedCancellationSource();
+        }
+    }
+
+    private void CompleteSucceeded()
+    {
+        if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Succeeded))
+        {
+            CompleteCancellationRegistration();
+            _completion.TrySetResult();
+        }
+    }
+
+    private void CompleteFromException(Exception exception)
+    {
+        if (exception is OperationCanceledException canceled
+            && canceled.CancellationToken == _effectiveCancellationToken)
+        {
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Canceled))
+            {
+                CompleteCancellationRegistration();
+
+                // Prefer the caller's token when it initiated cancellation; otherwise report dispatcher shutdown.
+                CancellationToken token = CancellationToken.IsCancellationRequested
+                    ? CancellationToken
+                    : _effectiveCancellationToken;
+                _completion.TrySetCanceled(token);
+            }
+
+            return;
+        }
+
+        if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Faulted))
+        {
+            CompleteFaulted(exception);
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteCanceled()
+    {
+        CompleteCancellationRegistration();
+        DisposeLinkedCancellationSource();
+        _completion.TrySetCanceled(CancellationToken);
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteFaulted(Exception exception)
+    {
+        CompleteCancellationRegistration();
+
+        // ObserveAsync still uses the effective token until the callback itself exits.
+        if (!_observerOwnsLinkedCancellationSource)
+        {
+            DisposeLinkedCancellationSource();
+        }
+
+        _completion.TrySetException(exception);
+    }
+
+    /// <inheritdoc/>
+    protected override void ReleaseCallback() => _callback = null;
+
+    private void DisposeLinkedCancellationSource() => _linkedCancellationSource?.Dispose();
+}

--- a/src/thirtytwo/Threading/DispatcherAsyncFuncWorkItem.cs
+++ b/src/thirtytwo/Threading/DispatcherAsyncFuncWorkItem.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents an asynchronous function that receives an effective cancellation token and returns a result.
+/// </summary>
+/// <typeparam name="TResult">The function result type.</typeparam>
+internal sealed class DispatcherAsyncFuncWorkItem<TResult> : DispatcherWorkItem
+{
+    private readonly TaskCompletionSource<TResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource? _linkedCancellationSource;
+    private readonly CancellationToken _effectiveCancellationToken;
+    private Func<CancellationToken, ValueTask<TResult>>? _callback;
+    private bool _observerOwnsLinkedCancellationSource;
+
+    /// <summary>
+    ///  Initializes an asynchronous function work item.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher that owns the operation.</param>
+    /// <param name="id">The operation identifier.</param>
+    /// <param name="callback">The asynchronous function to invoke.</param>
+    /// <param name="cancellationToken">The caller's cancellation token.</param>
+    internal DispatcherAsyncFuncWorkItem(
+        Dispatcher dispatcher,
+        long id,
+        Func<CancellationToken, ValueTask<TResult>> callback,
+        CancellationToken cancellationToken)
+        : base(dispatcher, id, cancellationToken)
+    {
+        _callback = callback;
+
+        // Running callbacks observe both caller cancellation and dispatcher shutdown. Avoid allocating a linked
+        // source when only shutdown can cancel the callback.
+        if (cancellationToken.CanBeCanceled)
+        {
+            _linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                dispatcher.ShutdownToken);
+            _effectiveCancellationToken = _linkedCancellationSource.Token;
+        }
+        else
+        {
+            _effectiveCancellationToken = dispatcher.ShutdownToken;
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override Task Task => _completion.Task;
+
+    /// <summary>
+    ///  Gets the task that contains the operation result.
+    /// </summary>
+    /// <returns>The typed operation task.</returns>
+    internal Task<TResult> GetTask() => _completion.Task;
+
+    /// <inheritdoc/>
+    protected override void InvokeCore()
+    {
+        Func<CancellationToken, ValueTask<TResult>> callback = _callback!;
+        _callback = null;
+
+        ValueTask<TResult> callbackTask;
+        try
+        {
+            callbackTask = callback(_effectiveCancellationToken);
+        }
+        catch (Exception exception)
+        {
+            CompleteFromException(exception);
+            DisposeLinkedCancellationSource();
+            return;
+        }
+
+        if (callbackTask.IsCompleted)
+        {
+            try
+            {
+                CompleteSucceeded(callbackTask.GetAwaiter().GetResult());
+            }
+            catch (Exception exception)
+            {
+                CompleteFromException(exception);
+            }
+            finally
+            {
+                DisposeLinkedCancellationSource();
+            }
+
+            return;
+        }
+
+        // An incomplete callback may outlive dispatcher shutdown. Its observer retains and ultimately disposes the
+        // linked source even if shutdown makes the public Task terminal first.
+        _observerOwnsLinkedCancellationSource = true;
+        Dispatcher.MarkAsyncPending(this);
+        _ = ObserveAsync(callbackTask);
+    }
+
+    private async Task ObserveAsync(ValueTask<TResult> callbackTask)
+    {
+        try
+        {
+            TResult result = await callbackTask.ConfigureAwait(false);
+            CompleteSucceeded(result);
+        }
+        catch (Exception exception)
+        {
+            CompleteFromException(exception);
+        }
+        finally
+        {
+            Dispatcher.RemoveAsyncPending(this);
+            DisposeLinkedCancellationSource();
+        }
+    }
+
+    private void CompleteSucceeded(TResult result)
+    {
+        if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Succeeded))
+        {
+            CompleteCancellationRegistration();
+            _completion.TrySetResult(result);
+        }
+    }
+
+    private void CompleteFromException(Exception exception)
+    {
+        if (exception is OperationCanceledException canceled
+            && canceled.CancellationToken == _effectiveCancellationToken)
+        {
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Canceled))
+            {
+                CompleteCancellationRegistration();
+
+                // Prefer the caller's token when it initiated cancellation; otherwise report dispatcher shutdown.
+                CancellationToken token = CancellationToken.IsCancellationRequested
+                    ? CancellationToken
+                    : _effectiveCancellationToken;
+                _completion.TrySetCanceled(token);
+            }
+
+            return;
+        }
+
+        if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Faulted))
+        {
+            CompleteFaulted(exception);
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteCanceled()
+    {
+        CompleteCancellationRegistration();
+        DisposeLinkedCancellationSource();
+        _completion.TrySetCanceled(CancellationToken);
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteFaulted(Exception exception)
+    {
+        CompleteCancellationRegistration();
+
+        // ObserveAsync still uses the effective token until the callback itself exits.
+        if (!_observerOwnsLinkedCancellationSource)
+        {
+            DisposeLinkedCancellationSource();
+        }
+
+        _completion.TrySetException(exception);
+    }
+
+    /// <inheritdoc/>
+    protected override void ReleaseCallback() => _callback = null;
+
+    private void DisposeLinkedCancellationSource() => _linkedCancellationSource?.Dispose();
+}

--- a/src/thirtytwo/Threading/DispatcherEventSource.cs
+++ b/src/thirtytwo/Threading/DispatcherEventSource.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Emits dispatcher lifecycle, queue, timer, and fault events.
+/// </summary>
+[EventSource(Name = "ThirtyTwo-Dispatcher")]
+internal sealed class DispatcherEventSource : EventSource
+{
+    /// <summary>
+    ///  Gets the dispatcher event source.
+    /// </summary>
+    internal static DispatcherEventSource Log { get; } = new();
+
+    /// <summary>
+    ///  Records that a dispatcher started.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    [Event(1, Level = EventLevel.Informational)]
+    public void Started(int nativeThreadId) => WriteEvent(1, nativeThreadId);
+
+    /// <summary>
+    ///  Records that an operation was posted.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="queueDepth">The queue depth at admission.</param>
+    /// <param name="highWatermark">The highest queue depth observed.</param>
+    [Event(2, Level = EventLevel.Verbose)]
+    public void OperationPosted(int nativeThreadId, long operationId, int queueDepth, int highWatermark)
+        => WriteEvent(2, nativeThreadId, operationId, queueDepth, highWatermark);
+
+    /// <summary>
+    ///  Records that an operation started.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="queueLatencyTicks">The monotonic queue latency in <see cref="TimeSpan"/> ticks.</param>
+    [Event(3, Level = EventLevel.Verbose)]
+    public void OperationStarted(int nativeThreadId, long operationId, long queueLatencyTicks)
+        => WriteEvent(3, nativeThreadId, operationId, queueLatencyTicks);
+
+    /// <summary>
+    ///  Records that an operation completed.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="state">The terminal <see cref="DispatcherWorkItemState"/> value.</param>
+    [Event(4, Level = EventLevel.Verbose)]
+    public void OperationCompleted(int nativeThreadId, long operationId, int state)
+        => WriteEvent(4, nativeThreadId, operationId, state);
+
+    /// <summary>
+    ///  Records that a delayed wake was scheduled.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="delayMilliseconds">The requested delay in milliseconds.</param>
+    [Event(5, Level = EventLevel.Verbose)]
+    public void DelayedWakeScheduled(int nativeThreadId, uint delayMilliseconds)
+        => WriteEvent(5, nativeThreadId, delayMilliseconds);
+
+    /// <summary>
+    ///  Records that the dispatcher faulted.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="hresult">The fault HRESULT.</param>
+    /// <param name="exceptionType">The exception type name.</param>
+    [Event(6, Level = EventLevel.Error)]
+    public void Faulted(int nativeThreadId, int hresult, string exceptionType)
+        => WriteEvent(6, nativeThreadId, hresult, exceptionType);
+
+    /// <summary>
+    ///  Records that the dispatcher stopped.
+    /// </summary>
+    /// <param name="nativeThreadId">The native dispatcher thread identifier.</param>
+    /// <param name="highWatermark">The highest queue depth observed.</param>
+    /// <param name="postedCount">The number of operations posted.</param>
+    /// <param name="completedCount">The number of operations completed.</param>
+    [Event(7, Level = EventLevel.Informational)]
+    public void Stopped(int nativeThreadId, int highWatermark, long postedCount, long completedCount)
+        => WriteEvent(7, nativeThreadId, highWatermark, postedCount, completedCount);
+}

--- a/src/thirtytwo/Threading/DispatcherFuncWorkItem.cs
+++ b/src/thirtytwo/Threading/DispatcherFuncWorkItem.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents a synchronous function that returns a result.
+/// </summary>
+/// <typeparam name="TResult">The function result type.</typeparam>
+internal sealed class DispatcherFuncWorkItem<TResult> : DispatcherWorkItem
+{
+    private readonly TaskCompletionSource<TResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Func<TResult>? _callback;
+
+    /// <summary>
+    ///  Initializes a synchronous function work item.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher that owns the operation.</param>
+    /// <param name="id">The operation identifier.</param>
+    /// <param name="callback">The function to invoke.</param>
+    /// <param name="cancellationToken">The caller's cancellation token.</param>
+    internal DispatcherFuncWorkItem(
+        Dispatcher dispatcher,
+        long id,
+        Func<TResult> callback,
+        CancellationToken cancellationToken)
+        : base(dispatcher, id, cancellationToken)
+    {
+        _callback = callback;
+    }
+
+    /// <inheritdoc/>
+    internal override Task Task => _completion.Task;
+
+    /// <inheritdoc/>
+    protected override void InvokeCore()
+    {
+        Func<TResult> callback = _callback!;
+        _callback = null;
+
+        try
+        {
+            TResult result = callback();
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Succeeded))
+            {
+                CompleteCancellationRegistration();
+                _completion.TrySetResult(result);
+            }
+        }
+        catch (Exception exception)
+        {
+            if (Dispatcher.TryTransitionToTerminal(this, DispatcherWorkItemState.Faulted))
+            {
+                CompleteFaulted(exception);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteCanceled()
+    {
+        CompleteCancellationRegistration();
+        _completion.TrySetCanceled(CancellationToken);
+    }
+
+    /// <inheritdoc/>
+    internal override void CompleteFaulted(Exception exception)
+    {
+        CompleteCancellationRegistration();
+        _completion.TrySetException(exception);
+    }
+
+    /// <inheritdoc/>
+    protected override void ReleaseCallback() => _callback = null;
+
+    /// <summary>
+    ///  Gets the task that contains the operation result.
+    /// </summary>
+    /// <returns>The typed operation task.</returns>
+    internal Task<TResult> GetTask() => _completion.Task;
+}

--- a/src/thirtytwo/Threading/DispatcherState.cs
+++ b/src/thirtytwo/Threading/DispatcherState.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Defines dispatcher lifecycle states.
+/// </summary>
+internal enum DispatcherState
+{
+    /// <summary>The dispatcher has been constructed but not started.</summary>
+    Created,
+
+    /// <summary>The dispatcher accepts and processes work.</summary>
+    Running,
+
+    /// <summary>The dispatcher no longer accepts work and is shutting down.</summary>
+    Stopping,
+
+    /// <summary>The dispatcher has stopped.</summary>
+    Stopped,
+
+    /// <summary>The dispatcher stopped because of an infrastructure or unhandled callback failure.</summary>
+    Faulted
+}

--- a/src/thirtytwo/Threading/DispatcherSynchronizationContext.cs
+++ b/src/thirtytwo/Threading/DispatcherSynchronizationContext.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Routes synchronization-context callbacks through a dispatcher.
+/// </summary>
+/// <param name="dispatcher">The dispatcher that owns this context.</param>
+internal sealed class DispatcherSynchronizationContext(Dispatcher dispatcher) : SynchronizationContext
+{
+    /// <inheritdoc/>
+    public override SynchronizationContext CreateCopy() => new DispatcherSynchronizationContext(dispatcher);
+
+    /// <inheritdoc/>
+    public override void Post(SendOrPostCallback callback, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        dispatcher.Post(callback, state);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    ///  <para>
+    ///   Runs inline on the dispatcher thread. A foreign thread blocks without pumping until the queued callback
+    ///   completes; dispatcher-aware callers should prefer
+    ///   <see cref="Dispatcher.InvokeAsync(Action, CancellationToken)"/>.
+    ///  </para>
+    /// </remarks>
+    public override void Send(SendOrPostCallback callback, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (dispatcher.CheckAccess())
+        {
+            callback(state);
+            return;
+        }
+
+        dispatcher.InvokeAsync(() => callback(state)).GetAwaiter().GetResult();
+    }
+}

--- a/src/thirtytwo/Threading/DispatcherTimer.cs
+++ b/src/thirtytwo/Threading/DispatcherTimer.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Repeats on a dispatcher using monotonic deadlines. Missed intervals are skipped rather than replayed.
+/// </summary>
+public sealed class DispatcherTimer : IDisposable
+{
+    private readonly Dispatcher _dispatcher;
+    private readonly ShutdownRegistration _shutdownRegistration;
+    private CancellationTokenSource? _scheduledCancellation;
+    private TimeSpan _interval;
+    private long _nextDueTicks;
+    private bool _disposed;
+
+    /// <summary>
+    ///  Initializes a timer owned by a dispatcher.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher on which ticks run.</param>
+    /// <param name="interval">The initial timer interval.</param>
+    internal DispatcherTimer(Dispatcher dispatcher, TimeSpan interval)
+    {
+        _dispatcher = dispatcher;
+        Interval = interval;
+
+        // Thread-context shutdown callbacks run before Dispatcher.Stop rejects and detaches delayed work.
+        if (ThreadContext.CurrentContext is { } context
+            && ReferenceEquals(context.Dispatcher, dispatcher))
+        {
+            _shutdownRegistration = context.RegisterShutdownCallback(Stop);
+        }
+    }
+
+    /// <summary>
+    ///  Occurs on the dispatcher thread when the interval elapses.
+    /// </summary>
+    public event EventHandler? Tick;
+
+    /// <summary>
+    ///  Gets or sets the positive interval. Changing it while running restarts the deadline from the current time.
+    /// </summary>
+    public TimeSpan Interval
+    {
+        get => _interval;
+        set
+        {
+            _dispatcher.VerifyAccess();
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _interval = value;
+            if (IsRunning)
+            {
+                try
+                {
+                    ScheduleFromNow();
+                }
+                catch
+                {
+                    IsRunning = false;
+                    throw;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Gets whether the timer is running.
+    /// </summary>
+    public bool IsRunning { get; private set; }
+
+    /// <summary>
+    ///  Starts the timer. Must be called by the dispatcher thread.
+    /// </summary>
+    public void Start()
+    {
+        _dispatcher.VerifyAccess();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (IsRunning)
+        {
+            return;
+        }
+
+        IsRunning = true;
+        try
+        {
+            ScheduleFromNow();
+        }
+        catch
+        {
+            IsRunning = false;
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///  Stops the timer. Calling this while stopped has no effect. Must be called by the dispatcher thread.
+    /// </summary>
+    public void Stop()
+    {
+        _dispatcher.VerifyAccess();
+
+        if (!IsRunning)
+        {
+            return;
+        }
+
+        IsRunning = false;
+        CancelScheduledTick();
+    }
+
+    private void ScheduleFromNow()
+    {
+        CancelScheduledTick();
+        _nextDueTicks = AddSaturating(_dispatcher.MonotonicTicks, _interval.Ticks);
+        ScheduleNextTick();
+    }
+
+    private void ScheduleNextTick()
+    {
+        long currentTicks = _dispatcher.MonotonicTicks;
+        if (_nextDueTicks <= currentTicks)
+        {
+            // Advance from the prior deadline so handler duration does not accumulate drift. Missed ticks are skipped.
+            long missedIntervals = ((currentTicks - _nextDueTicks) / _interval.Ticks) + 1;
+            _nextDueTicks = AddSaturating(_nextDueTicks, MultiplySaturating(_interval.Ticks, missedIntervals));
+        }
+
+        TimeSpan delay = TimeSpan.FromTicks(_nextDueTicks - currentTicks);
+        CancellationTokenSource cancellationSource = new();
+        _scheduledCancellation = cancellationSource;
+
+        try
+        {
+            _dispatcher.PostDelayed(delay, OnTick, cancellationSource.Token);
+        }
+        catch
+        {
+            _scheduledCancellation = null;
+            cancellationSource.Dispose();
+            throw;
+        }
+    }
+
+    private void OnTick()
+    {
+        _scheduledCancellation?.Dispose();
+        _scheduledCancellation = null;
+
+        if (!IsRunning)
+        {
+            return;
+        }
+
+        try
+        {
+            Tick?.Invoke(this, EventArgs.Empty);
+            if (!IsRunning)
+            {
+                return;
+            }
+
+            if (_scheduledCancellation is not null)
+            {
+                // The handler changed Interval and already scheduled from the new current time.
+                return;
+            }
+
+            _nextDueTicks = AddSaturating(_nextDueTicks, _interval.Ticks);
+            ScheduleNextTick();
+        }
+        catch
+        {
+            IsRunning = false;
+            CancelScheduledTick();
+            throw;
+        }
+    }
+
+    private void CancelScheduledTick()
+    {
+        _scheduledCancellation?.Cancel();
+        _scheduledCancellation?.Dispose();
+        _scheduledCancellation = null;
+    }
+
+    private static long AddSaturating(long left, long right)
+        => right > long.MaxValue - left ? long.MaxValue : left + right;
+
+    private static long MultiplySaturating(long left, long right)
+    {
+        Int128 result = (Int128)left * right;
+        return result > long.MaxValue ? long.MaxValue : (long)result;
+    }
+
+    /// <summary>
+    ///  Stops and releases the timer.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _dispatcher.VerifyAccess();
+        Stop();
+        _shutdownRegistration.Dispose();
+        _disposed = true;
+    }
+}

--- a/src/thirtytwo/Threading/DispatcherUnhandledExceptionEventArgs.cs
+++ b/src/thirtytwo/Threading/DispatcherUnhandledExceptionEventArgs.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Provides a fire-and-forget dispatcher exception and allows the UI thread to mark it handled.
+/// </summary>
+/// <param name="exception">The exception raised by dispatched work.</param>
+public sealed class DispatcherUnhandledExceptionEventArgs(Exception exception) : EventArgs
+{
+    /// <summary>
+    ///  Gets the exception raised by dispatched work.
+    /// </summary>
+    public Exception Exception { get; } = exception;
+
+    /// <summary>
+    ///  Gets or sets whether the dispatcher should continue pumping messages.
+    /// </summary>
+    public bool Handled { get; set; }
+}

--- a/src/thirtytwo/Threading/DispatcherWakeWindow.cs
+++ b/src/thirtytwo/Threading/DispatcherWakeWindow.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows.Support;
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Provides a message-only window that wakes the dispatcher queue and timer.
+/// </summary>
+internal sealed unsafe class DispatcherWakeWindow : WindowClass, IDispatcherWake
+{
+    private const nuint TimerId = 1;
+
+    private Dispatcher? _dispatcher;
+
+    // Message-only HWND that receives immediate and delayed wake signals.
+    private HWND _handle;
+    private bool _timerArmed;
+
+    /// <summary>
+    ///  Initializes a wake window for the dispatcher.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher to wake.</param>
+    internal DispatcherWakeWindow(Dispatcher dispatcher)
+        : base(
+            className: $"ThirtyTwoDispatcherWindow_{Guid.NewGuid()}",
+            classStyle: 0,
+            backgroundBrush: HBRUSH.Invalid,
+            icon: HICON.Invalid,
+            cursor: HCURSOR.Invalid)
+    {
+        _dispatcher = dispatcher;
+        _handle = CreateWindow(
+            bounds: new Rectangle(0, 0, 1, 1),
+            style: WindowStyles.Overlapped,
+            parentWindow: HWND.HWND_MESSAGE);
+    }
+
+    /// <inheritdoc/>
+    public void Wake()
+    {
+        PInvoke.PostMessage(_handle, Application.DispatcherWakeMessage, default, default).ThrowLastErrorIfFalse();
+    }
+
+    /// <inheritdoc/>
+    protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    {
+        if ((uint)message == Application.DispatcherWakeMessage)
+        {
+            _dispatcher?.ProcessWake();
+            return (LRESULT)0;
+        }
+
+        if (message == MessageType.Timer && (nuint)wParam == TimerId)
+        {
+            _dispatcher?.ProcessDelayedWake();
+            return (LRESULT)0;
+        }
+
+        return base.WindowProcedure(window, message, wParam, lParam);
+    }
+
+    /// <inheritdoc/>
+    public void WakeAfter(uint delayMilliseconds)
+    {
+        nuint result = PInvoke.SetCoalescableTimer(_handle, TimerId, delayMilliseconds, null, 0);
+        if (result == 0)
+        {
+            Error.GetLastError().ThrowThirtyTwoException();
+        }
+
+        _timerArmed = true;
+    }
+
+    /// <inheritdoc/>
+    public void CancelDelayedWake()
+    {
+        if (!_timerArmed)
+        {
+            return;
+        }
+
+        if (!PInvoke.KillTimer(_handle, TimerId))
+        {
+            WIN32_ERROR.NO_ERROR.ThrowIfLastErrorNot();
+        }
+
+        _timerArmed = false;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_handle.IsNull)
+        {
+            CancelDelayedWake();
+            PInvoke.DestroyWindow(_handle).ThrowLastErrorIfFalse();
+            _handle = HWND.Null;
+        }
+
+        _dispatcher = null;
+        base.Dispose(disposing);
+    }
+}

--- a/src/thirtytwo/Threading/DispatcherWorkItem.cs
+++ b/src/thirtytwo/Threading/DispatcherWorkItem.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents one dispatcher operation and its execution, cancellation, and completion state.
+/// </summary>
+internal abstract class DispatcherWorkItem
+{
+    private readonly Lock _cancellationLock = new();
+    private CancellationTokenRegistration? _cancellationRegistration;
+    private ExecutionContext? _executionContext;
+    private bool _cancellationRegistrationCompleted;
+
+    /// <summary>
+    ///  Initializes a dispatcher work item.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher that owns the operation.</param>
+    /// <param name="id">The operation identifier.</param>
+    /// <param name="cancellationToken">The caller's cancellation token.</param>
+    protected DispatcherWorkItem(Dispatcher dispatcher, long id, CancellationToken cancellationToken)
+    {
+        Dispatcher = dispatcher;
+        Id = id;
+        CancellationToken = cancellationToken;
+        _executionContext = ExecutionContext.Capture();
+    }
+
+    /// <summary>
+    ///  Gets the dispatcher that owns this operation.
+    /// </summary>
+    internal Dispatcher Dispatcher { get; }
+
+    /// <summary>
+    ///  Gets the operation identifier.
+    /// </summary>
+    internal long Id { get; }
+
+    /// <summary>
+    ///  Gets or sets the monotonic timestamp recorded when the operation was admitted.
+    /// </summary>
+    internal long AdmittedTicks { get; set; }
+
+    /// <summary>
+    ///  Gets or sets the queue depth recorded when the operation was admitted.
+    /// </summary>
+    internal int QueueDepthAtAdmission { get; set; }
+
+    /// <summary>
+    ///  Gets the caller's cancellation token.
+    /// </summary>
+    internal CancellationToken CancellationToken { get; }
+
+    /// <summary>
+    ///  Gets or sets the operation state.
+    /// </summary>
+    internal DispatcherWorkItemState State { get; set; }
+
+    /// <summary>
+    ///  Gets the task that represents operation completion.
+    /// </summary>
+    internal abstract Task Task { get; }
+
+    /// <summary>
+    ///  Registers cancellation of an operation that has not started.
+    /// </summary>
+    internal void RegisterCancellation()
+    {
+        if (!CancellationToken.CanBeCanceled)
+        {
+            return;
+        }
+
+        CancellationTokenRegistration registration = CancellationToken.Register(
+            static state => ((DispatcherWorkItem)state!).Dispatcher.Cancel((DispatcherWorkItem)state),
+            this,
+            useSynchronizationContext: false);
+
+        bool disposeRegistration;
+        lock (_cancellationLock)
+        {
+            // Register can invoke Cancel synchronously before returning. Completion and registration therefore use
+            // this handoff: whichever publishes second disposes the registration, always outside the lock.
+            disposeRegistration = _cancellationRegistrationCompleted;
+            if (!disposeRegistration)
+            {
+                Debug.Assert(_cancellationRegistration is null);
+                _cancellationRegistration = registration;
+            }
+        }
+
+        if (disposeRegistration)
+        {
+            registration.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///  Closes the cancellation-registration lifecycle and disposes a registration that has already been published.
+    /// </summary>
+    protected void CompleteCancellationRegistration()
+    {
+        if (!CancellationToken.CanBeCanceled)
+        {
+            return;
+        }
+
+        CancellationTokenRegistration? registration;
+
+        lock (_cancellationLock)
+        {
+            _cancellationRegistrationCompleted = true;
+            registration = _cancellationRegistration;
+            _cancellationRegistration = null;
+        }
+
+        registration?.Dispose();
+    }
+
+    /// <summary>
+    ///  Invokes the operation under its captured execution context and the dispatcher synchronization context.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The captured execution context preserves caller state such as <see cref="AsyncLocal{T}"/> values. The
+    ///   dispatcher synchronization context is then installed inside it so ordinary awaits resume on the UI thread.
+    ///  </para>
+    /// </remarks>
+    internal void Invoke()
+    {
+        ExecutionContext? executionContext = _executionContext;
+        _executionContext = null;
+
+        if (executionContext is null)
+        {
+            InvokeWithDispatcherContext(this);
+        }
+        else
+        {
+            ExecutionContext.Run(
+                executionContext,
+                static state => InvokeWithDispatcherContext((DispatcherWorkItem)state!),
+                this);
+        }
+
+        static void InvokeWithDispatcherContext(DispatcherWorkItem workItem)
+        {
+            SynchronizationContext? previous = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(workItem.Dispatcher.SynchronizationContext);
+
+            try
+            {
+                workItem.InvokeCore();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Invokes the operation callback and completes the operation.
+    /// </summary>
+    protected abstract void InvokeCore();
+
+    /// <summary>
+    ///  Completes the operation as canceled.
+    /// </summary>
+    internal abstract void CompleteCanceled();
+
+    /// <summary>
+    ///  Completes the operation as faulted.
+    /// </summary>
+    /// <param name="exception">The exception that faulted the operation.</param>
+    internal abstract void CompleteFaulted(Exception exception);
+
+    /// <summary>
+    ///  Releases references that are no longer needed after the operation becomes terminal.
+    /// </summary>
+    internal void Release()
+    {
+        _executionContext = null;
+        ReleaseCallback();
+    }
+
+    /// <summary>
+    ///  Releases the operation callback.
+    /// </summary>
+    protected abstract void ReleaseCallback();
+}

--- a/src/thirtytwo/Threading/DispatcherWorkItemState.cs
+++ b/src/thirtytwo/Threading/DispatcherWorkItemState.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Defines dispatcher operation states.
+/// </summary>
+internal enum DispatcherWorkItemState
+{
+    /// <summary>The operation is waiting to run.</summary>
+    Queued,
+
+    /// <summary>The operation callback has started.</summary>
+    Running,
+
+    /// <summary>The operation completed successfully.</summary>
+    Succeeded,
+
+    /// <summary>The operation was canceled.</summary>
+    Canceled,
+
+    /// <summary>The operation completed with an exception.</summary>
+    Faulted
+}

--- a/src/thirtytwo/Threading/IDispatcherWake.cs
+++ b/src/thirtytwo/Threading/IDispatcherWake.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Delivers immediate and delayed queue-processing signals to a dispatcher's owning thread.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This interface separates scheduling policy from delivery. <see cref="Dispatcher"/> owns queue ordering, wake
+///   coalescing, deadline selection, cancellation, faults, and shutdown. An implementation owns only the mechanism and
+///   resources used to deliver signals on the dispatcher thread.
+///  </para>
+///  <para>
+///   The default implementation uses a message-only HWND and a USER32 timer. Keeping that mechanism behind this
+///   boundary allows another owner-thread signaling mechanism, or a deterministic test transport, without duplicating
+///   the dispatcher state machine.
+///  </para>
+///  <para>
+///   The dispatcher requests at most one immediate signal and one delayed signal through a transport instance.
+///  </para>
+///  <para>
+///   Immediate and delayed signals are independent. Delivering or canceling one must not implicitly consume the
+///   other.
+///  </para>
+/// </remarks>
+internal interface IDispatcherWake : IDisposable
+{
+    /// <summary>
+    ///  Requests queue processing without an intentional delay.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The implementation schedules delivery on the dispatcher's owning thread and returns without processing
+    ///   dispatcher work inline on the calling thread.
+    ///  </para>
+    ///  <para>
+    ///   Any pending delayed wake remains pending. While processing this immediate wake, the dispatcher may explicitly
+    ///   replace or cancel the delayed wake after reevaluating delayed work.
+    ///  </para>
+    /// </remarks>
+    void Wake();
+
+    /// <summary>
+    ///  Requests queue processing after the specified delay, replacing any pending delayed wake.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Implementations may use a native timer or any equivalent mechanism. The dispatcher calls
+    ///   <see cref="CancelDelayedWake"/> after delivery and whenever the pending delayed wake is no longer needed;
+    ///   implementations do not call it themselves.
+    ///  </para>
+    ///  <para>This method does not affect a pending immediate wake.</para>
+    /// </remarks>
+    /// <param name="delayMilliseconds">The minimum delay in milliseconds.</param>
+    void WakeAfter(uint delayMilliseconds);
+
+    /// <summary>
+    ///  Cancels the pending delayed wake. Has no effect when none is pending or it has already been delivered.
+    /// </summary>
+    /// <remarks>
+    ///  <para>This method does not affect a pending immediate wake.</para>
+    /// </remarks>
+    void CancelDelayedWake();
+}

--- a/src/thirtytwo/Threading/ShutdownCallbackEntry.cs
+++ b/src/thirtytwo/Threading/ShutdownCallbackEntry.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Associates a shutdown callback with its registration identifier.
+/// </summary>
+/// <param name="Id">The registration identifier.</param>
+/// <param name="Callback">The registered shutdown callback.</param>
+internal sealed record ShutdownCallbackEntry(long Id, Action Callback);

--- a/src/thirtytwo/Threading/ShutdownRegistration.cs
+++ b/src/thirtytwo/Threading/ShutdownRegistration.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Represents a shutdown callback registered with a thread context.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="ThreadContext.RegisterShutdownCallback"/> adds the callback and returns this handle. Disposing the
+///   handle before shutdown begins removes that registration. Once shutdown begins, the callback set is fixed and
+///   disposal has no effect.
+///  </para>
+/// </remarks>
+internal readonly struct ShutdownRegistration : IDisposable
+{
+    private readonly ThreadContext? _context;
+    private readonly long _id;
+
+    /// <summary>
+    ///  Creates a handle for a shutdown callback that the thread context has already registered.
+    /// </summary>
+    /// <param name="context">The thread context that owns the callback.</param>
+    /// <param name="id">The registration identifier.</param>
+    internal ShutdownRegistration(ThreadContext context, long id)
+    {
+        _context = context;
+        _id = id;
+    }
+
+    /// <summary>
+    ///  Removes the represented callback registration when shutdown has not begun. Disposal from a different thread
+    ///  throws.
+    /// </summary>
+    public void Dispose() => _context?.RemoveShutdownCallback(_id);
+}

--- a/src/thirtytwo/Threading/ThreadContext.cs
+++ b/src/thirtytwo/Threading/ThreadContext.cs
@@ -1,0 +1,458 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.ExceptionServices;
+using Windows.Support;
+
+namespace Windows.Threading;
+
+/// <summary>
+///  Owns the message pump, dispatcher, message filters, and shutdown callbacks for one UI thread.
+/// </summary>
+/// <remarks>
+///  <para>
+///   A thread can have at most one context. <see cref="Application.Run(Window, bool)"/> creates and disposes the
+///   context that owns its outer message loop.
+///  </para>
+/// </remarks>
+internal sealed unsafe class ThreadContext : DisposableBase
+{
+    // Associates one context with its owner thread from successful construction until disposal.
+    [ThreadStatic]
+    private static ThreadContext? t_current;
+
+    // Retains message filters in registration order; message traversal reads the stable snapshot below.
+    private readonly List<MessageFilterEntry> _messageFilters = [];
+
+    // Retains shutdown callbacks in registration order so teardown can invoke them in reverse order.
+    private readonly List<ShutdownCallbackEntry> _shutdownCallbacks = [];
+
+    // Captures the managed owner thread used to reject cross-thread context mutation.
+    private readonly Thread _thread = Thread.CurrentThread;
+
+    // Indicates whether _messageFilterSnapshot still represents the current registration list.
+    private bool _filterSnapshotValid;
+
+    // Tracks only a WM_QUIT posted by RequestExit so an unconsumed framework message can be removed before reuse.
+    private bool _ownedQuitMessagePending;
+
+    // Requests that the outer loop stop before blocking for or dispatching another message.
+    private bool _quitRequested;
+
+    // Spans message pumping and shutdown callbacks, preventing a nested run and exposing the current dispatcher.
+    private bool _running;
+
+    // Records the first RunMessageLoop entry so this context cannot own a second outer loop.
+    private bool _hasRun;
+
+    // Becomes true before callbacks are detached, freezing the callback set for shutdown.
+    private bool _shutdownStarted;
+
+    // Generates identifiers shared by filter and shutdown registrations within this context.
+    private long _nextRegistrationId;
+
+    // Provides a stable filter traversal when a callback adds or removes registrations.
+    private MessageFilterEntry[] _messageFilterSnapshot = [];
+
+    private ThreadContext()
+    {
+        t_current = this;
+
+        try
+        {
+            Dispatcher = new Dispatcher();
+        }
+        catch
+        {
+            t_current = null;
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///  Gets the dispatcher owned by this context.
+    /// </summary>
+    internal Dispatcher Dispatcher { get; }
+
+    /// <summary>
+    ///  Gets the non-disposed context associated with the current thread, or <see langword="null"/>.
+    /// </summary>
+    internal static ThreadContext? CurrentContext => t_current is { Disposed: false } context
+        ? context
+        : null;
+
+    /// <summary>
+    ///  Gets the dispatcher for the running context on the current thread, or <see langword="null"/>.
+    /// </summary>
+    internal static Dispatcher? CurrentDispatcher => t_current is { _running: true, _shutdownStarted: false } context
+        ? context.Dispatcher
+        : null;
+
+    /// <summary>
+    ///  Creates the context for the current thread.
+    /// </summary>
+    /// <returns>The newly created thread context.</returns>
+    /// <exception cref="InvalidOperationException">The current thread already has a context.</exception>
+    internal static ThreadContext Create()
+    {
+        if (t_current is not null)
+        {
+            throw new InvalidOperationException("A message loop is already running on this thread.");
+        }
+
+        return new ThreadContext();
+    }
+
+    /// <summary>
+    ///  Starts the dispatcher, invokes initialization, and runs the outer message loop until quit, dispatcher fault,
+    ///  or message retrieval failure.
+    /// </summary>
+    /// <param name="initialize">Initialization to run before the message loop starts blocking.</param>
+    internal void RunMessageLoop(Action? initialize)
+    {
+        ObjectDisposedException.ThrowIf(Disposed, this);
+
+        if (_running)
+        {
+            throw new InvalidOperationException("A message loop is already running on this thread.");
+        }
+
+        if (_hasRun)
+        {
+            throw new InvalidOperationException("This thread context has already run its message loop.");
+        }
+
+        _hasRun = true;
+        _running = true;
+        SynchronizationContext? previousSynchronizationContext = SynchronizationContext.Current;
+
+        // Preserve pump and teardown failures independently so cleanup never hides the original failure.
+        ExceptionDispatchInfo? pumpFailure = null;
+        Exception? cleanupFailure = null;
+
+        try
+        {
+            Dispatcher.Start();
+            SynchronizationContext.SetSynchronizationContext(Dispatcher.SynchronizationContext);
+            Window.AttachDispatcherToCurrentThread(Dispatcher);
+            initialize?.Invoke();
+            RunMessageLoopCore();
+        }
+        catch (Exception exception)
+        {
+            pumpFailure = ExceptionDispatchInfo.Capture(exception);
+        }
+        finally
+        {
+            _shutdownStarted = true;
+
+            try
+            {
+                // Reject new work before callbacks tear down components that may own queued dispatcher work.
+                Dispatcher.BeginShutdown();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure = exception;
+            }
+
+            try
+            {
+                RunShutdownCallbacks();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure = cleanupFailure is null
+                    ? exception
+                    : new AggregateException(cleanupFailure, exception);
+            }
+
+            try
+            {
+                Dispatcher.Stop();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure = cleanupFailure is null
+                    ? exception
+                    : new AggregateException(cleanupFailure, exception);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previousSynchronizationContext);
+                _running = false;
+            }
+        }
+
+        if (pumpFailure is not null)
+        {
+            if (cleanupFailure is not null)
+            {
+                throw new AggregateException(pumpFailure.SourceException, cleanupFailure);
+            }
+
+            pumpFailure.Throw();
+        }
+
+        if (cleanupFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+        }
+
+        void RunShutdownCallbacks()
+        {
+            ShutdownCallbackEntry[] callbacks = [.. _shutdownCallbacks];
+            _shutdownCallbacks.Clear();
+            List<Exception>? exceptions = null;
+
+            for (int index = callbacks.Length - 1; index >= 0; index--)
+            {
+                try
+                {
+                    callbacks[index].Callback();
+                }
+                catch (Exception exception)
+                {
+                    (exceptions ??= []).Add(exception);
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        void RunMessageLoopCore()
+        {
+            try
+            {
+                while (!_quitRequested)
+                {
+                    BOOL result = PInvoke.GetMessage(out MSG message, HWND.Null, 0, 0);
+                    if ((int)result == -1)
+                    {
+                        Error.GetLastError().ThrowThirtyTwoException();
+                    }
+
+                    if (!result)
+                    {
+                        _quitRequested = true;
+                        _ownedQuitMessagePending = false;
+                        Dispatcher.ThrowIfFaulted();
+                        break;
+                    }
+
+                    if (_quitRequested)
+                    {
+                        break;
+                    }
+
+                    if (PreFilterMessage(ref message))
+                    {
+                        continue;
+                    }
+
+                    if (Window.FromHandle(message.hwnd) is { } target && target.PreProcessMessage(ref message))
+                    {
+                        continue;
+                    }
+
+                    PInvoke.TranslateMessage(&message);
+                    PInvoke.DispatchMessage(&message);
+                    Dispatcher.ThrowIfFaulted();
+                }
+            }
+            finally
+            {
+                if (_quitRequested && _ownedQuitMessagePending)
+                {
+                    // RequestExit usually makes the loop stop before GetMessage consumes our WM_QUIT. Remove it so a
+                    // later Application.Run on this thread does not inherit a stale quit message.
+                    _ = PInvoke.PeekMessage(
+                        out _,
+                        HWND.Null,
+                        Interop.WM_QUIT,
+                        Interop.WM_QUIT,
+                        PEEK_MESSAGE_REMOVE_TYPE.PM_REMOVE);
+
+                    _ownedQuitMessagePending = false;
+                }
+            }
+
+            bool PreFilterMessage(ref MSG message)
+            {
+                if (!_filterSnapshotValid)
+                {
+                    _messageFilterSnapshot = [.. _messageFilters];
+                    _filterSnapshotValid = true;
+                }
+
+                // The array isolates this traversal. Filter changes invalidate only the next message's snapshot.
+                foreach (MessageFilterEntry entry in _messageFilterSnapshot)
+                {
+                    if (entry.Filter.PreFilterMessage(ref message))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Requests exit from the message loop and posts one <c>WM_QUIT</c> wakeup.
+    /// </summary>
+    /// <remarks>
+    ///  <para>This method must be called by the owning thread.</para>
+    /// </remarks>
+    private void RequestExit()
+    {
+        VerifyAccess();
+
+        if (_quitRequested)
+        {
+            return;
+        }
+
+        _quitRequested = true;
+        PInvoke.PostQuitMessage(0);
+        _ownedQuitMessagePending = true;
+    }
+
+    /// <summary>
+    ///  Requests exit from the current thread's context, or posts <c>WM_QUIT</c> when no context is running.
+    /// </summary>
+    internal static void RequestExitCurrentThread()
+    {
+        if (t_current is { _running: true } context)
+        {
+            context.RequestExit();
+        }
+        else
+        {
+            PInvoke.PostQuitMessage(0);
+        }
+    }
+
+    /// <summary>
+    ///  Adds a message filter to the owning thread in registration order.
+    /// </summary>
+    /// <param name="filter">The filter to invoke before managed window lookup and native dispatch.</param>
+    /// <returns>A registration that removes the filter when disposed.</returns>
+    internal MessageFilterRegistration AddMessageFilter(IMessageFilter filter)
+    {
+        VerifyAccess();
+        ObjectDisposedException.ThrowIf(Disposed, this);
+
+        if (_shutdownStarted || (_hasRun && !_running))
+        {
+            throw new InvalidOperationException("Thread context shutdown has started.");
+        }
+
+        long id = ++_nextRegistrationId;
+        _messageFilters.Add(new(id, filter));
+        _filterSnapshotValid = false;
+        return new MessageFilterRegistration(this, id);
+    }
+
+    /// <summary>
+    ///  Removes a message filter by registration identifier.
+    /// </summary>
+    /// <param name="id">The registration identifier.</param>
+    internal void RemoveMessageFilter(long id)
+    {
+        VerifyAccess();
+
+        if (Disposed)
+        {
+            return;
+        }
+
+        int index = _messageFilters.FindIndex(entry => entry.Id == id);
+        if (index >= 0)
+        {
+            _messageFilters.RemoveAt(index);
+            _filterSnapshotValid = false;
+        }
+    }
+
+    /// <summary>
+    ///  Registers synchronous cleanup to run in reverse registration order before the dispatcher stops.
+    /// </summary>
+    /// <param name="callback">The cleanup callback to run on the owning thread.</param>
+    /// <returns>A registration that removes the callback when disposed before shutdown.</returns>
+    internal ShutdownRegistration RegisterShutdownCallback(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        VerifyAccess();
+
+        ObjectDisposedException.ThrowIf(Disposed, this);
+
+        if (_shutdownStarted || (_hasRun && !_running))
+        {
+            throw new InvalidOperationException("Thread context shutdown has started.");
+        }
+
+        long id = ++_nextRegistrationId;
+        _shutdownCallbacks.Add(new(id, callback));
+        return new ShutdownRegistration(this, id);
+    }
+
+    /// <summary>
+    ///  Removes a shutdown callback by registration identifier when shutdown has not started.
+    /// </summary>
+    /// <param name="id">The registration identifier.</param>
+    internal void RemoveShutdownCallback(long id)
+    {
+        VerifyAccess();
+
+        if (Disposed || _shutdownStarted)
+        {
+            return;
+        }
+
+        int index = _shutdownCallbacks.FindIndex(entry => entry.Id == id);
+        if (index >= 0)
+        {
+            _shutdownCallbacks.RemoveAt(index);
+        }
+    }
+
+    private void VerifyAccess()
+    {
+        if (!ReferenceEquals(Thread.CurrentThread, _thread))
+        {
+            throw new InvalidOperationException("The calling thread does not own this thread context.");
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">The message loop is still running.</exception>
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        if (_running)
+        {
+            throw new InvalidOperationException("The thread context cannot be disposed while its message loop is running.");
+        }
+
+        try
+        {
+            Dispatcher.Dispose();
+        }
+        finally
+        {
+            if (ReferenceEquals(t_current, this))
+            {
+                t_current = null;
+            }
+        }
+    }
+}

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -19,7 +19,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
     // Default fonts for each DPI
     private static readonly ConcurrentDictionary<int, HFONT> s_defaultFonts = new();
-    internal static WNDPROC DefaultWindowProcedure { get; } = GetDefaultWindowProcedure();
+    private static WNDPROC DefaultWindowProcedure { get; } = GetDefaultWindowProcedure();
 
     // High precision metric units are .01mm each
     private const int HiMetricUnitsPerInch = 2540;
@@ -30,6 +30,12 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     private readonly WindowProcedure _windowProcedure;
     private readonly WNDPROC _priorWindowProcedure;
     protected readonly WindowClass _windowClass;
+
+    // Identifies the managed thread that owns the HWND without querying a handle after destruction.
+    private readonly Thread _thread = Thread.CurrentThread;
+
+    // Retains the dispatcher affinity after the dispatcher stops and the HWND is destroyed.
+    private Threading.Dispatcher? _dispatcher;
     private bool _destroyed;
     private HWND _handle;
 
@@ -69,6 +75,35 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     /// </summary>
     public HWND Handle => _handle;
 
+    /// <summary>
+    ///  Gets the dispatcher associated with the thread that owns this window.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Once associated, the dispatcher remains available from this property after shutdown or handle destruction.
+    ///   Queue admission determines whether each operation is accepted; callers do not need to check dispatcher state
+    ///   before invoking it. A later <see cref="Application.Run(Window, bool)"/> on the same owning thread associates
+    ///   a surviving window with that run's fresh dispatcher after the previous dispatcher completes.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The window has not been associated with a dispatcher.</exception>
+    public Threading.Dispatcher Dispatcher
+    {
+        get
+        {
+            Threading.Dispatcher? dispatcher = Volatile.Read(ref _dispatcher);
+            if (dispatcher is not null)
+            {
+                return dispatcher;
+            }
+
+            dispatcher = Threading.Dispatcher.FromHandle(this)
+                ?? throw new InvalidOperationException("The window has not been associated with a dispatcher.");
+            AttachDispatcher(dispatcher);
+            return dispatcher;
+        }
+    }
+
     object? IHandle<HWND>.Wrapper => this;
 
     public event WindowsMessageEvent? MessageHandler;
@@ -85,6 +120,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
         Color backgroundColor = default,
         Features features = default)
     {
+        _dispatcher = parentWindow?._dispatcher ?? Threading.Dispatcher.Current;
         _windowClass = windowClass ?? s_defaultWindowClass;
 
         if (bounds.IsEmpty)
@@ -126,6 +162,49 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
         {
             // Default system font is applied, use a nicer (ClearType) font
             this.SetFontHandle(GetDefaultFontForDpi((int)_lastDpi));
+        }
+    }
+
+    /// <summary>
+    ///  Associates this window with its owning thread's dispatcher.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher to associate with the window.</param>
+    internal void AttachDispatcher(Threading.Dispatcher dispatcher)
+    {
+        while (true)
+        {
+            Threading.Dispatcher? existing = Volatile.Read(ref _dispatcher);
+            if (ReferenceEquals(existing, dispatcher))
+            {
+                return;
+            }
+
+            if (existing is not null && !existing.Completion.IsCompleted)
+            {
+                throw new InvalidOperationException("The window is already associated with another active dispatcher.");
+            }
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _dispatcher, dispatcher, existing), existing))
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Associates existing managed windows owned by the current thread with its dispatcher.
+    /// </summary>
+    /// <param name="dispatcher">The current thread's dispatcher.</param>
+    internal static void AttachDispatcherToCurrentThread(Threading.Dispatcher dispatcher)
+    {
+        dispatcher.VerifyAccess();
+
+        foreach (WeakReference<Window> reference in s_windows.Values)
+        {
+            if (reference.TryGetTarget(out Window? window) && ReferenceEquals(window._thread, Thread.CurrentThread))
+            {
+                window.AttachDispatcher(dispatcher);
+            }
         }
     }
 

--- a/src/thirtytwo_tests/Threading/DispatcherDelayTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherDelayTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+
+namespace Windows.Threading;
+
+[TestClass]
+public class DispatcherDelayTests
+{
+    [STATestMethod]
+    public void InvokeAsync_DelayedAction_WaitsForMonotonicDueTime()
+    {
+        ManualTimeProvider timeProvider = new();
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(timeProvider);
+        Dispatcher dispatcher = context.Dispatcher;
+        bool callbackRan = false;
+        bool incompleteBeforeDue = false;
+        TaskCompletionSource<Task> queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task worker = DispatcherTestWorker.Start(() =>
+        {
+            Task delayed = dispatcher.InvokeAsync(TimeSpan.FromSeconds(10), () =>
+            {
+                callbackRan = true;
+                PInvoke.PostQuitMessage(0);
+            });
+
+            _ = dispatcher.InvokeAsync(() =>
+            {
+                incompleteBeforeDue = !delayed.IsCompleted && !callbackRan;
+                timeProvider.Advance(TimeSpan.FromSeconds(10));
+                _ = dispatcher.InvokeAsync(static () => { });
+            });
+
+            queued.SetResult(delayed);
+        });
+
+        context.RunMessageLoop();
+        worker.GetAwaiter().GetResult();
+
+        queued.Task.GetAwaiter().GetResult().GetAwaiter().GetResult();
+        incompleteBeforeDue.Should().BeTrue();
+        callbackRan.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_EqualDueTimes_PreserveAdmissionOrder()
+    {
+        ManualTimeProvider timeProvider = new();
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(timeProvider);
+        Dispatcher dispatcher = context.Dispatcher;
+        List<int> order = [];
+        TaskCompletionSource<Task[]> queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task worker = DispatcherTestWorker.Start(() =>
+        {
+            Task first = dispatcher.InvokeAsync(TimeSpan.FromSeconds(10), () => order.Add(1));
+            Task second = dispatcher.InvokeAsync(TimeSpan.FromSeconds(10), () =>
+            {
+                order.Add(2);
+                PInvoke.PostQuitMessage(0);
+            });
+
+            _ = dispatcher.InvokeAsync(() =>
+            {
+                timeProvider.Advance(TimeSpan.FromSeconds(10));
+                _ = dispatcher.InvokeAsync(static () => { });
+            });
+
+            queued.SetResult([first, second]);
+        });
+
+        context.RunMessageLoop();
+        worker.GetAwaiter().GetResult();
+
+        Task.WhenAll(queued.Task.GetAwaiter().GetResult()).GetAwaiter().GetResult();
+        order.Should().Equal(1, 2);
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_DelayedActionCanceled_ReleasesWithoutRunning()
+    {
+        ManualTimeProvider timeProvider = new();
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(timeProvider);
+        Dispatcher dispatcher = context.Dispatcher;
+        using CancellationTokenSource cancellationSource = new();
+        bool callbackRan = false;
+        TaskCompletionSource<Task> queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task worker = DispatcherTestWorker.Start(() =>
+        {
+            Task delayed = dispatcher.InvokeAsync(
+                TimeSpan.FromHours(1),
+                () => callbackRan = true,
+                cancellationSource.Token);
+
+            _ = dispatcher.InvokeAsync(() =>
+            {
+                cancellationSource.Cancel();
+                PInvoke.PostQuitMessage(0);
+            });
+
+            queued.SetResult(delayed);
+        });
+
+        context.RunMessageLoop();
+        worker.GetAwaiter().GetResult();
+
+        Task delayed = queued.Task.GetAwaiter().GetResult();
+        Action getResult = () => delayed.GetAwaiter().GetResult();
+        getResult.Should().Throw<OperationCanceledException>();
+        callbackRan.Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_DelayedFunc_ReturnsResult()
+    {
+        ManualTimeProvider timeProvider = new();
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(timeProvider);
+        Dispatcher dispatcher = context.Dispatcher;
+        TaskCompletionSource<Task<int>> queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task worker = DispatcherTestWorker.Start(() =>
+        {
+            Task<int> delayed = dispatcher.InvokeAsync(TimeSpan.FromSeconds(1), () => 42);
+            _ = dispatcher.InvokeAsync(() =>
+            {
+                timeProvider.Advance(TimeSpan.FromSeconds(1));
+                _ = dispatcher.InvokeAsync(static () => { });
+            });
+
+            queued.SetResult(delayed);
+            delayed.GetAwaiter().GetResult();
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+        });
+
+        context.RunMessageLoop();
+        worker.GetAwaiter().GetResult();
+
+        queued.Task.GetAwaiter().GetResult().GetAwaiter().GetResult().Should().Be(42);
+    }
+
+    [TestMethod]
+    public void InvokeAsync_NegativeDelay_Throws()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+
+        Action action = () => context.Dispatcher.InvokeAsync(TimeSpan.FromTicks(-1), static () => { });
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void InvokeAsync_MaximumDelay_ClampsDelayedWake()
+    {
+        ManualTimeProvider timeProvider = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            timeProvider,
+            dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+
+        Task operation = dispatcher.InvokeAsync(TimeSpan.MaxValue, static () => { });
+        wake!.DeliverOne();
+
+        operation.IsCompleted.Should().BeFalse();
+        wake.DelayedWakeDelay.Should().Be(uint.MaxValue);
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherDiscoveryTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherDiscoveryTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Windows.Threading;
+
+[TestClass]
+public class DispatcherDiscoveryTests
+{
+    [STATestMethod]
+    public void WindowDispatcher_BeforeAssociation_Throws()
+    {
+        using Window window = new(Window.DefaultBounds);
+
+        Action getDispatcher = () => _ = window.Dispatcher;
+
+        getDispatcher.Should().Throw<InvalidOperationException>()
+            .WithMessage("The window has not been associated with a dispatcher.");
+        Dispatcher.FromHandle(window).Should().BeNull();
+        Dispatcher.FromHandle(window.Handle).Should().BeNull();
+        Dispatcher.FromHandle(HWND.Null).Should().BeNull();
+    }
+
+    [STATestMethod]
+    public void FromHandle_DestroyedWindow_ReturnsNull()
+    {
+        HWND handle;
+        using (Window window = new(Window.DefaultBounds))
+        {
+            handle = window.Handle;
+        }
+
+        Dispatcher.FromHandle(handle).Should().BeNull();
+    }
+
+    [STATestMethod]
+    public void FromHandle_ForeignUiThreadWithoutDispatcher_ReturnsNull()
+    {
+        TaskCompletionSource<HWND> created = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Thread thread = new(() =>
+        {
+            try
+            {
+                using Window window = new(Window.DefaultBounds);
+                created.SetResult(window.Handle);
+                release.Task.GetAwaiter().GetResult();
+            }
+            catch (Exception exception)
+            {
+                created.TrySetException(exception);
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        try
+        {
+            HWND handle = created.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            Dispatcher.FromHandle(handle).Should().BeNull();
+        }
+        finally
+        {
+            release.TrySetResult();
+            thread.Join();
+        }
+    }
+
+    [STATestMethod]
+    public void FromHandle_ApplicationRun_ResolvesOwningDispatcher()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using Window child = new(Window.DefaultBounds, parentWindow: window);
+        HWND windowHandle = window.Handle;
+        HWND childHandle = child.Handle;
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        TaskCompletionSource completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Dispatcher? resolvedDispatcher = null;
+
+        Action getDispatcher = () => _ = window.Dispatcher;
+        getDispatcher.Should().Throw<InvalidOperationException>();
+
+        Thread worker = new(() =>
+        {
+            try
+            {
+                if (!SpinWait.SpinUntil(
+                    () => (resolvedDispatcher = Dispatcher.FromHandle(windowHandle)) is not null,
+                    TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("The window dispatcher did not become available.");
+                }
+
+                Dispatcher dispatcher = resolvedDispatcher
+                    ?? throw new InvalidOperationException("Dispatcher lookup succeeded without a result.");
+                dispatcher.CheckAccess().Should().BeFalse();
+                window.Dispatcher.Should().BeSameAs(dispatcher);
+                Dispatcher.FromHandle(childHandle).Should().BeSameAs(dispatcher);
+
+                dispatcher.InvokeAsync(() =>
+                {
+                    dispatcher.CheckAccess().Should().BeTrue();
+                    Dispatcher.Current.Should().BeSameAs(dispatcher);
+                    window.Dispatcher.Should().BeSameAs(dispatcher);
+                    child.Dispatcher.Should().BeSameAs(dispatcher);
+                    Dispatcher.FromHandle(window).Should().BeSameAs(dispatcher);
+                    Dispatcher.FromHandle(windowHandle).Should().BeSameAs(dispatcher);
+                    Dispatcher.FromHandle(childHandle).Should().BeSameAs(dispatcher);
+                    PInvoke.PostQuitMessage(0);
+                }).GetAwaiter().GetResult();
+
+                completion.SetResult();
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+                PInvoke.PostThreadMessage(dispatcherThreadId, Interop.WM_QUIT, default, default);
+            }
+        });
+
+        worker.Start();
+        Application.Run(window, disposeWindow: false);
+        completion.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+        worker.Join();
+
+        window.Handle.Should().Be(windowHandle);
+        window.Dispatcher.Should().BeSameAs(resolvedDispatcher);
+        child.Dispatcher.Should().BeSameAs(resolvedDispatcher);
+        resolvedDispatcher!.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        resolvedDispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+        resolvedDispatcher.TryPost(static () => { }).Should().BeFalse();
+        Dispatcher.FromHandle(windowHandle).Should().BeNull();
+        Dispatcher.FromHandle(childHandle).Should().BeNull();
+    }
+
+    [STATestMethod]
+    public void ApplicationRun_WindowFactory_HasActiveDispatcher()
+    {
+        Dispatcher? factoryDispatcher = null;
+        Dispatcher? windowDispatcher = null;
+        Window? createdWindow = null;
+
+        Application.Run(() =>
+        {
+            factoryDispatcher = Dispatcher.Current;
+            createdWindow = new Window(Window.DefaultBounds);
+            windowDispatcher = createdWindow.Dispatcher;
+            createdWindow.PostMessage(MessageType.Close);
+            return createdWindow;
+        });
+
+        factoryDispatcher.Should().NotBeNull();
+        windowDispatcher.Should().BeSameAs(factoryDispatcher);
+        createdWindow.Should().NotBeNull();
+        createdWindow!.Handle.Should().Be(HWND.Null);
+        createdWindow.Dispatcher.Should().BeSameAs(factoryDispatcher);
+        factoryDispatcher!.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        factoryDispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void ApplicationRun_SurvivingWindow_ReassociatesAfterCompletion()
+    {
+        using Window window = new(Window.DefaultBounds);
+        PInvoke.PostQuitMessage(0);
+
+        Application.Run(window, disposeWindow: false);
+        Dispatcher firstDispatcher = window.Dispatcher;
+
+        firstDispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+        firstDispatcher.TryPost(static () => { }).Should().BeFalse();
+
+        PInvoke.PostQuitMessage(0);
+        Application.Run(window, disposeWindow: false);
+        Dispatcher secondDispatcher = window.Dispatcher;
+
+        secondDispatcher.Should().NotBeSameAs(firstDispatcher);
+        secondDispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+        secondDispatcher.TryPost(static () => { }).Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void ApplicationRun_WindowFactoryThrows_CompletesDispatcherAndClearsCurrent()
+    {
+        Dispatcher? dispatcher = null;
+
+        Action run = () => Application.Run(() =>
+        {
+            dispatcher = Dispatcher.Current;
+            throw new InvalidOperationException("Expected");
+        });
+
+        run.Should().Throw<InvalidOperationException>().WithMessage("Expected");
+        dispatcher.Should().NotBeNull();
+        dispatcher!.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        dispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+        Dispatcher.Current.Should().BeNull();
+
+        Application.Run(() =>
+        {
+            Window window = new(Window.DefaultBounds);
+            window.PostMessage(MessageType.Close);
+            return window;
+        });
+    }
+
+    [STATestMethod]
+    public void ApplicationRun_WindowFactoryReturnsNull_ThrowsAndClearsCurrent()
+    {
+        Action run = () => Application.Run(static () => null!);
+
+        run.Should().Throw<InvalidOperationException>().WithMessage("The window factory returned null.");
+        Dispatcher.Current.Should().BeNull();
+
+        Application.Run(() =>
+        {
+            Window window = new(Window.DefaultBounds);
+            window.PostMessage(MessageType.Close);
+            return window;
+        });
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherEventListener.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherEventListener.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace Windows.Threading;
+
+internal sealed class DispatcherEventListener : EventListener
+{
+    private readonly List<int> _eventIds = [];
+
+    internal IReadOnlyList<int> EventIds
+    {
+        get
+        {
+            lock (_eventIds)
+            {
+                return [.. _eventIds];
+            }
+        }
+    }
+
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource.Name == "ThirtyTwo-Dispatcher")
+        {
+            EnableEvents(eventSource, EventLevel.Verbose);
+        }
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        lock (_eventIds)
+        {
+            _eventIds.Add(eventData.EventId);
+        }
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherModalTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherModalTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Dialogs;
+using Windows.Messages;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Windows.Threading;
+
+[TestClass]
+public unsafe class DispatcherModalTests
+{
+    [STATestMethod]
+    public void InvokeAsync_FileDialogModalLoop_ExecutesCallback()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        using Window window = new(Window.DefaultBounds);
+        using FileOpenDialog dialog = new(window);
+        bool callbackRan = false;
+        bool callbackQueued = false;
+        Timer? watchdog = null;
+
+        Task<Task> queued = DispatcherTestWorker.Start(() => dispatcher.InvokeAsync(() =>
+        {
+            EnterIdleHandler.Attach(window, (bool isDialog, HWND dialogWindow) =>
+            {
+                if (callbackQueued)
+                {
+                    return;
+                }
+
+                callbackQueued = true;
+                watchdog = new Timer(
+                    static state =>
+                    {
+                        HWND hwnd = (HWND)(nint)state!;
+                        _ = PInvoke.PostMessage(hwnd, Interop.WM_CLOSE, default, default);
+                    },
+                    (nint)dialogWindow.Value,
+                    TimeSpan.FromSeconds(5),
+                    Timeout.InfiniteTimeSpan);
+
+                _ = dispatcher.InvokeAsync(() =>
+                {
+                    callbackRan = true;
+                    dialogWindow.SendMessage(MessageType.Close);
+                });
+            });
+
+            dialog.ShowDialog().Should().BeFalse();
+            watchdog?.Dispose();
+            context.RequestExit();
+        }));
+
+        context.RunMessageLoop();
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        callbackRan.Should().BeTrue();
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherTestWorker.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTestWorker.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+internal static class DispatcherTestWorker
+{
+    private const uint StartMessage = Interop.WM_APP + 102;
+
+    internal static Task Start(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        return Start(() =>
+        {
+            callback();
+            return true;
+        });
+    }
+
+    internal static Task<TResult> Start<TResult>(Func<TResult> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<TResult> completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        MessageFilterRegistration registration = default;
+        registration = Application.AddMessageFilter(new StartMessageFilter(() =>
+        {
+            registration.Dispose();
+            started.TrySetResult();
+        }));
+
+        if (!PInvoke.PostThreadMessage(dispatcherThreadId, StartMessage, default, default))
+        {
+            registration.Dispose();
+            throw new InvalidOperationException("Failed to post the dispatcher test startup message.");
+        }
+
+        Thread worker = new(() =>
+        {
+            try
+            {
+                started.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+                completion.SetResult(callback());
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+                PInvoke.PostThreadMessage(dispatcherThreadId, Interop.WM_QUIT, default, default);
+            }
+        });
+
+        worker.Start();
+        return completion.Task;
+    }
+
+    private sealed class StartMessageFilter(Action callback) : IMessageFilter
+    {
+        public bool PreFilterMessage(ref MSG message)
+        {
+            if (message.message != StartMessage)
+            {
+                return false;
+            }
+
+            callback();
+            return true;
+        }
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTests.cs
@@ -391,11 +391,13 @@ public class DispatcherTests
     public void InvokeAsync_ProducerBurst_AllowsNativeMessageBetweenItems()
     {
         using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        using ManualResetEventSlim burstReady = new(initialState: false);
         Dispatcher dispatcher = context.Dispatcher;
         uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
         int callbacksRun = 0;
         int callbacksAtNativeMessage = -1;
-        _ = Application.AddMessageFilter(new FairnessFilter(() => callbacksAtNativeMessage = callbacksRun));
+        using MessageFilterRegistration fairnessRegistration = Application.AddMessageFilter(
+            new FairnessFilter(burstReady, () => callbacksAtNativeMessage = callbacksRun));
         Task<Task[]> queued = DispatcherTestWorker.Start(() =>
         {
             Task[] operations = Enumerable.Range(0, 100)
@@ -409,7 +411,9 @@ public class DispatcherTests
                 }))
                 .ToArray();
 
-            PInvoke.PostThreadMessage(dispatcherThreadId, FairnessMessage, default, default);
+            bool posted = PInvoke.PostThreadMessage(dispatcherThreadId, FairnessMessage, default, default);
+            burstReady.Set();
+            posted.Should().BeTrue();
             return operations;
         });
 
@@ -463,10 +467,19 @@ public class DispatcherTests
         observedValue.Should().BeNull();
     }
 
-    private sealed class FairnessFilter(Action callback) : IMessageFilter
+    private sealed class FairnessFilter(ManualResetEventSlim burstReady, Action callback) : IMessageFilter
     {
+        private bool _firstWakeObserved;
+
         public bool PreFilterMessage(ref MSG message)
         {
+            if (!_firstWakeObserved && message.message == Application.DispatcherWakeMessage)
+            {
+                _firstWakeObserved = true;
+                burstReady.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+                return false;
+            }
+
             if (message.message != FairnessMessage)
             {
                 return false;

--- a/src/thirtytwo_tests/Threading/DispatcherTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTests.cs
@@ -1,0 +1,483 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.Threading;
+
+[TestClass]
+public class DispatcherTests
+{
+    private const uint FairnessMessage = Interop.WM_APP + 101;
+
+    [STATestMethod]
+    public void InvokeAsync_Actions_ExecuteInFifoOrder()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        List<int> order = [];
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        uint callbackThreadId = 0;
+        Dispatcher? callbackDispatcher = null;
+
+        Task<Task[]> queued = QueueFromWorker(
+            dispatcher,
+            () => order.Add(1),
+            () => order.Add(2),
+            () =>
+            {
+                order.Add(3);
+                callbackThreadId = PInvoke.GetCurrentThreadId();
+                callbackDispatcher = Dispatcher.Current;
+                PInvoke.PostQuitMessage(0);
+            });
+
+        context.RunMessageLoop();
+    Task[] operations = queued.GetAwaiter().GetResult();
+        Task.WhenAll(operations).GetAwaiter().GetResult();
+
+        order.Should().Equal(1, 2, 3);
+        callbackThreadId.Should().Be(dispatcherThreadId);
+        callbackDispatcher.Should().BeSameAs(dispatcher);
+        Dispatcher.Current.Should().BeNull();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_ResultAndException_CompleteTasks()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        Task<(Task<int> Result, Task Fault)> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task<int> result = dispatcher.InvokeAsync(() => 42);
+            Task fault = dispatcher.InvokeAsync(() => throw new InvalidOperationException("Expected"));
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return (result, fault);
+        });
+
+        context.RunMessageLoop();
+
+        (Task<int> result, Task fault) = queued.GetAwaiter().GetResult();
+        result.GetAwaiter().GetResult().Should().Be(42);
+        Action getFault = () => fault.GetAwaiter().GetResult();
+        getFault.Should().Throw<InvalidOperationException>().WithMessage("Expected");
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_PreCanceled_DoesNotRunCallback()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        using CancellationTokenSource cancellationSource = new();
+        cancellationSource.Cancel();
+        bool callbackRan = false;
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task canceled = dispatcher.InvokeAsync(() => callbackRan = true, cancellationSource.Token);
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return canceled;
+        });
+
+        context.RunMessageLoop();
+
+        Task canceled = queued.GetAwaiter().GetResult();
+        Action getResult = () => canceled.GetAwaiter().GetResult();
+        getResult.Should().Throw<OperationCanceledException>();
+        callbackRan.Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_FromDispatcherThread_QueuesCallback()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        bool nestedRan = false;
+        bool nestedCompletedInline = true;
+        Task? nestedOperation = null;
+
+        Task<Task[]> queued = QueueFromWorker(
+            dispatcher,
+            () =>
+            {
+                nestedOperation = dispatcher.InvokeAsync(() =>
+                {
+                    nestedRan = true;
+                    PInvoke.PostQuitMessage(0);
+                });
+
+                nestedCompletedInline = nestedOperation.IsCompleted;
+            });
+
+        context.RunMessageLoop();
+    Task[] operations = queued.GetAwaiter().GetResult();
+        Task.WhenAll(operations).GetAwaiter().GetResult();
+        nestedOperation!.GetAwaiter().GetResult();
+
+        nestedCompletedInline.Should().BeFalse();
+        nestedRan.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_Callback_FlowsExecutionContextAndInstallsDispatcherContext()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        AsyncLocal<string?> contextValue = new();
+        string? observedValue = null;
+        SynchronizationContext? observedSynchronizationContext = null;
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            contextValue.Value = "Producer";
+            return dispatcher.InvokeAsync(() =>
+            {
+                observedValue = contextValue.Value;
+                observedSynchronizationContext = SynchronizationContext.Current;
+                PInvoke.PostQuitMessage(0);
+            });
+        });
+
+        context.RunMessageLoop();
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        observedValue.Should().Be("Producer");
+        observedSynchronizationContext.Should().BeOfType<DispatcherSynchronizationContext>();
+    }
+
+    [STATestMethod]
+    public void SynchronizationContext_Post_HandledExceptionContinuesPump()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        Exception? observedException = null;
+
+        Task<Task[]> queued = QueueFromWorker(
+            dispatcher,
+            () =>
+            {
+                dispatcher.UnhandledException += (_, arguments) =>
+                {
+                    observedException = arguments.Exception;
+                    arguments.Handled = true;
+                };
+
+                SynchronizationContext.Current!.Post(
+                    static _ => throw new InvalidOperationException("Expected"),
+                    null);
+
+                SynchronizationContext.Current.Post(static _ => PInvoke.PostQuitMessage(0), null);
+            });
+
+        context.RunMessageLoop();
+        Task.WhenAll(queued.GetAwaiter().GetResult()).GetAwaiter().GetResult();
+
+        observedException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Expected");
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_AsyncCallback_RepresentsFullLifetimeAndResumesOnDispatcher()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        uint resumedThreadId = 0;
+        bool interleavedCallbackRan = false;
+        Task<(Task<int> Async, Task Interleaved)> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task<int> asyncOperation = dispatcher.InvokeAsync<int>(async _ =>
+            {
+                await Task.Yield();
+                resumedThreadId = PInvoke.GetCurrentThreadId();
+                interleavedCallbackRan.Should().BeTrue();
+                return 42;
+            });
+
+            Task interleaved = dispatcher.InvokeAsync(() => interleavedCallbackRan = true);
+            asyncOperation.GetAwaiter().GetResult();
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return (asyncOperation, interleaved);
+        });
+
+        context.RunMessageLoop();
+
+        (Task<int> asyncOperation, Task interleaved) = queued.GetAwaiter().GetResult();
+        interleaved.GetAwaiter().GetResult();
+        asyncOperation.GetAwaiter().GetResult().Should().Be(42);
+        resumedThreadId.Should().Be(dispatcherThreadId);
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_ParameterlessAsyncLambda_RepresentsFullLifetime()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        bool resumed = false;
+        Task<Task<int>> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task<int> operation = dispatcher.InvokeAsync(async () =>
+            {
+                await Task.Yield();
+                resumed = true;
+                return 42;
+            });
+
+            operation.GetAwaiter().GetResult();
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return operation;
+        });
+
+        context.RunMessageLoop();
+
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult().Should().Be(42);
+        resumed.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_AsyncCallback_FinallyRunsBeforeTaskCompletes()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        bool finallyRan = false;
+        bool finallyObservedAtCompletion = false;
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task operation = dispatcher.InvokeAsync(async () =>
+            {
+                try
+                {
+                    await Task.Yield();
+                }
+                finally
+                {
+                    finallyRan = true;
+                }
+            });
+
+            operation.GetAwaiter().GetResult();
+            finallyObservedAtCompletion = finallyRan;
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return operation;
+        });
+
+        context.RunMessageLoop();
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        finallyObservedAtCompletion.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_CanceledWhileQueued_DoesNotRunCallback()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        using CancellationTokenSource cancellationSource = new();
+        bool callbackRan = false;
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            _ = dispatcher.InvokeAsync(cancellationSource.Cancel);
+            Task canceled = dispatcher.InvokeAsync(() => callbackRan = true, cancellationSource.Token);
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return canceled;
+        });
+
+        context.RunMessageLoop();
+
+        Task canceled = queued.GetAwaiter().GetResult();
+        Action getResult = () => canceled.GetAwaiter().GetResult();
+        getResult.Should().Throw<OperationCanceledException>();
+        callbackRan.Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_RunningAsyncCallback_CancellationIsCooperative()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        using CancellationTokenSource cancellationSource = new();
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task canceled = dispatcher.InvokeAsync(
+                async cancellationToken =>
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                },
+                cancellationSource.Token);
+
+            _ = dispatcher.InvokeAsync(cancellationSource.Cancel);
+
+            try
+            {
+                canceled.GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            }
+
+            return canceled;
+        });
+
+        context.RunMessageLoop();
+
+        Task canceled = queued.GetAwaiter().GetResult();
+        Action getResult = () => canceled.GetAwaiter().GetResult();
+        getResult.Should().Throw<OperationCanceledException>();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_RunningAsyncCallback_HandlesCancellationAndSucceeds()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        using CancellationTokenSource cancellationSource = new();
+        Task<Task<int>> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task<int> operation = dispatcher.InvokeAsync(
+                async cancellationToken =>
+                {
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    return 42;
+                },
+                cancellationSource.Token);
+
+            _ = dispatcher.InvokeAsync(cancellationSource.Cancel);
+            operation.GetAwaiter().GetResult();
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return operation;
+        });
+
+        context.RunMessageLoop();
+
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult().Should().Be(42);
+    }
+
+    [STATestMethod]
+    public void RunMessageLoop_SuspendedAsyncCallback_ShutdownFaultsOperation()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        TaskCompletionSource releaseCallback = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource callbackFinished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task operation = dispatcher.InvokeAsync(async _ =>
+            {
+                await releaseCallback.Task.ConfigureAwait(false);
+                callbackFinished.SetResult();
+            });
+
+            _ = dispatcher.InvokeAsync(() => PInvoke.PostQuitMessage(0));
+            return operation;
+        });
+
+        context.RunMessageLoop();
+
+        Task operation = queued.GetAwaiter().GetResult();
+        Action getResult = () => operation.GetAwaiter().GetResult();
+        getResult.Should().Throw<ObjectDisposedException>().WithMessage("*Operation 1*");
+
+        releaseCallback.SetResult();
+        callbackFinished.Task.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_ProducerBurst_AllowsNativeMessageBetweenItems()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        int callbacksRun = 0;
+        int callbacksAtNativeMessage = -1;
+        _ = Application.AddMessageFilter(new FairnessFilter(() => callbacksAtNativeMessage = callbacksRun));
+        Task<Task[]> queued = DispatcherTestWorker.Start(() =>
+        {
+            Task[] operations = Enumerable.Range(0, 100)
+                .Select(index => dispatcher.InvokeAsync(() =>
+                {
+                    callbacksRun++;
+                    if (index == 99)
+                    {
+                        PInvoke.PostQuitMessage(0);
+                    }
+                }))
+                .ToArray();
+
+            PInvoke.PostThreadMessage(dispatcherThreadId, FairnessMessage, default, default);
+            return operations;
+        });
+
+        context.RunMessageLoop();
+        Task.WhenAll(queued.GetAwaiter().GetResult()).GetAwaiter().GetResult();
+
+        callbacksRun.Should().Be(100);
+        callbacksAtNativeMessage.Should().Be(1);
+    }
+
+    [STATestMethod]
+    public void SynchronizationContext_Post_UnhandledException_ExitsPumpAndRethrows()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        Task<Task[]> queued = QueueFromWorker(dispatcher, () =>
+            SynchronizationContext.Current!.Post(
+                static _ => throw new InvalidOperationException("Expected"),
+                null));
+
+        Action run = context.RunMessageLoop;
+
+        run.Should().Throw<InvalidOperationException>().WithMessage("Expected");
+        Task.WhenAll(queued.GetAwaiter().GetResult()).GetAwaiter().GetResult();
+    }
+
+    [STATestMethod]
+    public void InvokeAsync_SuppressedExecutionContext_DoesNotFlowAsyncLocal()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        AsyncLocal<string?> contextValue = new();
+        string? observedValue = "NotRun";
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            contextValue.Value = "Producer";
+
+            using (ExecutionContext.SuppressFlow())
+            {
+                return dispatcher.InvokeAsync(() =>
+                {
+                    observedValue = contextValue.Value;
+                    PInvoke.PostQuitMessage(0);
+                });
+            }
+        });
+
+        context.RunMessageLoop();
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        observedValue.Should().BeNull();
+    }
+
+    private sealed class FairnessFilter(Action callback) : IMessageFilter
+    {
+        public bool PreFilterMessage(ref MSG message)
+        {
+            if (message.message != FairnessMessage)
+            {
+                return false;
+            }
+
+            callback();
+            return true;
+        }
+    }
+
+    private static Task<Task[]> QueueFromWorker(Dispatcher dispatcher, params Action[] callbacks)
+        => DispatcherTestWorker.Start(
+            () => callbacks.Select(callback => dispatcher.InvokeAsync(callback)).ToArray());
+}

--- a/src/thirtytwo_tests/Threading/DispatcherTimerTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTimerTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Win32;
+
+[TestClass]
+public class DispatcherTimerTests
+{
+    [TestMethod]
+    public void Tick_MissedIntervals_SkipsToNextDeadline()
+    {
+        ManualTimeProvider timeProvider = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            timeProvider,
+            dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        using DispatcherTimer timer = dispatcher.CreateTimer(TimeSpan.FromSeconds(10));
+        int tickCount = 0;
+        timer.Tick += (_, _) =>
+        {
+            tickCount++;
+            if (tickCount == 1)
+            {
+                timeProvider.Advance(TimeSpan.FromSeconds(35));
+            }
+            else
+            {
+                timer.Stop();
+            }
+        };
+
+        timer.Start();
+        wake!.DeliverOne();
+        wake.DelayedWakeDelay.Should().Be(10_000);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        wake.DeliverDelayedWake();
+        wake.DeliverOne();
+        wake.DelayedWakeDelay.Should().Be(5_000);
+        tickCount.Should().Be(1);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(4));
+        _ = dispatcher.InvokeAsync(static () => { });
+        wake.DeliverOne();
+        wake.DelayedWakeDelay.Should().Be(1_000);
+        tickCount.Should().Be(1);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        wake.DeliverDelayedWake();
+        tickCount.Should().Be(2);
+        timer.IsRunning.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Tick_IntervalChangedInHandler_SchedulesOnceFromChange()
+    {
+        ManualTimeProvider timeProvider = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            timeProvider,
+            dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        using DispatcherTimer timer = dispatcher.CreateTimer(TimeSpan.FromSeconds(10));
+        int tickCount = 0;
+        timer.Tick += (_, _) =>
+        {
+            tickCount++;
+            timer.Interval = TimeSpan.FromSeconds(5);
+        };
+
+        timer.Start();
+        wake!.DeliverOne();
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        wake.DeliverDelayedWake();
+        wake.DeliverOne();
+
+        tickCount.Should().Be(1);
+        wake.DelayedWakeDelay.Should().Be(5_000);
+        timer.Stop();
+    }
+
+    [TestMethod]
+    public void Tick_HandledException_RoutesToDispatcher()
+    {
+        ManualTimeProvider timeProvider = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            timeProvider,
+            dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        using DispatcherTimer timer = dispatcher.CreateTimer(TimeSpan.FromSeconds(1));
+        Exception? observed = null;
+        dispatcher.UnhandledException += (_, arguments) =>
+        {
+            observed = arguments.Exception;
+            arguments.Handled = true;
+        };
+        timer.Tick += (_, _) => throw new InvalidOperationException("Expected");
+
+        timer.Start();
+        wake!.DeliverOne();
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        wake.DeliverDelayedWake();
+
+        observed.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Expected");
+        timer.IsRunning.Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void RunMessageLoop_RunningTimer_StopsDuringShutdown()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        DispatcherTimer? timer = null;
+        Task<Task> queued = DispatcherTestWorker.Start(() => dispatcher.InvokeAsync(() =>
+        {
+            timer = dispatcher.CreateTimer(TimeSpan.FromHours(1));
+            timer.Start();
+            context.RequestExit();
+        }));
+
+        context.RunMessageLoop();
+        queued.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        timer.Should().NotBeNull();
+        timer!.IsRunning.Should().BeFalse();
+        timer.Dispose();
+    }
+}

--- a/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
@@ -182,9 +182,10 @@ public class DispatcherWakeTests
     [TestMethod]
     public void BeginShutdown_CancelsTokenBeforeDisposeCompletesTask()
     {
-        ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
             wakeFactory: dispatcher => new FakeDispatcherWake(dispatcher));
         Dispatcher dispatcher = context.Dispatcher;
+        CancellationTokenSource shutdownSource = ThreadingTestAccessors.GetShutdownSource(dispatcher);
         CancellationToken shutdownToken = dispatcher.ShutdownToken;
         Task completion = dispatcher.Completion;
         dispatcher.Start();
@@ -198,6 +199,11 @@ public class DispatcherWakeTests
         context.Dispose();
 
         dispatcher.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        Action getSourceToken = () => _ = shutdownSource.Token;
+        getSourceToken.Should().Throw<ObjectDisposedException>();
+        bool shutdownObserved = false;
+        using CancellationTokenRegistration registration = dispatcher.ShutdownToken.Register(() => shutdownObserved = true);
+        shutdownObserved.Should().BeTrue();
         completion.IsCompletedSuccessfully.Should().BeTrue();
     }
 

--- a/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Support;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+[TestClass]
+public class DispatcherWakeTests
+{
+    [ThreadStatic]
+    private static bool t_processingWake;
+
+    [TestMethod]
+    public void InvokeAsync_MultipleItems_CoalescesOutstandingWake()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+
+        Task[] operations = Enumerable.Range(0, 100)
+            .Select(_ => dispatcher.InvokeAsync(static () => { }))
+            .ToArray();
+
+        wake.Should().NotBeNull();
+        wake!.WakeCount.Should().Be(1);
+        wake.MaximumPendingWakes.Should().Be(1);
+
+        while (operations.Any(operation => !operation.IsCompleted))
+        {
+            wake.DeliverOne();
+        }
+
+        Task.WhenAll(operations).GetAwaiter().GetResult();
+        wake.WakeCount.Should().Be(operations.Length);
+        wake.MaximumPendingWakes.Should().Be(1);
+    }
+
+    [TestMethod]
+    public void ProcessWake_DelayedWakePending_PreservesDelayedWake()
+    {
+        ManualTimeProvider timeProvider = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            timeProvider,
+            dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        bool delayedRan = false;
+        bool immediateRan = false;
+
+        Task delayed = dispatcher.InvokeAsync(TimeSpan.FromSeconds(10), () => delayedRan = true);
+        wake!.DeliverOne();
+        wake.DelayedWakeDelay.Should().Be(10_000);
+
+        Task immediate = dispatcher.InvokeAsync(() => immediateRan = true);
+        wake.DelayedWakeDelay.Should().Be(10_000);
+        wake.DeliverOne();
+
+        immediate.GetAwaiter().GetResult();
+        immediateRan.Should().BeTrue();
+        delayedRan.Should().BeFalse();
+        wake.DelayedWakeDelay.Should().Be(10_000);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        wake.DeliverDelayedWake();
+
+        delayed.GetAwaiter().GetResult();
+        delayedRan.Should().BeTrue();
+        wake.DelayedWakeDelay.Should().BeNull();
+    }
+
+    [STATestMethod]
+    public void ProcessQueue_RearmFailure_FaultsRemainingWork()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        using Window window = new(Window.DefaultBounds);
+        dispatcher.Start();
+        ThreadingTestAccessors.AttachDispatcher(window, dispatcher);
+        window.Dispatcher.Should().BeSameAs(dispatcher);
+
+        Task first = dispatcher.InvokeAsync(static () => { });
+        Task second = dispatcher.InvokeAsync(static () => { });
+        wake!.FailWakes = true;
+
+        wake.DeliverOne();
+
+        first.GetAwaiter().GetResult();
+        Action getSecond = () => second.GetAwaiter().GetResult();
+        getSecond.Should().Throw<ThirtyTwoException>().WithMessage("Expected wake failure.");
+        Action throwFault = dispatcher.ThrowIfFaulted;
+        throwFault.Should().Throw<ThirtyTwoException>().WithMessage("Expected wake failure.");
+        window.Dispatcher.Should().BeSameAs(dispatcher);
+        dispatcher.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        dispatcher.TryPost(static () => { }).Should().BeFalse();
+        Dispatcher.FromHandle(window.Handle).Should().BeNull();
+
+        _ = PInvoke.PeekMessage(
+            out _,
+            HWND.Null,
+            Interop.WM_QUIT,
+            Interop.WM_QUIT,
+            PEEK_MESSAGE_REMOVE_TYPE.PM_REMOVE);
+    }
+
+    [TestMethod]
+    public void InvokeAsync_Completion_DoesNotInlineContinuationInWakeProcessor()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        bool continuationRanInsideWake = false;
+
+        Task operation = dispatcher.InvokeAsync(static () => { });
+        Task continuation = operation.ContinueWith(
+            _ => continuationRanInsideWake = t_processingWake,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        t_processingWake = true;
+        try
+        {
+            wake!.DeliverOne();
+        }
+        finally
+        {
+            t_processingWake = false;
+        }
+
+        continuation.GetAwaiter().GetResult();
+
+        continuationRanInsideWake.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void InvokeAsync_AfterStop_ReturnsFaultedTask()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        dispatcher.Stop();
+
+        Task operation = dispatcher.InvokeAsync(static () => { });
+
+        Action getResult = () => operation.GetAwaiter().GetResult();
+        getResult.Should().Throw<ObjectDisposedException>().WithMessage("*Stopped*");
+        dispatcher.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        dispatcher.TryPost(static () => { }).Should().BeFalse();
+        wake.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void TryPost_RunningDispatcher_ExecutesCallback()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        bool callbackRan = false;
+
+        bool accepted = dispatcher.TryPost(() => callbackRan = true);
+        wake!.DeliverOne();
+
+        accepted.Should().BeTrue();
+        callbackRan.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void BeginShutdown_CancelsTokenBeforeDisposeCompletesTask()
+    {
+        ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        CancellationToken shutdownToken = dispatcher.ShutdownToken;
+        Task completion = dispatcher.Completion;
+        dispatcher.Start();
+
+        dispatcher.BeginShutdown();
+
+        shutdownToken.IsCancellationRequested.Should().BeTrue();
+        dispatcher.TryPost(static () => { }).Should().BeFalse();
+        completion.IsCompleted.Should().BeFalse();
+
+        context.Dispose();
+
+        dispatcher.ShutdownToken.IsCancellationRequested.Should().BeTrue();
+        completion.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void Start_SecondDispatcherFailure_DoesNotUnregisterRunningDispatcher()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        Dispatcher second = ThreadingTestAccessors.CreateDispatcher(
+            wakeFactory: candidate => new FakeDispatcherWake(candidate));
+        using Window window = new(Window.DefaultBounds);
+        dispatcher.Start();
+        ThreadingTestAccessors.AttachDispatcher(window, dispatcher);
+
+        try
+        {
+            Action start = second.Start;
+            start.Should().Throw<InvalidOperationException>()
+                .WithMessage("The current thread already has a running dispatcher.");
+        }
+        finally
+        {
+            second.Dispose();
+        }
+
+        window.Dispatcher.Should().BeSameAs(dispatcher);
+    }
+
+    [TestMethod]
+    public void EventSource_Operation_EmitsLifecycleAndQueueEvents()
+    {
+        using DispatcherEventListener listener = new();
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        dispatcher.Start();
+        Task operation = dispatcher.InvokeAsync(static () => { });
+
+        wake!.DeliverOne();
+        operation.GetAwaiter().GetResult();
+        dispatcher.Stop();
+
+        listener.EventIds.Should().Contain([1, 2, 3, 4, 7]);
+    }
+
+    [TestMethod]
+    public void InvokeAsync_WorkerWakeFailure_FaultsTaskAndExitsPump()
+    {
+        FakeDispatcherWake? wake = null;
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext(
+            wakeFactory: dispatcher => wake = new FakeDispatcherWake(dispatcher));
+        Dispatcher dispatcher = context.Dispatcher;
+        Task<Task> queued = DispatcherTestWorker.Start(() =>
+        {
+            wake!.FailWakes = true;
+            return dispatcher.InvokeAsync(static () => { });
+        });
+
+        Action run = context.RunMessageLoop;
+
+        run.Should().Throw<ThirtyTwoException>().WithMessage("Expected wake failure.");
+        Task operation = queued.GetAwaiter().GetResult();
+        Action getResult = () => operation.GetAwaiter().GetResult();
+        getResult.Should().Throw<ThirtyTwoException>().WithMessage("Expected wake failure.");
+    }
+}

--- a/src/thirtytwo_tests/Threading/FakeDispatcherWake.cs
+++ b/src/thirtytwo_tests/Threading/FakeDispatcherWake.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Support;
+using Windows.Win32.Foundation;
+
+internal sealed class FakeDispatcherWake(Dispatcher dispatcher) : IDispatcherWake
+{
+    private int _pendingWakes;
+
+    internal bool FailWakes { get; set; }
+
+    internal int MaximumPendingWakes { get; private set; }
+
+    internal int WakeCount { get; private set; }
+
+    internal uint? DelayedWakeDelay { get; private set; }
+
+    public void Wake()
+    {
+        if (FailWakes)
+        {
+            throw new ThirtyTwoException(WIN32_ERROR.ERROR_NOT_ENOUGH_QUOTA, "Expected wake failure.");
+        }
+
+        WakeCount++;
+        _pendingWakes++;
+        MaximumPendingWakes = Math.Max(MaximumPendingWakes, _pendingWakes);
+    }
+
+    public void WakeAfter(uint delayMilliseconds)
+    {
+        DelayedWakeDelay = delayMilliseconds;
+    }
+
+    public void CancelDelayedWake()
+    {
+        DelayedWakeDelay = null;
+    }
+
+    internal void DeliverOne()
+    {
+        if (_pendingWakes == 0)
+        {
+            throw new InvalidOperationException("No dispatcher wake is pending.");
+        }
+
+        _pendingWakes--;
+        dispatcher.ProcessWake();
+    }
+
+    internal void DeliverDelayedWake()
+    {
+        if (DelayedWakeDelay is null)
+        {
+            throw new InvalidOperationException("No delayed dispatcher wake is pending.");
+        }
+
+        dispatcher.ProcessDelayedWake();
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/thirtytwo_tests/Threading/ManualTimeProvider.cs
+++ b/src/thirtytwo_tests/Threading/ManualTimeProvider.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+internal sealed class ManualTimeProvider : TimeProvider
+{
+    private long _timestamp;
+
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+    public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+
+    internal void Advance(TimeSpan elapsed)
+    {
+        if (elapsed < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(elapsed));
+        }
+
+        Interlocked.Add(ref _timestamp, elapsed.Ticks);
+    }
+}

--- a/src/thirtytwo_tests/Threading/MessageFilterTests.cs
+++ b/src/thirtytwo_tests/Threading/MessageFilterTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+[TestClass]
+public class MessageFilterTests
+{
+    private const uint TestMessage = Interop.WM_APP + 100;
+
+    [STATestMethod]
+    public void AddMessageFilter_SelfRemoval_AppliesToNextMessage()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        List<int> order = [];
+        MessageFilterRegistration firstRegistration = default;
+        int secondFilterCount = 0;
+
+        Task<Task> setup = DispatcherTestWorker.Start(() => dispatcher.InvokeAsync(() =>
+        {
+            firstRegistration = Application.AddMessageFilter(new CallbackFilter(message =>
+            {
+                if (message == TestMessage)
+                {
+                    order.Add(1);
+                    firstRegistration.Dispose();
+                }
+
+                return false;
+            }));
+
+            _ = Application.AddMessageFilter(new CallbackFilter(message =>
+            {
+                if (message == TestMessage)
+                {
+                    order.Add(2);
+                    secondFilterCount++;
+                    if (secondFilterCount == 2)
+                    {
+                        PInvoke.PostQuitMessage(0);
+                    }
+                }
+
+                return false;
+            }));
+
+            PInvoke.PostThreadMessage(dispatcherThreadId, TestMessage, default, default);
+            PInvoke.PostThreadMessage(dispatcherThreadId, TestMessage, default, default);
+        }));
+
+        context.RunMessageLoop();
+    setup.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        order.Should().Equal(1, 2, 2);
+    }
+
+    [STATestMethod]
+    public void MessageFilterRegistration_DisposeFromWrongThread_Throws()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        uint dispatcherThreadId = PInvoke.GetCurrentThreadId();
+        TaskCompletionSource<Exception?> result = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<Task> setup = DispatcherTestWorker.Start(() => dispatcher.InvokeAsync(() =>
+        {
+            MessageFilterRegistration registration =
+                Application.AddMessageFilter(new CallbackFilter(static _ => false));
+
+            Thread worker = new(() =>
+            {
+                try
+                {
+                    registration.Dispose();
+                    result.SetResult(null);
+                }
+                catch (Exception exception)
+                {
+                    result.SetResult(exception);
+                }
+                finally
+                {
+                    PInvoke.PostThreadMessage(dispatcherThreadId, Interop.WM_QUIT, default, default);
+                }
+            });
+
+            worker.Start();
+        }));
+
+        context.RunMessageLoop();
+        setup.GetAwaiter().GetResult().GetAwaiter().GetResult();
+
+        result.Task.GetAwaiter().GetResult().Should().BeOfType<InvalidOperationException>();
+    }
+
+    private sealed class CallbackFilter(Func<uint, bool> callback) : IMessageFilter
+    {
+        public bool PreFilterMessage(ref MSG message) => callback(message.message);
+    }
+}

--- a/src/thirtytwo_tests/Threading/ThreadContextTests.cs
+++ b/src/thirtytwo_tests/Threading/ThreadContextTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+[TestClass]
+public class ThreadContextTests
+{
+    [TestMethod]
+    public void Create_ExistingContext_Throws()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+
+        Action action = () => ThreadingTestAccessors.CreateThreadContext();
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [TestMethod]
+    public void Create_AfterDispose_Succeeds()
+    {
+        ThreadingTestAccessors.CreateThreadContext().Dispose();
+
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+    }
+
+    [STATestMethod]
+    public void RunMessageLoop_QuitPosted_Returns()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        PInvoke.PostQuitMessage(0);
+
+        context.RunMessageLoop();
+    }
+
+    [STATestMethod]
+    public void RunMessageLoop_PreviousSynchronizationContext_Restores()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        SynchronizationContext previous = new();
+        SynchronizationContext.SetSynchronizationContext(previous);
+
+        try
+        {
+            PInvoke.PostQuitMessage(0);
+            context.RunMessageLoop();
+
+            SynchronizationContext.Current.Should().BeSameAs(previous);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+        }
+    }
+
+    [STATestMethod]
+    public void RegisterShutdownCallback_MultipleCallbacks_RunInReverseOrder()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        List<int> order = [];
+        context.RegisterShutdownCallback(() =>
+        {
+            Dispatcher.Current.Should().BeNull();
+            Action getResult = () => context.Dispatcher.InvokeAsync(static () => { }).GetAwaiter().GetResult();
+            getResult.Should().Throw<ObjectDisposedException>().WithMessage("*Stopping*");
+            order.Add(1);
+        });
+        context.RegisterShutdownCallback(() => order.Add(2));
+
+        PInvoke.PostQuitMessage(0);
+        context.RunMessageLoop();
+
+        order.Should().Equal(2, 1);
+    }
+
+    [STATestMethod]
+    public void RegisterShutdownCallback_ThrowingCallback_RunsRemainingCallbacks()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        List<int> order = [];
+        context.RegisterShutdownCallback(() => order.Add(1));
+        context.RegisterShutdownCallback(() =>
+        {
+            order.Add(2);
+            throw new InvalidOperationException("Expected");
+        });
+
+        PInvoke.PostQuitMessage(0);
+        Action run = context.RunMessageLoop;
+
+        run.Should().Throw<AggregateException>()
+            .Which.InnerExceptions.Should().ContainSingle()
+            .Which.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be("Expected");
+        order.Should().Equal(2, 1);
+    }
+
+    [STATestMethod]
+    public void RunMessageLoop_ThrowingShutdownTokenCallback_RunsShutdownCallbacks()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        bool shutdownCallbackRan = false;
+        context.RegisterShutdownCallback(() => shutdownCallbackRan = true);
+        using CancellationTokenRegistration registration = context.Dispatcher.ShutdownToken.Register(
+            static () => throw new InvalidOperationException("Expected"));
+        PInvoke.PostQuitMessage(0);
+
+        Action run = context.RunMessageLoop;
+
+        run.Should().Throw<InvalidOperationException>().WithMessage("Expected");
+        shutdownCallbackRan.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void MessageFilterRegistration_DisposeAfterContextDispose_DoesNotThrow()
+    {
+        ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        MessageFilterRegistration registration =
+            context.AddMessageFilter(new PassiveMessageFilter());
+        context.Dispose();
+
+        Action dispose = registration.Dispose;
+
+        dispose.Should().NotThrow();
+    }
+
+    private sealed class PassiveMessageFilter : IMessageFilter
+    {
+        public bool PreFilterMessage(ref MSG message) => false;
+    }
+}

--- a/src/thirtytwo_tests/Threading/ThreadingTestAccessors.cs
+++ b/src/thirtytwo_tests/Threading/ThreadingTestAccessors.cs
@@ -55,6 +55,9 @@ internal static class ThreadingTestAccessors
     internal static void RequestExit(this ThreadContext context)
         => context.TestAccessor.CreateDelegate<Action>("RequestExit")();
 
+    internal static CancellationTokenSource GetShutdownSource(Dispatcher dispatcher)
+        => dispatcher.TestAccessor.Dynamic._shutdownSource;
+
     private static void ConfigureDispatcher(
         Dispatcher dispatcher,
         TimeProvider? timeProvider,

--- a/src/thirtytwo_tests/Threading/ThreadingTestAccessors.cs
+++ b/src/thirtytwo_tests/Threading/ThreadingTestAccessors.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Threading;
+
+internal static class ThreadingTestAccessors
+{
+    private delegate void RunMessageLoopDelegate(Action? initialize);
+
+    private static readonly Func<ThreadContext> s_createThreadContext =
+        typeof(ThreadContext).TestAccessor.CreateDelegate<Func<ThreadContext>>("Create");
+
+    internal static ThreadContext CreateThreadContext(
+        TimeProvider? timeProvider = null,
+        Func<Dispatcher, IDispatcherWake>? wakeFactory = null)
+    {
+        ThreadContext context = s_createThreadContext();
+
+        try
+        {
+            ConfigureDispatcher(context.Dispatcher, timeProvider, wakeFactory);
+            return context;
+        }
+        catch
+        {
+            context.Dispose();
+            throw;
+        }
+    }
+
+    internal static Dispatcher CreateDispatcher(
+        TimeProvider? timeProvider = null,
+        Func<Dispatcher, IDispatcherWake>? wakeFactory = null)
+    {
+        Dispatcher dispatcher = new();
+
+        try
+        {
+            ConfigureDispatcher(dispatcher, timeProvider, wakeFactory);
+            return dispatcher;
+        }
+        catch
+        {
+            dispatcher.Dispose();
+            throw;
+        }
+    }
+
+    internal static void AttachDispatcher(Window window, Dispatcher dispatcher)
+        => window.TestAccessor.CreateDelegate<Action<Dispatcher>>("AttachDispatcher")(dispatcher);
+
+    internal static void RunMessageLoop(this ThreadContext context)
+        => context.TestAccessor.CreateDelegate<RunMessageLoopDelegate>("RunMessageLoop")(null);
+
+    internal static void RequestExit(this ThreadContext context)
+        => context.TestAccessor.CreateDelegate<Action>("RequestExit")();
+
+    private static void ConfigureDispatcher(
+        Dispatcher dispatcher,
+        TimeProvider? timeProvider,
+        Func<Dispatcher, IDispatcherWake>? wakeFactory)
+    {
+        dynamic accessor = dispatcher.TestAccessor.Dynamic;
+
+        if (timeProvider is not null)
+        {
+            accessor._timeProvider = timeProvider;
+            accessor._timestampOrigin = timeProvider.GetTimestamp();
+        }
+
+        if (wakeFactory is not null)
+        {
+            IDispatcherWake replacement = wakeFactory(dispatcher);
+            IDispatcherWake original = accessor._wake;
+            accessor._wake = replacement;
+            original.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a thread-owned UI dispatcher and message-loop context so callers can safely queue synchronous and asynchronous work without depending on an application window handle.

## Changes

- Add `ThreadContext` ownership for the message pump, synchronization context, message filters, and ordered shutdown callbacks.
- Add Task-based `Dispatcher` APIs with cancellation, delayed work, repeating timers, diagnostics, stable `Window.Dispatcher` affinity, and atomic shutdown admission.
- Use a dispatcher-owned message-only HWND and USER32 timer for immediate and delayed wake delivery.
- Add focused threading, modal-loop, discovery, wake-failure, cancellation, and timer tests.
- Add application and UI-thread dispatching guides, and link them from the README.
- Adopt Touki naming enforcement while keeping test-only access out of production code.

## Validation

- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (341 passed, 1 skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (341 passed, 1 skipped)
- [x] New or changed behavior has focused tests
- [x] Native ownership, size units, failure cleanup, and shutdown races were reviewed
- [x] Agent-file validation is not applicable; no `.agents` files changed
- [x] `git diff --check` passes

## Related issues

N/A