### PR TITLE
Add WinUI host environment

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,6 +57,9 @@ jobs:
       run: dotnet build --no-restore
     - name: Build Release
       run: dotnet build --configuration Release --no-restore
+    - name: Verify WinUI package isolation
+      shell: pwsh
+      run: ./eng/verify-winui-package-isolation.ps1 -Configuration Release
     - name: Test
       run: |
         $resultsDir = Join-Path $PWD.Path 'artifacts/test-results'

--- a/eng/verify-winui-package-isolation.ps1
+++ b/eng/verify-winui-package-isolation.ps1
@@ -1,0 +1,120 @@
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$artifacts = Join-Path $repoRoot 'artifacts/package-tests'
+$packages = Join-Path $artifacts 'packages'
+$restoreRoot = Join-Path $artifacts 'restore'
+$nugetConfig = Join-Path $artifacts 'NuGet.Config'
+$version = '0.0.0-local'
+
+Remove-Item $artifacts -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $packages, $restoreRoot | Out-Null
+
+$writerSettings = [System.Xml.XmlWriterSettings]::new()
+$writerSettings.Indent = $true
+$writer = [System.Xml.XmlWriter]::Create($nugetConfig, $writerSettings)
+try {
+    $writer.WriteStartDocument()
+    $writer.WriteStartElement('configuration')
+    $writer.WriteStartElement('packageSources')
+    $writer.WriteStartElement('clear')
+    $writer.WriteEndElement()
+    foreach ($source in @(
+        @{ Key = 'local'; Value = $packages },
+        @{ Key = 'nuget'; Value = 'https://api.nuget.org/v3/index.json' },
+        @{ Key = 'winsdk'; Value = 'https://pkgs.dev.azure.com/azure-public/winsdk/_packaging/CI/nuget/v3/index.json' }
+    )) {
+        $writer.WriteStartElement('add')
+        $writer.WriteAttributeString('key', $source.Key)
+        $writer.WriteAttributeString('value', $source.Value)
+        $writer.WriteEndElement()
+    }
+
+    $writer.WriteEndElement()
+    $writer.WriteEndElement()
+    $writer.WriteEndDocument()
+}
+finally {
+    $writer.Dispose()
+}
+
+dotnet pack (Join-Path $repoRoot 'src/thirtytwo/thirtytwo.csproj') `
+    --configuration $Configuration `
+    --output $packages `
+    -p:Version=$version
+if ($LASTEXITCODE -ne 0) { throw 'Packing thirtytwo failed.' }
+
+dotnet pack (Join-Path $repoRoot 'src/thirtytwo.winui/thirtytwo.winui.csproj') `
+    --configuration $Configuration `
+    --output $packages `
+    -p:Version=$version
+if ($LASTEXITCODE -ne 0) { throw 'Packing thirtytwo.winui failed.' }
+
+function Restore-And-ReadAssets([string] $ProjectName) {
+    $projectDirectory = Join-Path $repoRoot "src/package-tests/$ProjectName"
+    $project = Join-Path $projectDirectory "$ProjectName.csproj"
+    $packageRoot = Join-Path $restoreRoot $ProjectName
+    $intermediateRoot = Join-Path $artifacts "obj/$ProjectName/"
+    $outputRoot = Join-Path $artifacts "bin/$ProjectName/"
+
+    dotnet restore $project `
+        --packages $packageRoot `
+        --configfile $nugetConfig `
+        -p:BaseIntermediateOutputPath=$intermediateRoot `
+        -p:BaseOutputPath=$outputRoot `
+        --force-evaluate | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Restoring $ProjectName failed." }
+
+    dotnet build $project `
+        --configuration $Configuration `
+        --no-restore `
+        -p:BaseIntermediateOutputPath=$intermediateRoot `
+        -p:BaseOutputPath=$outputRoot | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Building $ProjectName failed." }
+
+    return Get-Content (Join-Path $intermediateRoot 'project.assets.json') -Raw | ConvertFrom-Json
+}
+
+$coreAssets = Restore-And-ReadAssets 'CoreOnlyConsumer'
+$coreLibraries = @($coreAssets.libraries.PSObject.Properties.Name)
+if ($coreLibraries -match '^Microsoft\.WindowsAppSDK(?:\.|/)') {
+    throw 'The core-only consumer restored a Microsoft.WindowsAppSDK package.'
+}
+
+if ($coreLibraries -match '^thirtytwo\.winui/') {
+    throw 'The core-only consumer restored thirtytwo.winui.'
+}
+
+$winuiAssets = Restore-And-ReadAssets 'WinUIConsumer'
+$winuiLibraries = @($winuiAssets.libraries.PSObject.Properties.Name)
+if ($winuiLibraries -notcontains "thirtytwo/$version") {
+    throw 'The WinUI consumer did not restore the local thirtytwo package.'
+}
+
+if ($winuiLibraries -notcontains "thirtytwo.winui/$version") {
+    throw 'The WinUI consumer did not restore the local thirtytwo.winui package.'
+}
+
+$windowsAppSdk = @($winuiLibraries | Where-Object { $_ -like 'Microsoft.WindowsAppSDK/*' })
+if ($windowsAppSdk.Count -ne 1 -or $windowsAppSdk[0] -ne 'Microsoft.WindowsAppSDK/2.3.1') {
+    throw "Expected Microsoft.WindowsAppSDK/2.3.1, found '$($windowsAppSdk -join ', ')'."
+}
+
+$deploymentProperties = dotnet msbuild `
+    (Join-Path $repoRoot 'src/thirtytwo.winui/thirtytwo.winui.csproj') `
+    -getProperty:WindowsPackageType `
+    -getProperty:WindowsAppSDKSelfContained `
+    -getProperty:SelfContained `
+    -getProperty:RuntimeIdentifier | ConvertFrom-Json
+
+foreach ($propertyName in @('WindowsPackageType', 'WindowsAppSDKSelfContained', 'SelfContained', 'RuntimeIdentifier')) {
+    if ($deploymentProperties.Properties.$propertyName) {
+        throw "thirtytwo.winui forces $propertyName='$($deploymentProperties.Properties.$propertyName)'."
+    }
+}
+
+Write-Host 'WinUI package isolation checks passed.'

--- a/src/package-tests/CoreOnlyConsumer/Consumer.cs
+++ b/src/package-tests/CoreOnlyConsumer/Consumer.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CoreOnlyConsumer;
+
+public static class Consumer
+{
+    public static Type WindowType => typeof(Windows.Window);
+}

--- a/src/package-tests/CoreOnlyConsumer/CoreOnlyConsumer.csproj
+++ b/src/package-tests/CoreOnlyConsumer/CoreOnlyConsumer.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="thirtytwo" Version="0.0.0-local" />
+  </ItemGroup>
+
+</Project>

--- a/src/package-tests/WinUIConsumer/Consumer.cs
+++ b/src/package-tests/WinUIConsumer/Consumer.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace WinUIConsumer;
+
+public static class Consumer
+{
+    public static Type EnvironmentType => typeof(Windows.WinUI.XamlHostEnvironment);
+}

--- a/src/package-tests/WinUIConsumer/WinUIConsumer.csproj
+++ b/src/package-tests/WinUIConsumer/WinUIConsumer.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="thirtytwo.winui" Version="0.0.0-local" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAControl.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAControl.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace SampleWinUIClassLibraryA;
+
+public sealed class LibraryAControl : Control;

--- a/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAMetadataProvider.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAMetadataProvider.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace SampleWinUIClassLibraryA;
+
+public sealed class LibraryAMetadataProvider : IXamlMetadataProvider
+{
+    public const string CollisionTypeName = "SampleWinUI.SharedControl";
+    private readonly LibraryAXamlType _xamlType = new();
+
+    public IXamlType? GetXamlType(string fullName)
+        => fullName == typeof(LibraryAControl).FullName || fullName == CollisionTypeName
+            ? _xamlType
+            : null;
+
+    public IXamlType? GetXamlType(Type type)
+        => type == typeof(LibraryAControl) ? _xamlType : null;
+
+    public XmlnsDefinition[] GetXmlnsDefinitions() => [];
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAResources.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAResources.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml;
+
+namespace SampleWinUIClassLibraryA;
+
+public sealed class LibraryAResources : ResourceDictionary
+{
+    public const string SharedResourceKey = "SampleWinUI.SharedResource";
+
+    public LibraryAResources()
+    {
+        this["SampleWinUI.LibraryAResource"] = "LibraryA";
+        this[SharedResourceKey] = "LibraryA";
+
+        ResourceDictionary defaultTheme = new();
+        defaultTheme["SampleWinUI.LibraryAThemeResource"] = "LibraryA.Default";
+        ThemeDictionaries["Default"] = defaultTheme;
+    }
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAXamlType.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryA/LibraryAXamlType.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace SampleWinUIClassLibraryA;
+
+internal sealed class LibraryAXamlType : IXamlType
+{
+    public IXamlType? BaseType => null;
+    public IXamlType? BoxedType => null;
+    public IXamlMember? ContentProperty => null;
+    public string FullName => typeof(LibraryAControl).FullName!;
+    public bool IsArray => false;
+    public bool IsBindable => false;
+    public bool IsCollection => false;
+    public bool IsConstructible => true;
+    public bool IsDictionary => false;
+    public bool IsMarkupExtension => false;
+    public IXamlType? ItemType => null;
+    public IXamlType? KeyType => null;
+    public Type UnderlyingType => typeof(LibraryAControl);
+
+    public object ActivateInstance() => new LibraryAControl();
+    public void AddToMap(object instance, object key, object value) => throw new NotSupportedException();
+    public void AddToVector(object instance, object value) => throw new NotSupportedException();
+    public object CreateFromString(string value) => throw new NotSupportedException();
+    public IXamlMember? GetMember(string name) => null;
+    public void RunInitializer() { }
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryA/SampleWinUIClassLibraryA.csproj
+++ b/src/samples/WinUI/SampleWinUIClassLibraryA/SampleWinUIClassLibraryA.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RootNamespace>SampleWinUIClassLibraryA</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBControl.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBControl.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace SampleWinUIClassLibraryB;
+
+public sealed class LibraryBControl : Control;

--- a/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBMetadataProvider.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBMetadataProvider.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace SampleWinUIClassLibraryB;
+
+public sealed class LibraryBMetadataProvider : IXamlMetadataProvider
+{
+    public const string CollisionTypeName = "SampleWinUI.SharedControl";
+    private readonly LibraryBXamlType _xamlType = new();
+
+    public IXamlType? GetXamlType(string fullName)
+        => fullName == typeof(LibraryBControl).FullName || fullName == CollisionTypeName
+            ? _xamlType
+            : null;
+
+    public IXamlType? GetXamlType(Type type)
+        => type == typeof(LibraryBControl) ? _xamlType : null;
+
+    public XmlnsDefinition[] GetXmlnsDefinitions() => [];
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBResources.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBResources.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml;
+
+namespace SampleWinUIClassLibraryB;
+
+public sealed class LibraryBResources : ResourceDictionary
+{
+    public const string SharedResourceKey = "SampleWinUI.SharedResource";
+
+    public LibraryBResources()
+    {
+        this["SampleWinUI.LibraryBResource"] = "LibraryB";
+        this[SharedResourceKey] = "LibraryB";
+
+        ResourceDictionary defaultTheme = new();
+        defaultTheme["SampleWinUI.LibraryBThemeResource"] = "LibraryB.Default";
+        ThemeDictionaries["Default"] = defaultTheme;
+    }
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBXamlType.cs
+++ b/src/samples/WinUI/SampleWinUIClassLibraryB/LibraryBXamlType.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace SampleWinUIClassLibraryB;
+
+internal sealed class LibraryBXamlType : IXamlType
+{
+    public IXamlType? BaseType => null;
+    public IXamlType? BoxedType => null;
+    public IXamlMember? ContentProperty => null;
+    public string FullName => typeof(LibraryBControl).FullName!;
+    public bool IsArray => false;
+    public bool IsBindable => false;
+    public bool IsCollection => false;
+    public bool IsConstructible => true;
+    public bool IsDictionary => false;
+    public bool IsMarkupExtension => false;
+    public IXamlType? ItemType => null;
+    public IXamlType? KeyType => null;
+    public Type UnderlyingType => typeof(LibraryBControl);
+
+    public object ActivateInstance() => new LibraryBControl();
+    public void AddToMap(object instance, object key, object value) => throw new NotSupportedException();
+    public void AddToVector(object instance, object value) => throw new NotSupportedException();
+    public object CreateFromString(string value) => throw new NotSupportedException();
+    public IXamlMember? GetMember(string name) => null;
+    public void RunInitializer() { }
+}

--- a/src/samples/WinUI/SampleWinUIClassLibraryB/SampleWinUIClassLibraryB.csproj
+++ b/src/samples/WinUI/SampleWinUIClassLibraryB/SampleWinUIClassLibraryB.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RootNamespace>SampleWinUIClassLibraryB</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/thirtytwo.winui/IXamlHostApplication.cs
+++ b/src/thirtytwo.winui/IXamlHostApplication.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Provides metadata and resource composition to the WinUI host environment.
+/// </summary>
+public interface IXamlHostApplication : IXamlMetadataProvider
+{
+    /// <summary>
+    ///  Gets the metadata providers exposed by the application.
+    /// </summary>
+    XamlMetadataProviderRegistry MetadataProviders { get; }
+
+    /// <summary>
+    ///  Gets the resource dictionaries exposed by the application.
+    /// </summary>
+    XamlResourceDictionaryRegistry ResourceDictionaries { get; }
+}

--- a/src/thirtytwo.winui/XamlApplication.cs
+++ b/src/thirtytwo.winui/XamlApplication.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.XamlTypeInfo;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Resolves XAML types through registered metadata providers and merges registered resource dictionaries into the
+///  application resources.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="XamlHostEnvironment"/> creates this application when the process does not provide an
+///   <see cref="IXamlHostApplication"/>.
+///  </para>
+/// </remarks>
+internal sealed class XamlApplication : Microsoft.UI.Xaml.Application, IXamlHostApplication
+{
+    private XamlMetadataProviderRegistry? _metadataProviders;
+    private XamlResourceDictionaryRegistry? _resourceDictionaries;
+
+    public XamlMetadataProviderRegistry MetadataProviders
+        => _metadataProviders ?? throw new InvalidOperationException("XAML composition has not been initialized.");
+
+    public XamlResourceDictionaryRegistry ResourceDictionaries
+        => _resourceDictionaries ?? throw new InvalidOperationException("XAML composition has not been initialized.");
+
+    /// <summary>
+    ///  Initializes the metadata and resource registries with WinUI's built-in controls.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see cref="XamlHostEnvironment"/> calls this on the application's owner thread after
+    ///   <see cref="Microsoft.UI.Xaml.Hosting.WindowsXamlManager"/> has initialized XAML for that thread and before the
+    ///   application is exposed through the host environment. Calling this again after successful initialization has
+    ///   no effect.
+    ///  </para>
+    /// </remarks>
+    internal void InitializeComposition()
+    {
+        if (_metadataProviders is not null)
+        {
+            return;
+        }
+
+        _metadataProviders = new();
+        _resourceDictionaries = new(Resources);
+        MetadataProviders.Register(new XamlControlsXamlMetaDataProvider());
+        ResourceDictionaries.Register(new XamlControlsResources());
+    }
+
+    IXamlType? IXamlMetadataProvider.GetXamlType(string fullName)
+        => MetadataProviders.GetXamlType(fullName);
+
+    IXamlType? IXamlMetadataProvider.GetXamlType(Type type)
+        => MetadataProviders.GetXamlType(type);
+
+    XmlnsDefinition[] IXamlMetadataProvider.GetXmlnsDefinitions()
+        => MetadataProviders.GetXmlnsDefinitions();
+}

--- a/src/thirtytwo.winui/XamlHostEnvironment.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironment.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Dispatching;
+using Windows.Win32;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Acquires a reference-counted WinUI environment for the current thirtytwo UI thread.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Acquire the environment from the window factory passed to <see cref="Application.Run(Window, bool)"/>, typically
+///   at the start of the primary window's construction. At that point the thirtytwo dispatcher is active on the STA
+///   thread. Acquire it before creating or loading WinUI content and before registering metadata providers or resource
+///   dictionaries. Do not acquire it before <see cref="Application.Run(Window, bool)"/> or from a background thread.
+///  </para>
+///  <para>
+///   Public leases may fall to zero and be acquired again; native XAML and queue state is released when the owning core
+///   dispatcher shuts down.
+///  </para>
+///  <para>Only one designated XAML UI thread is supported per process.</para>
+/// </remarks>
+public sealed class XamlHostEnvironment : IDisposable
+{
+    private static readonly Lock s_lock = new();
+
+    // Application construction permanently designates its XAML thread. Native environment state may stop, but moving
+    // the retained process application to another thread or replacing it is not a supported rollback.
+    private static Thread? s_designatedThread;
+    private static XamlHostEnvironmentState? s_state;
+    private static Microsoft.UI.Xaml.Application? s_processApplication;
+
+    private XamlHostEnvironmentState? _state;
+
+    private XamlHostEnvironment(XamlHostEnvironmentState state)
+    {
+        _state = state;
+    }
+
+    /// <summary>Gets the process WinUI application.</summary>
+    /// <exception cref="ObjectDisposedException">This lease has been disposed.</exception>
+    public Microsoft.UI.Xaml.Application Application => GetState().Application;
+
+    /// <summary>Gets the current thread's Windows App SDK dispatcher queue.</summary>
+    /// <exception cref="ObjectDisposedException">This lease has been disposed.</exception>
+    public DispatcherQueue DispatcherQueue => GetState().Queue;
+
+    /// <summary>Gets the application-wide metadata provider registry.</summary>
+    /// <exception cref="ObjectDisposedException">This lease has been disposed.</exception>
+    public XamlMetadataProviderRegistry MetadataProviders => GetState().HostApplication.MetadataProviders;
+
+    /// <summary>Gets the application-wide resource dictionary registry.</summary>
+    /// <exception cref="ObjectDisposedException">This lease has been disposed.</exception>
+    public XamlResourceDictionaryRegistry ResourceDictionaries => GetState().HostApplication.ResourceDictionaries;
+
+    /// <summary>
+    ///  Gets whether this environment created the process WinUI application instead of adopting an existing one.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is initialization information only. The process application is retained whether this environment created
+    ///   or adopted it, so the value does not change application cleanup responsibilities.
+    ///  </para>
+    /// </remarks>
+    public bool OwnsApplication => GetState().OwnsApplication;
+
+    /// <summary>Gets whether this environment created the current thread's dispatcher queue.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   The environment shuts down a queue it created during core dispatcher shutdown. An existing queue is borrowed
+    ///   and remains under its creator's lifetime management.
+    ///  </para>
+    /// </remarks>
+    public bool OwnsDispatcherQueue => GetState().OwnsDispatcherQueue;
+
+    /// <summary>
+    ///  Gets a point-in-time snapshot of the active thread environment, or <see langword="null"/> when none exists.
+    /// </summary>
+    /// <remarks>
+    ///  <para>The returned lease count and ownership state may become stale immediately after this property returns.</para>
+    /// </remarks>
+    public static XamlHostEnvironmentInfo? Current
+    {
+        get
+        {
+            lock (s_lock)
+            {
+                return s_state is { Disposed: false } state
+                    ? new(
+                        state.OwnerManagedThreadId,
+                        state.OwnerNativeThreadId,
+                        state.LeaseCount,
+                        state.OwnsApplication,
+                        state.OwnsDispatcherQueue)
+                    : null;
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Gets an independently disposable handle to the current UI thread's WinUI environment, creating the environment
+    ///  on the first call.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Call this from the window factory passed to <see cref="Application.Run(Window, bool)"/> after it establishes
+    ///   the thirtytwo dispatcher on an STA thread. If the process already has a WinUI application, that application
+    ///   must implement <see cref="IXamlHostApplication"/> and expose registries owned by the same thread. Do not create
+    ///   or load WinUI content that depends on those registries before calling this method.
+    ///  </para>
+    ///  <para>
+    ///   On the first call, this method borrows or creates the current thread's dispatcher queue, adopts or creates the
+    ///   process WinUI application, and initializes the XAML manager. When it creates the application, it also registers
+    ///   WinUI's built-in metadata provider and resources. After this method returns, register any library metadata
+    ///   providers and resource dictionaries before creating or loading content that depends on them.
+    ///  </para>
+    ///  <para>
+    ///   Each call returns a separate lease over the same thread-bound environment. Keep the lease while the caller
+    ///   needs its properties, then dispose it on the owner thread. Disposal invalidates only that lease and decrements
+    ///   the active lease count; native XAML state remains active until the owning thirtytwo dispatcher shuts down.
+    ///  </para>
+    /// </remarks>
+    /// <returns>A thread-bound lease on the initialized WinUI environment.</returns>
+    /// <exception cref="XamlHostInitializationException">
+    ///  The thread, dispatcher, runtime, application, or XAML manager is incompatible with hosting.
+    /// </exception>
+    public static XamlHostEnvironment Acquire()
+    {
+        lock (s_lock)
+        {
+            Thread currentThread = Thread.CurrentThread;
+            if (s_designatedThread is not null && !ReferenceEquals(s_designatedThread, currentThread))
+            {
+                int designatedThreadId = s_designatedThread.ManagedThreadId;
+                XamlHostInitializationException exception = new(
+                    XamlHostInitializationStage.ThreadValidation,
+                    $"WinUI hosting is designated to managed thread {designatedThreadId}; the calling thread is {Environment.CurrentManagedThreadId}.",
+                    GetCurrentNativeThreadId());
+                XamlHostEventSource.Log.InitializationFailed(
+                    exception.NativeThreadId,
+                    (int)exception.Stage,
+                    exception.HResult,
+                    exception.GetType().FullName!);
+                throw exception;
+            }
+
+            if (s_state is { Disposed: false } state)
+            {
+                state.AddLease();
+                return new(state);
+            }
+
+            state = XamlHostEnvironmentState.Create();
+            s_designatedThread ??= currentThread;
+            s_state = state;
+            return new(state);
+        }
+    }
+
+    /// <summary>Releases this public lease. Repeated disposal has no effect.</summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own this lease.</exception>
+    public void Dispose()
+    {
+        XamlHostEnvironmentState? state = _state;
+        if (state is null)
+        {
+            return;
+        }
+
+        state.VerifyAccess();
+        _state = null;
+
+        lock (s_lock)
+        {
+            state.ReleaseLease();
+        }
+    }
+
+    internal static uint GetCurrentNativeThreadId() => PInvoke.GetCurrentThreadId();
+
+    internal static XamlApplication CreateProcessApplication()
+    {
+        if (s_processApplication is not null)
+        {
+            throw new XamlHostInitializationException(
+                XamlHostInitializationStage.Application,
+                "The retained process WinUI application cannot be rebound after its XAML thread has stopped.",
+                GetCurrentNativeThreadId());
+        }
+
+        XamlApplication application = new();
+
+        // Retain immediately. If later XAML initialization fails, Application construction has already affected
+        // process WinUI state and a replacement Application would hide that partial initialization.
+        s_processApplication = application;
+        s_designatedThread ??= Thread.CurrentThread;
+        return application;
+    }
+
+    internal static void RetainProcessApplication(Microsoft.UI.Xaml.Application application)
+    {
+        if (s_processApplication is not null && !ReferenceEquals(s_processApplication, application))
+        {
+            throw new XamlHostInitializationException(
+                XamlHostInitializationStage.Application,
+                "A different WinUI application is already retained for this process.",
+                GetCurrentNativeThreadId());
+        }
+
+        s_processApplication = application;
+        s_designatedThread ??= Thread.CurrentThread;
+    }
+
+    internal static void Shutdown(XamlHostEnvironmentState state)
+    {
+        state.VerifyAccess();
+        lock (s_lock)
+        {
+            if (ReferenceEquals(s_state, state))
+            {
+                s_state = null;
+            }
+        }
+
+        state.Dispose();
+    }
+
+    private XamlHostEnvironmentState GetState()
+    {
+        XamlHostEnvironmentState state = _state
+            ?? throw new ObjectDisposedException(nameof(XamlHostEnvironment));
+        state.VerifyAccess();
+        ObjectDisposedException.ThrowIf(state.Disposed, this);
+        return state;
+    }
+}

--- a/src/thirtytwo.winui/XamlHostEnvironmentInfo.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironmentInfo.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Describes the active process XAML host environment.
+/// </summary>
+/// <param name="OwnerManagedThreadId">The managed owner thread identifier.</param>
+/// <param name="OwnerNativeThreadId">The native owner thread identifier.</param>
+/// <param name="LeaseCount">The current public lease count.</param>
+/// <param name="OwnsApplication">
+///  Whether the environment created the process WinUI application instead of adopting an existing one.
+/// </param>
+/// <param name="OwnsDispatcherQueue">
+///  Whether the environment created the current thread's dispatcher queue and will shut it down.
+/// </param>
+public sealed record XamlHostEnvironmentInfo(
+    int OwnerManagedThreadId,
+    uint OwnerNativeThreadId,
+    int LeaseCount,
+    bool OwnsApplication,
+    bool OwnsDispatcherQueue);

--- a/src/thirtytwo.winui/XamlHostEnvironmentState.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironmentState.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Hosting;
+using Windows.Threading;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Owns the WinUI state for the designated UI thread and tracks active host-environment leases.
+/// </summary>
+internal sealed class XamlHostEnvironmentState
+{
+    private readonly XamlThreadAffinity _affinity = new();
+    private readonly DispatcherQueueController? _queueController;
+    private readonly WindowsXamlManager _xamlManager;
+    private ShutdownRegistration _shutdownRegistration;
+    private bool _disposed;
+
+    private XamlHostEnvironmentState(
+        Dispatcher dispatcher,
+        DispatcherQueue queue,
+        DispatcherQueueController? queueController,
+        WindowsXamlManager xamlManager,
+        Microsoft.UI.Xaml.Application application,
+        IXamlHostApplication hostApplication,
+        bool ownsApplication)
+    {
+        Dispatcher = dispatcher;
+        Queue = queue;
+        _queueController = queueController;
+        _xamlManager = xamlManager;
+        Application = application;
+        HostApplication = hostApplication;
+        OwnsApplication = ownsApplication;
+        LeaseCount = 1;
+    }
+
+    /// <summary>Gets the owning thirtytwo dispatcher whose shutdown tears down this environment.</summary>
+    internal Dispatcher Dispatcher { get; }
+
+    /// <summary>Gets the Windows App SDK dispatcher queue associated with the owner thread.</summary>
+    internal DispatcherQueue Queue { get; }
+
+    /// <summary>Gets the retained process WinUI application.</summary>
+    internal Microsoft.UI.Xaml.Application Application { get; }
+
+    /// <summary>Gets the application's metadata and resource composition contract.</summary>
+    internal IXamlHostApplication HostApplication { get; }
+
+    /// <summary>Gets whether this environment created the process WinUI application.</summary>
+    internal bool OwnsApplication { get; }
+
+    /// <summary>Gets whether this environment created and must shut down the dispatcher queue.</summary>
+    internal bool OwnsDispatcherQueue => _queueController is not null;
+
+    /// <summary>Gets the number of active public environment leases.</summary>
+    internal int LeaseCount { get; private set; }
+
+    /// <summary>Gets the managed identifier of the owner thread.</summary>
+    internal int OwnerManagedThreadId => _affinity.ManagedThreadId;
+
+    /// <summary>Gets the native identifier of the owner thread.</summary>
+    internal uint OwnerNativeThreadId => _affinity.NativeThreadId;
+
+    /// <summary>Gets whether this environment has entered dispatcher shutdown.</summary>
+    internal bool Disposed => _disposed;
+
+    internal static XamlHostEnvironmentState Create()
+    {
+        uint nativeThreadId = XamlHostEnvironment.GetCurrentNativeThreadId();
+        if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
+        {
+            XamlHostInitializationException exception = new(
+                XamlHostInitializationStage.ThreadValidation,
+                $"WinUI hosting requires an STA thread. Actual apartment: {Thread.CurrentThread.GetApartmentState()}.",
+                nativeThreadId);
+            XamlHostEventSource.Log.InitializationFailed(
+                nativeThreadId,
+                (int)exception.Stage,
+                exception.HResult,
+                exception.GetType().FullName!);
+            throw exception;
+        }
+
+        Dispatcher dispatcher = Dispatcher.Current
+            ?? throw CreateThreadValidationException(nativeThreadId);
+
+        DispatcherQueueController? queueController = null;
+        WindowsXamlManager? xamlManager = null;
+        Microsoft.UI.Xaml.Application? preexistingApplication = Microsoft.UI.Xaml.Application.Current;
+        XamlApplication? createdApplication = null;
+
+        try
+        {
+            DispatcherQueue? queue = DispatcherQueue.GetForCurrentThread();
+            if (queue is null)
+            {
+                try
+                {
+                    queueController = DispatcherQueueController.CreateOnCurrentThread();
+                    queue = queueController.DispatcherQueue;
+                }
+                catch (Exception exception)
+                {
+                    throw CreateInitializationException(
+                        XamlHostInitializationStage.DispatcherQueue,
+                        "Failed to create the Windows App SDK dispatcher queue. Verify runtime deployment and process architecture.",
+                        nativeThreadId,
+                        exception);
+                }
+            }
+
+            Microsoft.UI.Xaml.Application? application = preexistingApplication;
+            bool ownsApplication = preexistingApplication is null;
+            if (application is null)
+            {
+                try
+                {
+                    createdApplication = XamlHostEnvironment.CreateProcessApplication();
+                    application = createdApplication;
+                }
+                catch (Exception exception)
+                {
+                    throw CreateInitializationException(
+                        XamlHostInitializationStage.Application,
+                        "Failed to create the WinUI host application.",
+                        nativeThreadId,
+                        exception);
+                }
+            }
+
+            try
+            {
+                xamlManager = WindowsXamlManager.InitializeForCurrentThread();
+            }
+            catch (Exception exception)
+            {
+                throw CreateInitializationException(
+                    XamlHostInitializationStage.XamlManager,
+                    "Failed to initialize the WinUI XAML manager. Verify runtime WinMD and resource deployment.",
+                    nativeThreadId,
+                    exception);
+            }
+
+            if (createdApplication is not null)
+            {
+                try
+                {
+                    createdApplication.InitializeComposition();
+                }
+                catch (Exception exception)
+                {
+                    throw CreateInitializationException(
+                        XamlHostInitializationStage.Application,
+                        "Failed to initialize the WinUI host application's metadata and resources.",
+                        nativeThreadId,
+                        exception);
+                }
+            }
+
+            if (application is not IXamlHostApplication hostApplication)
+            {
+                string applicationType = application.GetType().FullName ?? application.GetType().Name;
+                string contractType = typeof(IXamlHostApplication).FullName!;
+                throw new XamlHostInitializationException(
+                    XamlHostInitializationStage.Application,
+                    $"Application.Current is '{applicationType}', which does not implement {contractType}.",
+                    nativeThreadId);
+            }
+
+            if (hostApplication.MetadataProviders.OwnerNativeThreadId != nativeThreadId
+                || hostApplication.ResourceDictionaries.OwnerNativeThreadId != nativeThreadId)
+            {
+                throw new XamlHostInitializationException(
+                    XamlHostInitializationStage.Application,
+                    "The existing WinUI host application's registries belong to a different XAML thread.",
+                    nativeThreadId);
+            }
+
+                    XamlHostEnvironment.RetainProcessApplication(application);
+
+            XamlHostEnvironmentState state = new(
+                dispatcher,
+                queue,
+                queueController,
+                xamlManager,
+                application,
+                hostApplication,
+                ownsApplication);
+            state._shutdownRegistration = dispatcher.RegisterShutdownCallback(
+                () => XamlHostEnvironment.Shutdown(state));
+            queueController = null;
+            xamlManager = null;
+            XamlHostEventSource.Log.EnvironmentCreated(
+                nativeThreadId,
+                state.OwnsDispatcherQueue,
+                state.OwnsApplication);
+            XamlHostEventSource.Log.LeaseCountChanged(nativeThreadId, state.LeaseCount);
+            return state;
+        }
+        catch (Exception exception)
+        {
+            XamlHostInitializationStage stage = exception is XamlHostInitializationException initializationException
+                ? initializationException.Stage
+                : XamlHostInitializationStage.Application;
+            XamlHostEventSource.Log.InitializationFailed(
+                nativeThreadId,
+                (int)stage,
+                exception.HResult,
+                exception.GetType().FullName ?? exception.GetType().Name);
+            xamlManager?.Dispose();
+            queueController?.ShutdownQueue();
+            throw;
+        }
+    }
+
+    internal void AddLease()
+    {
+        VerifyAccess();
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        LeaseCount = checked(LeaseCount + 1);
+        XamlHostEventSource.Log.LeaseCountChanged(OwnerNativeThreadId, LeaseCount);
+    }
+
+    internal void ReleaseLease()
+    {
+        VerifyAccess();
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (LeaseCount <= 0)
+        {
+            throw new InvalidOperationException("The XAML environment has no active public lease to release.");
+        }
+
+        LeaseCount--;
+        XamlHostEventSource.Log.LeaseCountChanged(OwnerNativeThreadId, LeaseCount);
+    }
+
+    internal void VerifyAccess() => _affinity.VerifyAccess();
+
+    internal void Dispose()
+    {
+        VerifyAccess();
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        LeaseCount = 0;
+        try
+        {
+            _xamlManager.Dispose();
+        }
+        finally
+        {
+            try
+            {
+                _queueController?.ShutdownQueue();
+            }
+            finally
+            {
+                _shutdownRegistration.Dispose();
+                XamlHostEventSource.Log.EnvironmentStopped(OwnerNativeThreadId);
+            }
+        }
+    }
+
+    private static XamlHostInitializationException CreateInitializationException(
+        XamlHostInitializationStage stage,
+        string message,
+        uint nativeThreadId,
+        Exception exception)
+        => exception as XamlHostInitializationException
+            ?? new(stage, message, nativeThreadId, exception);
+
+    private static XamlHostInitializationException CreateThreadValidationException(uint nativeThreadId)
+    {
+        XamlHostInitializationException exception = new(
+            XamlHostInitializationStage.ThreadValidation,
+            "WinUI hosting requires an active thirtytwo Application.Run message loop.",
+            nativeThreadId);
+        XamlHostEventSource.Log.InitializationFailed(
+            nativeThreadId,
+            (int)exception.Stage,
+            exception.HResult,
+            exception.GetType().FullName!);
+        return exception;
+    }
+}

--- a/src/thirtytwo.winui/XamlHostEnvironmentState.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironmentState.cs
@@ -179,7 +179,7 @@ internal sealed class XamlHostEnvironmentState
                     nativeThreadId);
             }
 
-                    XamlHostEnvironment.RetainProcessApplication(application);
+                XamlHostEnvironment.RetainProcessApplication(application);
 
             XamlHostEnvironmentState state = new(
                 dispatcher,

--- a/src/thirtytwo.winui/XamlHostEventSource.cs
+++ b/src/thirtytwo.winui/XamlHostEventSource.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Emits WinUI host lifecycle, lease, initialization failure, and composition collision events.
+/// </summary>
+[EventSource(Name = "ThirtyTwo-WinUI")]
+internal sealed class XamlHostEventSource : EventSource
+{
+    internal static XamlHostEventSource Log { get; } = new();
+
+    [Event(1, Level = EventLevel.Informational)]
+    public void EnvironmentCreated(uint nativeThreadId, bool ownsQueue, bool ownsApplication)
+        => WriteEvent(1, nativeThreadId, ownsQueue, ownsApplication);
+
+    [Event(2, Level = EventLevel.Informational)]
+    public void LeaseCountChanged(uint nativeThreadId, int leaseCount)
+        => WriteEvent(2, nativeThreadId, leaseCount);
+
+    [Event(3, Level = EventLevel.Informational)]
+    public void EnvironmentStopped(uint nativeThreadId)
+        => WriteEvent(3, nativeThreadId);
+
+    [Event(4, Level = EventLevel.Error)]
+    public void InitializationFailed(uint nativeThreadId, int stage, int hresult, string exceptionType)
+        => WriteEvent(4, nativeThreadId, stage, hresult, exceptionType);
+
+    [Event(5, Level = EventLevel.Warning)]
+    public void MetadataCollision(string requestedType, string winningProvider, string conflictingProvider)
+        => WriteEvent(5, requestedType, winningProvider, conflictingProvider);
+
+    [Event(6, Level = EventLevel.Warning)]
+    public void ResourceCollision(string key)
+        => WriteEvent(6, key);
+}

--- a/src/thirtytwo.winui/XamlHostInitializationException.cs
+++ b/src/thirtytwo.winui/XamlHostInitializationException.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Reports a WinUI host initialization failure with process and thread context.
+/// </summary>
+public sealed class XamlHostInitializationException : InvalidOperationException
+{
+    internal XamlHostInitializationException(
+        XamlHostInitializationStage stage,
+        string message,
+        uint nativeThreadId,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Stage = stage;
+        NativeThreadId = nativeThreadId;
+        ManagedThreadId = Environment.CurrentManagedThreadId;
+        ProcessArchitecture = RuntimeInformation.ProcessArchitecture;
+    }
+
+    /// <summary>Gets the failed initialization stage.</summary>
+    public XamlHostInitializationStage Stage { get; }
+
+    /// <summary>Gets the current process architecture.</summary>
+    public Architecture ProcessArchitecture { get; }
+
+    /// <summary>Gets the managed thread identifier that observed the failure.</summary>
+    public int ManagedThreadId { get; }
+
+    /// <summary>Gets the native thread identifier that observed the failure.</summary>
+    public uint NativeThreadId { get; }
+}

--- a/src/thirtytwo.winui/XamlHostInitializationStage.cs
+++ b/src/thirtytwo.winui/XamlHostInitializationStage.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Identifies the stage at which WinUI host initialization failed.
+/// </summary>
+public enum XamlHostInitializationStage
+{
+    /// <summary>Thread apartment, affinity, or core dispatcher validation.</summary>
+    ThreadValidation,
+
+    /// <summary>Windows App SDK dispatcher queue discovery or creation.</summary>
+    DispatcherQueue,
+
+    /// <summary>WinUI XAML manager initialization.</summary>
+    XamlManager,
+
+    /// <summary>Process application creation or compatibility validation.</summary>
+    Application
+}

--- a/src/thirtytwo.winui/XamlMetadataCollisionEventArgs.cs
+++ b/src/thirtytwo.winui/XamlMetadataCollisionEventArgs.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Reports that multiple metadata providers resolved the same XAML type.
+/// </summary>
+public sealed class XamlMetadataCollisionEventArgs(
+    string requestedType,
+    Type winningProviderType,
+    Type conflictingProviderType) : EventArgs
+{
+    /// <summary>Gets the requested XAML type name.</summary>
+    public string RequestedType { get; } = requestedType;
+
+    /// <summary>Gets the first provider, whose result wins.</summary>
+    public Type WinningProviderType { get; } = winningProviderType;
+
+    /// <summary>Gets the later provider that also resolved the type.</summary>
+    public Type ConflictingProviderType { get; } = conflictingProviderType;
+}

--- a/src/thirtytwo.winui/XamlMetadataProviderRegistry.cs
+++ b/src/thirtytwo.winui/XamlMetadataProviderRegistry.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Markup;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Composes XAML metadata providers in deterministic registration order.
+/// </summary>
+/// <remarks>
+///  <para>Instances are bound to their construction thread; cross-thread member access throws.</para>
+/// </remarks>
+public sealed class XamlMetadataProviderRegistry : IXamlMetadataProvider
+{
+    private readonly XamlThreadAffinity _affinity = new();
+    private readonly List<IXamlMetadataProvider> _providers = [];
+    private readonly HashSet<Type> _providerTypes = [];
+
+    /// <summary>Occurs when a later provider also resolves a type already resolved by an earlier provider.</summary>
+    public event EventHandler<XamlMetadataCollisionEventArgs>? CollisionDetected;
+
+    /// <summary>Gets the number of registered provider types.</summary>
+    public int Count
+    {
+        get
+        {
+            _affinity.VerifyAccess();
+            return _providers.Count;
+        }
+    }
+
+    /// <summary>Gets provider types in deterministic registration order.</summary>
+    public IReadOnlyList<Type> ProviderTypes
+    {
+        get
+        {
+            _affinity.VerifyAccess();
+            return _providers.Select(provider => provider.GetType()).ToArray();
+        }
+    }
+
+    /// <summary>Gets the managed owner thread identifier.</summary>
+    public int OwnerManagedThreadId => _affinity.ManagedThreadId;
+
+    /// <summary>Gets the native owner thread identifier.</summary>
+    public uint OwnerNativeThreadId => _affinity.NativeThreadId;
+
+    /// <summary>
+    ///  Registers a provider. A provider type already present is treated as the same registration.
+    /// </summary>
+    /// <returns><see langword="true"/> when the provider was added.</returns>
+    public bool Register(IXamlMetadataProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        _affinity.VerifyAccess();
+
+        if (!_providerTypes.Add(provider.GetType()))
+        {
+            return false;
+        }
+
+        _providers.Add(provider);
+        return true;
+    }
+
+    /// <summary>Resolves a XAML type name using first-provider precedence.</summary>
+    public IXamlType? GetXamlType(string fullName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullName);
+        _affinity.VerifyAccess();
+        return Resolve(fullName, provider => provider.GetXamlType(fullName));
+    }
+
+    /// <summary>Resolves a managed type using first-provider precedence.</summary>
+    public IXamlType? GetXamlType(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        _affinity.VerifyAccess();
+        return Resolve(type.FullName ?? type.Name, provider => provider.GetXamlType(type));
+    }
+
+    /// <summary>Gets namespace definitions in provider registration order.</summary>
+    public XmlnsDefinition[] GetXmlnsDefinitions()
+    {
+        _affinity.VerifyAccess();
+        List<XmlnsDefinition> definitions = [];
+        IXamlMetadataProvider[] providers = [.. _providers];
+        foreach (IXamlMetadataProvider provider in providers)
+        {
+            definitions.AddRange(provider.GetXmlnsDefinitions());
+        }
+
+        return [.. definitions];
+    }
+
+    private IXamlType? Resolve(string requestedType, Func<IXamlMetadataProvider, IXamlType?> resolve)
+    {
+        IXamlType? result = null;
+        Type? winningProviderType = null;
+        IXamlMetadataProvider[] providers = [.. _providers];
+
+        foreach (IXamlMetadataProvider provider in providers)
+        {
+            IXamlType? candidate = resolve(provider);
+            if (candidate is null)
+            {
+                continue;
+            }
+
+            if (result is null)
+            {
+                result = candidate;
+                winningProviderType = provider.GetType();
+                continue;
+            }
+
+            XamlHostEventSource.Log.MetadataCollision(
+                requestedType,
+                winningProviderType!.FullName ?? winningProviderType.Name,
+                provider.GetType().FullName ?? provider.GetType().Name);
+            CollisionDetected?.Invoke(
+                this,
+                new(requestedType, winningProviderType, provider.GetType()));
+        }
+
+        return result;
+    }
+}

--- a/src/thirtytwo.winui/XamlResourceCollisionEventArgs.cs
+++ b/src/thirtytwo.winui/XamlResourceCollisionEventArgs.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Reports that a later resource dictionary overrides an earlier key.
+/// </summary>
+public sealed class XamlResourceCollisionEventArgs(
+    object key,
+    ResourceDictionary overriddenDictionary,
+    ResourceDictionary winningDictionary) : EventArgs
+{
+    /// <summary>Gets the duplicate resource key.</summary>
+    public object Key { get; } = key;
+
+    /// <summary>Gets the earlier dictionary whose value is overridden.</summary>
+    public ResourceDictionary OverriddenDictionary { get; } = overriddenDictionary;
+
+    /// <summary>Gets the later dictionary whose value wins.</summary>
+    public ResourceDictionary WinningDictionary { get; } = winningDictionary;
+}

--- a/src/thirtytwo.winui/XamlResourceDictionaryRegistry.cs
+++ b/src/thirtytwo.winui/XamlResourceDictionaryRegistry.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Composes application resource dictionaries using WinUI merge precedence.
+/// </summary>
+/// <remarks>
+///  <para>Instances are bound to their construction thread; cross-thread member access throws.</para>
+/// </remarks>
+public sealed class XamlResourceDictionaryRegistry
+{
+    private readonly XamlThreadAffinity _affinity = new();
+    private readonly ResourceDictionary _applicationResources;
+    private readonly List<ResourceDictionary> _dictionaries = [];
+    private readonly HashSet<ResourceDictionary> _registered = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<object, ResourceDictionary> _resourceOwners = [];
+
+    public XamlResourceDictionaryRegistry(ResourceDictionary applicationResources)
+    {
+        ArgumentNullException.ThrowIfNull(applicationResources);
+        _applicationResources = applicationResources;
+
+        foreach (ResourceDictionary dictionary in applicationResources.MergedDictionaries)
+        {
+            _dictionaries.Add(dictionary);
+            _registered.Add(dictionary);
+            IndexResources(dictionary);
+        }
+    }
+
+    /// <summary>Occurs when a later dictionary overrides a key from an earlier dictionary.</summary>
+    public event EventHandler<XamlResourceCollisionEventArgs>? CollisionDetected;
+
+    /// <summary>Gets the number of registered dictionaries.</summary>
+    public int Count
+    {
+        get
+        {
+            _affinity.VerifyAccess();
+            return _dictionaries.Count;
+        }
+    }
+
+    /// <summary>Gets dictionaries in WinUI merge order.</summary>
+    public IReadOnlyList<ResourceDictionary> Dictionaries
+    {
+        get
+        {
+            _affinity.VerifyAccess();
+            return [.. _dictionaries];
+        }
+    }
+
+    /// <summary>Gets the managed owner thread identifier.</summary>
+    public int OwnerManagedThreadId => _affinity.ManagedThreadId;
+
+    /// <summary>Gets the native owner thread identifier.</summary>
+    public uint OwnerNativeThreadId => _affinity.NativeThreadId;
+
+    /// <summary>
+    ///  Registers a dictionary. Registering the same instance more than once has no effect.
+    /// </summary>
+    /// <returns><see langword="true"/> when the dictionary was added.</returns>
+    public bool Register(ResourceDictionary dictionary)
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+        _affinity.VerifyAccess();
+
+        if (!_registered.Add(dictionary))
+        {
+            return false;
+        }
+
+        try
+        {
+            ReportCollisions(dictionary);
+            _dictionaries.Add(dictionary);
+            try
+            {
+                _applicationResources.MergedDictionaries.Add(dictionary);
+                IndexResources(dictionary);
+                return true;
+            }
+            catch
+            {
+                _dictionaries.Remove(dictionary);
+                throw;
+            }
+        }
+        catch
+        {
+            _registered.Remove(dictionary);
+            throw;
+        }
+    }
+
+    private void ReportCollisions(ResourceDictionary winningDictionary)
+    {
+        if (CollisionDetected is null && !XamlHostEventSource.Log.IsEnabled())
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<object, object> resource in winningDictionary)
+        {
+            if (_resourceOwners.TryGetValue(resource.Key, out ResourceDictionary? existing))
+            {
+                XamlHostEventSource.Log.ResourceCollision(resource.Key.ToString() ?? resource.Key.GetType().Name);
+                CollisionDetected?.Invoke(
+                    this,
+                    new(resource.Key, existing, winningDictionary));
+            }
+        }
+    }
+
+    private void IndexResources(ResourceDictionary dictionary)
+    {
+        foreach (KeyValuePair<object, object> resource in dictionary)
+        {
+            _resourceOwners[resource.Key] = dictionary;
+        }
+    }
+}

--- a/src/thirtytwo.winui/XamlResourceDictionaryRegistry.cs
+++ b/src/thirtytwo.winui/XamlResourceDictionaryRegistry.cs
@@ -17,7 +17,7 @@ public sealed class XamlResourceDictionaryRegistry
     private readonly ResourceDictionary _applicationResources;
     private readonly List<ResourceDictionary> _dictionaries = [];
     private readonly HashSet<ResourceDictionary> _registered = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<object, ResourceDictionary> _resourceOwners = [];
+    private Dictionary<object, ResourceDictionary> _resourceOwners = [];
 
     public XamlResourceDictionaryRegistry(ResourceDictionary applicationResources)
     {
@@ -28,7 +28,7 @@ public sealed class XamlResourceDictionaryRegistry
         {
             _dictionaries.Add(dictionary);
             _registered.Add(dictionary);
-            IndexResources(dictionary);
+            IndexResources([.. dictionary], dictionary, _resourceOwners);
         }
     }
 
@@ -77,12 +77,17 @@ public sealed class XamlResourceDictionaryRegistry
 
         try
         {
-            ReportCollisions(dictionary);
+            KeyValuePair<object, object>[] resources = [.. dictionary];
+            ReportCollisions(dictionary, resources);
+
+            Dictionary<object, ResourceDictionary> resourceOwners = new(_resourceOwners, _resourceOwners.Comparer);
+            IndexResources(resources, dictionary, resourceOwners);
+
             _dictionaries.Add(dictionary);
             try
             {
                 _applicationResources.MergedDictionaries.Add(dictionary);
-                IndexResources(dictionary);
+                _resourceOwners = resourceOwners;
                 return true;
             }
             catch
@@ -98,14 +103,16 @@ public sealed class XamlResourceDictionaryRegistry
         }
     }
 
-    private void ReportCollisions(ResourceDictionary winningDictionary)
+    private void ReportCollisions(
+        ResourceDictionary winningDictionary,
+        IReadOnlyList<KeyValuePair<object, object>> resources)
     {
         if (CollisionDetected is null && !XamlHostEventSource.Log.IsEnabled())
         {
             return;
         }
 
-        foreach (KeyValuePair<object, object> resource in winningDictionary)
+        foreach (KeyValuePair<object, object> resource in resources)
         {
             if (_resourceOwners.TryGetValue(resource.Key, out ResourceDictionary? existing))
             {
@@ -117,11 +124,14 @@ public sealed class XamlResourceDictionaryRegistry
         }
     }
 
-    private void IndexResources(ResourceDictionary dictionary)
+    private static void IndexResources(
+        IReadOnlyList<KeyValuePair<object, object>> resources,
+        ResourceDictionary dictionary,
+        Dictionary<object, ResourceDictionary> resourceOwners)
     {
-        foreach (KeyValuePair<object, object> resource in dictionary)
+        foreach (KeyValuePair<object, object> resource in resources)
         {
-            _resourceOwners[resource.Key] = dictionary;
+            resourceOwners[resource.Key] = dictionary;
         }
     }
 }

--- a/src/thirtytwo.winui/XamlThreadAffinity.cs
+++ b/src/thirtytwo.winui/XamlThreadAffinity.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Captures a XAML object's owner thread and rejects access from other threads.
+/// </summary>
+internal sealed class XamlThreadAffinity
+{
+    private readonly Thread _thread = Thread.CurrentThread;
+
+    /// <summary>Captures the current thread as the owner.</summary>
+    internal XamlThreadAffinity()
+    {
+        NativeThreadId = PInvoke.GetCurrentThreadId();
+    }
+
+    /// <summary>Gets the managed identifier of the owner thread.</summary>
+    internal int ManagedThreadId => _thread.ManagedThreadId;
+
+    /// <summary>Gets the native identifier of the owner thread.</summary>
+    internal uint NativeThreadId { get; }
+
+    /// <summary>Verifies that the calling thread is the captured owner thread.</summary>
+    /// <exception cref="InvalidOperationException">The calling thread is not the owner thread.</exception>
+    internal void VerifyAccess()
+    {
+        if (ReferenceEquals(Thread.CurrentThread, _thread))
+        {
+            return;
+        }
+
+        int actualManagedThreadId = Environment.CurrentManagedThreadId;
+        uint actualNativeThreadId = PInvoke.GetCurrentThreadId();
+        throw new InvalidOperationException(
+            $"The calling thread does not own this XAML state. Expected managed thread {ManagedThreadId} and native thread {NativeThreadId}; actual managed thread {actualManagedThreadId} and native thread {actualNativeThreadId}.");
+    }
+}

--- a/src/thirtytwo.winui/thirtytwo.winui.csproj
+++ b/src/thirtytwo.winui/thirtytwo.winui.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RootNamespace>Windows.WinUI</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Description>Optional WinUI 3 hosting integration for thirtytwo.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <ProjectReference Include="..\thirtytwo\thirtytwo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/thirtytwo.winui_tests/IntegrationHost/CompatibleApplication.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/CompatibleApplication.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.XamlTypeInfo;
+using Windows.WinUI;
+
+namespace IntegrationHost;
+
+internal sealed class CompatibleApplication : Microsoft.UI.Xaml.Application, IXamlHostApplication
+{
+    private XamlMetadataProviderRegistry? _metadataProviders;
+    private XamlResourceDictionaryRegistry? _resourceDictionaries;
+
+    public XamlMetadataProviderRegistry MetadataProviders
+        => _metadataProviders ?? throw new InvalidOperationException("XAML composition has not been initialized.");
+
+    public XamlResourceDictionaryRegistry ResourceDictionaries
+        => _resourceDictionaries ?? throw new InvalidOperationException("XAML composition has not been initialized.");
+
+    internal void InitializeComposition()
+    {
+        _metadataProviders = new();
+        _resourceDictionaries = new(Resources);
+        MetadataProviders.Register(new XamlControlsXamlMetaDataProvider());
+        ResourceDictionaries.Register(new XamlControlsResources());
+    }
+
+    IXamlType? IXamlMetadataProvider.GetXamlType(string fullName)
+        => MetadataProviders.GetXamlType(fullName);
+
+    IXamlType? IXamlMetadataProvider.GetXamlType(Type type)
+        => MetadataProviders.GetXamlType(type);
+
+    XmlnsDefinition[] IXamlMetadataProvider.GetXmlnsDefinitions()
+        => MetadataProviders.GetXmlnsDefinitions();
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/DelayedHashCodeFailureComparer.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/DelayedHashCodeFailureComparer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace IntegrationHost;
+
+internal sealed class DelayedHashCodeFailureComparer : IEqualityComparer<object>
+{
+    private bool _failureEnabled;
+    private object? _failureKey;
+    private int _successfulHashCallsRemaining;
+
+    public new bool Equals(object? first, object? second)
+        => EqualityComparer<object>.Default.Equals(first, second);
+
+    public int GetHashCode(object value)
+    {
+        if (_failureEnabled
+            && EqualityComparer<object>.Default.Equals(value, _failureKey)
+            && _successfulHashCallsRemaining-- == 0)
+        {
+            throw new InvalidOperationException("Expected resource key hash failure.");
+        }
+
+        return EqualityComparer<object>.Default.GetHashCode(value);
+    }
+
+    internal void FailAfterSuccessfulCalls(object failureKey, int successfulHashCalls)
+    {
+        ArgumentNullException.ThrowIfNull(failureKey);
+        ArgumentOutOfRangeException.ThrowIfNegative(successfulHashCalls);
+        _failureKey = failureKey;
+        _successfulHashCallsRemaining = successfulHashCalls;
+        _failureEnabled = true;
+    }
+
+    internal void DisableFailure()
+    {
+        _failureEnabled = false;
+        _failureKey = null;
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace IntegrationHost;
+
+internal enum EnvironmentScenario
+{
+    Owned,
+    Borrowed,
+    Composition,
+    MultipleLeases,
+    CompatibleApplication,
+    IncompatibleApplication,
+    MtaRejected,
+    WrongThreadRejected,
+    SecondThreadRejected,
+    FinalRelease
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Markup;
+using SampleWinUIClassLibraryA;
+using SampleWinUIClassLibraryB;
+using Windows;
+using Windows.Threading;
+using Windows.Win32;
+using Windows.WinUI;
+
+namespace IntegrationHost;
+
+internal sealed class EnvironmentWindow : Window
+{
+    private readonly ScenarioReporter _reporter;
+    private XamlHostEnvironment? _environment;
+    private XamlHostEnvironment? _secondEnvironment;
+
+    internal EnvironmentWindow(EnvironmentScenario scenario, ScenarioReporter reporter)
+        : base(DefaultBounds, text: "ThirtyTwo WinUI Environment Host")
+    {
+        _reporter = reporter;
+        Execute(scenario);
+        reporter.Write("ready", Handle);
+
+        if (!Dispatcher.TryPost(() =>
+            {
+                if (!PInvoke.DestroyWindow(Handle))
+                {
+                    throw new Win32Exception(Marshal.GetLastPInvokeError());
+                }
+            }))
+        {
+            throw new InvalidOperationException("Failed to schedule environment host shutdown.");
+        }
+    }
+
+    private void Execute(EnvironmentScenario scenario)
+    {
+        switch (scenario)
+        {
+            case EnvironmentScenario.Owned:
+            case EnvironmentScenario.Borrowed:
+            case EnvironmentScenario.CompatibleApplication:
+                AcquireAndReport();
+                break;
+            case EnvironmentScenario.Composition:
+                AcquireAndReport();
+                VerifyComposition();
+                break;
+            case EnvironmentScenario.MultipleLeases:
+                AcquireAndReport();
+                _secondEnvironment = XamlHostEnvironment.Acquire();
+                Ensure(XamlHostEnvironment.Current?.LeaseCount == 2, "Two leases were not recorded.");
+                _reporter.Write("lease-count-two");
+                _environment!.Dispose();
+                _environment = null;
+                Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "One lease was not retained.");
+                _reporter.Write("lease-count-one");
+                break;
+            case EnvironmentScenario.IncompatibleApplication:
+                VerifyIncompatibleApplication();
+                break;
+            case EnvironmentScenario.MtaRejected:
+                VerifyMtaRejected();
+                break;
+            case EnvironmentScenario.WrongThreadRejected:
+                AcquireAndReport();
+                VerifyWrongThreadRejected();
+                break;
+            case EnvironmentScenario.SecondThreadRejected:
+                AcquireAndReport();
+                VerifySecondThreadRejected();
+                break;
+            case EnvironmentScenario.FinalRelease:
+                AcquireAndReport();
+                WeakReference<Microsoft.UI.Xaml.Application> application = new(_environment!.Application);
+                XamlHostEnvironment releasedEnvironment = _environment;
+                releasedEnvironment.Dispose();
+                releasedEnvironment.Dispose();
+                _environment = null;
+                Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "The final public lease was not released.");
+                _reporter.Write("double-dispose-idempotent");
+                _reporter.Write("final-lease-released");
+                using (XamlHostEnvironment reacquired = XamlHostEnvironment.Acquire())
+                {
+                    Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "The environment was not reacquired.");
+                    Ensure(
+                        application.TryGetTarget(out Microsoft.UI.Xaml.Application? target)
+                        && ReferenceEquals(target, reacquired.Application),
+                        "Reacquisition replaced the process application.");
+                    _reporter.Write("environment-reacquired");
+                }
+
+                Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "The reacquired lease was not released.");
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                Ensure(application.TryGetTarget(out _), "The process application was not retained.");
+                _reporter.Write("application-retained");
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(scenario));
+        }
+    }
+
+    private void AcquireAndReport()
+    {
+        _environment = XamlHostEnvironment.Acquire();
+        _reporter.Write(_environment.OwnsDispatcherQueue ? "queue-owned" : "queue-borrowed");
+        _reporter.Write(_environment.OwnsApplication ? "application-owned" : "application-borrowed");
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "The first lease was not recorded.");
+        _reporter.Write("environment-acquired");
+    }
+
+    private void VerifyComposition()
+    {
+        XamlMetadataProviderRegistry metadata = _environment!.MetadataProviders;
+        XamlResourceDictionaryRegistry resources = _environment.ResourceDictionaries;
+        int metadataCollisions = 0;
+        int resourceCollisions = 0;
+        metadata.CollisionDetected += (_, _) => metadataCollisions++;
+
+        LibraryAMetadataProvider providerA = new();
+        LibraryBMetadataProvider providerB = new();
+        Ensure(metadata.Register(providerA), "Provider A was not registered.");
+        Ensure(!metadata.Register(new LibraryAMetadataProvider()), "Provider A registration was not idempotent.");
+        Ensure(metadata.Register(providerB), "Provider B was not registered.");
+
+        IXamlType typeA = metadata.GetXamlType(typeof(LibraryAControl))
+            ?? throw new InvalidOperationException("Provider A did not resolve its custom type.");
+        IXamlType typeB = metadata.GetXamlType(typeof(LibraryBControl))
+            ?? throw new InvalidOperationException("Provider B did not resolve its custom type.");
+        Ensure(typeA.ActivateInstance() is LibraryAControl, "Provider A activated the wrong type.");
+        Ensure(typeB.ActivateInstance() is LibraryBControl, "Provider B activated the wrong type.");
+        IXamlType collision = metadata.GetXamlType(LibraryAMetadataProvider.CollisionTypeName)
+            ?? throw new InvalidOperationException("The collision alias was not resolved.");
+        Ensure(collision.UnderlyingType == typeof(LibraryAControl), "Metadata lookup did not preserve first-provider precedence.");
+        Ensure(metadataCollisions == 1, "The metadata collision was not reported exactly once.");
+        _reporter.Write("metadata-composed");
+        _reporter.Write("metadata-collision-reported");
+
+        LibraryAResources resourcesA = new();
+        LibraryBResources resourcesB = new();
+        Ensure(resources.Register(resourcesA), "Resources A were not registered.");
+        Ensure(!resources.Register(resourcesA), "Resource registration was not idempotent.");
+        EventHandler<XamlResourceCollisionEventArgs> throwingHandler =
+            static (_, _) => throw new InvalidOperationException("Expected collision callback failure.");
+        resources.CollisionDetected += throwingHandler;
+        try
+        {
+            _ = resources.Register(resourcesB);
+            throw new InvalidOperationException("A throwing collision callback did not fail registration.");
+        }
+        catch (InvalidOperationException exception) when (exception.Message == "Expected collision callback failure.")
+        {
+            _reporter.Write("resource-registration-rolled-back");
+        }
+        finally
+        {
+            resources.CollisionDetected -= throwingHandler;
+        }
+
+        resources.CollisionDetected += (_, _) => resourceCollisions++;
+        Ensure(resources.Register(resourcesB), "Resources B were not registered.");
+        Ensure(resourceCollisions == 1, "The resource collision was not reported exactly once.");
+        Ensure(
+            Equals(_environment.Application.Resources[LibraryAResources.SharedResourceKey], "LibraryB"),
+            "Later resource registration did not win duplicate-key lookup.");
+        Ensure(resourcesA.ThemeDictionaries.ContainsKey("Default"), "Resources A lost its theme dictionary.");
+        Ensure(resourcesB.ThemeDictionaries.ContainsKey("Default"), "Resources B lost its theme dictionary.");
+        _reporter.Write("resources-composed");
+        _reporter.Write("resource-collision-reported");
+        _reporter.Write("theme-dictionaries-preserved");
+    }
+
+    private void VerifyIncompatibleApplication()
+    {
+        try
+        {
+            _ = XamlHostEnvironment.Acquire();
+            throw new InvalidOperationException("An incompatible Application.Current was accepted.");
+        }
+        catch (XamlHostInitializationException exception) when (
+            exception.Stage == XamlHostInitializationStage.Application)
+        {
+            _reporter.Write("incompatible-application-rejected", message: exception.Message);
+        }
+    }
+
+    private void VerifyMtaRejected()
+    {
+        Exception? failure = null;
+        Thread thread = new(() =>
+        {
+            try
+            {
+                _ = XamlHostEnvironment.Acquire();
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.MTA);
+        thread.Start();
+        thread.Join();
+        if (failure is not XamlHostInitializationException
+            {
+                Stage: XamlHostInitializationStage.ThreadValidation
+            } diagnostic)
+        {
+            throw new InvalidOperationException("MTA acquisition did not fail with thread diagnostics.", failure);
+        }
+
+        Ensure(diagnostic.ManagedThreadId == thread.ManagedThreadId, "The MTA diagnostic did not capture its managed thread.");
+        Ensure(diagnostic.NativeThreadId != 0, "The MTA diagnostic did not capture its native thread.");
+        _reporter.Write("mta-rejected", message: diagnostic.Message);
+    }
+
+    private void VerifyWrongThreadRejected()
+    {
+        Exception? failure = null;
+        Thread thread = new(() =>
+        {
+            try
+            {
+                _environment!.Dispose();
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        });
+        thread.Start();
+        thread.Join();
+        if (failure is not InvalidOperationException diagnostic)
+        {
+            throw new InvalidOperationException("Wrong-thread disposal was not rejected.", failure);
+        }
+
+        _reporter.Write("wrong-thread-rejected", message: diagnostic.Message);
+    }
+
+    private void VerifySecondThreadRejected()
+    {
+        Exception? failure = null;
+        Thread thread = new(() =>
+        {
+            try
+            {
+                _ = XamlHostEnvironment.Acquire();
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (failure is not XamlHostInitializationException
+            {
+                Stage: XamlHostInitializationStage.ThreadValidation
+            } diagnostic)
+        {
+            throw new InvalidOperationException("A second XAML thread was not rejected.", failure);
+        }
+
+        _reporter.Write("second-thread-rejected", message: diagnostic.Message);
+    }
+
+    private static void Ensure(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _secondEnvironment?.Dispose();
+            _environment?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -7,10 +7,12 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Markup;
 using SampleWinUIClassLibraryA;
 using SampleWinUIClassLibraryB;
+using Touki.TestSupport;
 using Windows;
 using Windows.Threading;
 using Windows.Win32;
 using Windows.WinUI;
+using ResourceDictionary = Microsoft.UI.Xaml.ResourceDictionary;
 
 namespace IntegrationHost;
 
@@ -148,6 +150,7 @@ internal sealed class EnvironmentWindow : Window
         LibraryBResources resourcesB = new();
         Ensure(resources.Register(resourcesA), "Resources A were not registered.");
         Ensure(!resources.Register(resourcesA), "Resource registration was not idempotent.");
+        VerifyResourceIndexFailureRollsBack(resources);
         EventHandler<XamlResourceCollisionEventArgs> throwingHandler =
             static (_, _) => throw new InvalidOperationException("Expected collision callback failure.");
         resources.CollisionDetected += throwingHandler;
@@ -176,6 +179,53 @@ internal sealed class EnvironmentWindow : Window
         _reporter.Write("resources-composed");
         _reporter.Write("resource-collision-reported");
         _reporter.Write("theme-dictionaries-preserved");
+    }
+
+    private void VerifyResourceIndexFailureRollsBack(XamlResourceDictionaryRegistry resources)
+    {
+        const string indexedBeforeFailure = "SampleWinUI.IndexedBeforeFailure";
+        const string failureKey = "SampleWinUI.IndexFailure";
+        ResourceDictionary failingDictionary = new();
+        failingDictionary[indexedBeforeFailure] = "Expected";
+        failingDictionary[failureKey] = "Expected";
+        DelayedHashCodeFailureComparer comparer = new();
+        dynamic accessor = resources.TestAccessor.Dynamic;
+        Dictionary<object, ResourceDictionary> resourceOwners = accessor._resourceOwners;
+        accessor._resourceOwners = new Dictionary<object, ResourceDictionary>(resourceOwners, comparer);
+        comparer.FailAfterSuccessfulCalls(failureKey, 1);
+        EventHandler<XamlResourceCollisionEventArgs> collisionObserver = static (_, _) => { };
+        resources.CollisionDetected += collisionObserver;
+        int dictionaryCount = resources.Count;
+        int mergedDictionaryCount = _environment!.Application.Resources.MergedDictionaries.Count;
+        bool expectedFailureObserved = false;
+        bool ownerIndexChanged = false;
+
+        try
+        {
+            _ = resources.Register(failingDictionary);
+        }
+        catch (InvalidOperationException exception) when (exception.Message == "Expected resource key hash failure.")
+        {
+            expectedFailureObserved = true;
+        }
+        finally
+        {
+            resources.CollisionDetected -= collisionObserver;
+            comparer.DisableFailure();
+            Dictionary<object, ResourceDictionary> currentResourceOwners = accessor._resourceOwners;
+            ownerIndexChanged = currentResourceOwners.ContainsKey(indexedBeforeFailure);
+            accessor._resourceOwners = resourceOwners;
+        }
+
+        Ensure(expectedFailureObserved, "Resource owner indexing did not fail as expected.");
+        Ensure(!ownerIndexChanged, "Failed resource owner indexing partially updated the owner index.");
+        Ensure(resources.Count == dictionaryCount, "Failed resource owner indexing changed the registry count.");
+        Ensure(!resources.Dictionaries.Contains(failingDictionary), "Failed resource owner indexing retained the dictionary.");
+        Ensure(
+            _environment.Application.Resources.MergedDictionaries.Count == mergedDictionaryCount
+                && !_environment.Application.Resources.MergedDictionaries.Contains(failingDictionary),
+            "Failed resource owner indexing mutated the application resources.");
+        Ensure(resources.Register(failingDictionary), "The dictionary could not be registered after rollback.");
     }
 
     private void VerifyIncompatibleApplication()

--- a/src/thirtytwo.winui_tests/IntegrationHost/IncompatibleApplication.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/IncompatibleApplication.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace IntegrationHost;
+
+internal sealed class IncompatibleApplication : Microsoft.UI.Xaml.Application;

--- a/src/thirtytwo.winui_tests/IntegrationHost/IntegrationHost.csproj
+++ b/src/thirtytwo.winui_tests/IntegrationHost/IntegrationHost.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationManifest>..\..\samples\WinUI\ControlHost\app.manifest</ApplicationManifest>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+    <ProjectReference Include="..\..\samples\WinUI\SampleWinUIClassLibraryA\SampleWinUIClassLibraryA.csproj" />
+    <ProjectReference Include="..\..\samples\WinUI\SampleWinUIClassLibraryB\SampleWinUIClassLibraryB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/thirtytwo.winui_tests/IntegrationHost/IntegrationHost.csproj
+++ b/src/thirtytwo.winui_tests/IntegrationHost/IntegrationHost.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="KlutzyNinja.Touki.TestSupport" PrivateAssets="all" />
     <ProjectReference Include="..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
     <ProjectReference Include="..\..\samples\WinUI\SampleWinUIClassLibraryA\SampleWinUIClassLibraryA.csproj" />
     <ProjectReference Include="..\..\samples\WinUI\SampleWinUIClassLibraryB\SampleWinUIClassLibraryB.csproj" />

--- a/src/thirtytwo.winui_tests/IntegrationHost/Program.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/Program.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Hosting;
+using Windows;
+using Windows.WinUI;
+
+namespace IntegrationHost;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] arguments)
+    {
+        EnvironmentScenario scenario;
+        try
+        {
+            scenario = ScenarioArguments.Parse(arguments);
+        }
+        catch (ArgumentException exception)
+        {
+            Console.Error.WriteLine(exception.Message);
+            return 2;
+        }
+
+        ScenarioReporter reporter = new(scenario);
+        using XamlHostEventListener eventListener = new();
+        reporter.Write("process-started");
+        DispatcherQueueController? borrowedQueueController = null;
+        WindowsXamlManager? existingManager = null;
+        Microsoft.UI.Xaml.Application? existingApplication = null;
+        WeakReference<Microsoft.UI.Xaml.Application>? environmentApplication = null;
+
+        try
+        {
+            if (scenario is EnvironmentScenario.Borrowed
+                or EnvironmentScenario.CompatibleApplication
+                or EnvironmentScenario.IncompatibleApplication)
+            {
+                borrowedQueueController = DispatcherQueueController.CreateOnCurrentThread();
+                reporter.Write("external-queue-created");
+            }
+
+            if (scenario is EnvironmentScenario.CompatibleApplication
+                or EnvironmentScenario.IncompatibleApplication)
+            {
+                existingApplication = scenario == EnvironmentScenario.CompatibleApplication
+                    ? new CompatibleApplication()
+                    : new IncompatibleApplication();
+                existingManager = WindowsXamlManager.InitializeForCurrentThread();
+                if (existingApplication is CompatibleApplication compatibleApplication)
+                {
+                    compatibleApplication.InitializeComposition();
+                }
+
+                reporter.Write("external-application-created");
+            }
+
+            EnvironmentWindow? window = null;
+            Application.Run(() =>
+            {
+                EnvironmentWindow createdWindow = new(scenario, reporter);
+                window = createdWindow;
+                environmentApplication = XamlHostEnvironment.Current is not null
+                    ? new(Microsoft.UI.Xaml.Application.Current)
+                    : existingApplication is null ? null : new(existingApplication);
+                return createdWindow;
+            });
+
+            Ensure(XamlHostEnvironment.Current is null, "The environment survived core dispatcher shutdown.");
+            reporter.Write("environment-stopped");
+            if (environmentApplication is not null)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                Ensure(environmentApplication.TryGetTarget(out _), "The process application was not retained.");
+                reporter.Write("application-retained");
+            }
+
+            if (borrowedQueueController is null)
+            {
+                Ensure(DispatcherQueue.GetForCurrentThread() is null, "An owned dispatcher queue remained active.");
+                reporter.Write("owned-queue-stopped");
+            }
+            else
+            {
+                Ensure(DispatcherQueue.GetForCurrentThread() is not null, "A borrowed dispatcher queue was shut down.");
+                reporter.Write("borrowed-queue-retained");
+            }
+
+            VerifyDiagnostics(scenario, eventListener.EventIds);
+            reporter.Write("product-diagnostics-observed");
+            reporter.Write("scenario-completed");
+            GC.KeepAlive(existingApplication);
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            reporter.Write("scenario-failed", message: exception.ToString());
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+        finally
+        {
+            existingManager?.Dispose();
+            borrowedQueueController?.ShutdownQueue();
+        }
+    }
+
+    private static void Ensure(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static void VerifyDiagnostics(EnvironmentScenario scenario, IReadOnlyList<int> eventIds)
+    {
+        if (scenario is EnvironmentScenario.IncompatibleApplication or EnvironmentScenario.MtaRejected)
+        {
+            Ensure(eventIds.Contains(4), "The initialization failure was not traced.");
+            return;
+        }
+
+        Ensure(eventIds.Contains(1), "Environment creation was not traced.");
+        Ensure(eventIds.Contains(2), "Lease changes were not traced.");
+        Ensure(eventIds.Contains(3), "Environment shutdown was not traced.");
+
+        if (scenario == EnvironmentScenario.Composition)
+        {
+            Ensure(eventIds.Contains(5), "Metadata collisions were not traced.");
+            Ensure(eventIds.Contains(6), "Resource collisions were not traced.");
+        }
+
+        if (scenario == EnvironmentScenario.SecondThreadRejected)
+        {
+            Ensure(eventIds.Contains(4), "Second-thread rejection was not traced.");
+        }
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace IntegrationHost;
+
+internal static class ScenarioArguments
+{
+    internal static EnvironmentScenario Parse(string[] arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        if (arguments.Length != 2 || arguments[0] != "--scenario")
+        {
+            throw new ArgumentException("Expected '--scenario <name>'.");
+        }
+
+        return arguments[1] switch
+        {
+            "environment-owned" => EnvironmentScenario.Owned,
+            "environment-borrowed" => EnvironmentScenario.Borrowed,
+            "environment-composition" => EnvironmentScenario.Composition,
+            "environment-multiple-leases" => EnvironmentScenario.MultipleLeases,
+            "environment-compatible-application" => EnvironmentScenario.CompatibleApplication,
+            "environment-incompatible-application" => EnvironmentScenario.IncompatibleApplication,
+            "environment-mta-rejected" => EnvironmentScenario.MtaRejected,
+            "environment-wrong-thread-rejected" => EnvironmentScenario.WrongThreadRejected,
+            "environment-second-thread-rejected" => EnvironmentScenario.SecondThreadRejected,
+            "environment-final-release" => EnvironmentScenario.FinalRelease,
+            _ => throw new ArgumentException($"Unknown environment scenario '{arguments[1]}'.")
+        };
+    }
+
+    internal static string GetName(EnvironmentScenario scenario) => scenario switch
+    {
+        EnvironmentScenario.Owned => "environment-owned",
+        EnvironmentScenario.Borrowed => "environment-borrowed",
+        EnvironmentScenario.Composition => "environment-composition",
+        EnvironmentScenario.MultipleLeases => "environment-multiple-leases",
+        EnvironmentScenario.CompatibleApplication => "environment-compatible-application",
+        EnvironmentScenario.IncompatibleApplication => "environment-incompatible-application",
+        EnvironmentScenario.MtaRejected => "environment-mta-rejected",
+        EnvironmentScenario.WrongThreadRejected => "environment-wrong-thread-rejected",
+        EnvironmentScenario.SecondThreadRejected => "environment-second-thread-rejected",
+        EnvironmentScenario.FinalRelease => "environment-final-release",
+        _ => throw new ArgumentOutOfRangeException(nameof(scenario))
+    };
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/ScenarioEvent.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/ScenarioEvent.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace IntegrationHost;
+
+internal sealed record ScenarioEvent(
+    string Scenario,
+    string Event,
+    DateTimeOffset TimestampUtc,
+    int ProcessId,
+    uint ThreadId,
+    long WindowHandle,
+    string? Message);

--- a/src/thirtytwo.winui_tests/IntegrationHost/ScenarioReporter.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/ScenarioReporter.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace IntegrationHost;
+
+internal sealed unsafe class ScenarioReporter(EnvironmentScenario scenario)
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    internal void Write(string eventName, HWND window = default, string? message = null)
+    {
+        ScenarioEvent scenarioEvent = new(
+            ScenarioArguments.GetName(scenario),
+            eventName,
+            DateTimeOffset.UtcNow,
+            Environment.ProcessId,
+            PInvoke.GetCurrentThreadId(),
+            window.IsNull ? 0 : (long)window.Value,
+            message);
+        Console.Out.WriteLine(JsonSerializer.Serialize(scenarioEvent, s_jsonOptions));
+        Console.Out.Flush();
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/XamlHostEventListener.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/XamlHostEventListener.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace IntegrationHost;
+
+internal sealed class XamlHostEventListener : EventListener
+{
+    private readonly List<int> _eventIds = [];
+
+    internal IReadOnlyList<int> EventIds
+    {
+        get
+        {
+            lock (_eventIds)
+            {
+                return [.. _eventIds];
+            }
+        }
+    }
+
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource.Name == "ThirtyTwo-WinUI")
+        {
+            EnableEvents(eventSource, EventLevel.Verbose);
+        }
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        lock (_eventIds)
+        {
+            _eventIds.Add(eventData.EventId);
+        }
+    }
+}

--- a/src/thirtytwo/Threading/Dispatcher.cs
+++ b/src/thirtytwo/Threading/Dispatcher.cs
@@ -203,6 +203,31 @@ public sealed class Dispatcher
     }
 
     /// <summary>
+    ///  Registers synchronous cleanup to run on the owning thread after admission closes and before native dispatcher
+    ///  resources are released. Registrations run in reverse order.
+    /// </summary>
+    /// <param name="callback">The cleanup callback.</param>
+    /// <returns>A registration that removes the callback when disposed before shutdown.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///  The calling thread does not own this dispatcher, no active message loop owns it, or shutdown has started.
+    /// </exception>
+    public ShutdownRegistration RegisterShutdownCallback(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        VerifyAccess();
+
+        ThreadContext context = ThreadContext.CurrentContext
+            ?? throw new InvalidOperationException("A message loop is not running on this thread.");
+        if (!ReferenceEquals(context.Dispatcher, this))
+        {
+            throw new InvalidOperationException("The current message loop does not own this dispatcher.");
+        }
+
+        return context.RegisterShutdownCallback(callback);
+    }
+
+    /// <summary>
     ///  Queues a synchronous callback. The callback is deferred even when called by the owning thread.
     /// </summary>
     /// <remarks>

--- a/src/thirtytwo/Threading/ShutdownRegistration.cs
+++ b/src/thirtytwo/Threading/ShutdownRegistration.cs
@@ -4,16 +4,16 @@
 namespace Windows.Threading;
 
 /// <summary>
-///  Represents a shutdown callback registered with a thread context.
+///  Represents a callback registered for dispatcher shutdown.
 /// </summary>
 /// <remarks>
 ///  <para>
-///   <see cref="ThreadContext.RegisterShutdownCallback"/> adds the callback and returns this handle. Disposing the
-///   handle before shutdown begins removes that registration. Once shutdown begins, the callback set is fixed and
-///   disposal has no effect.
+///   <see cref="Dispatcher.RegisterShutdownCallback"/> adds the callback and returns this handle. Disposing the handle
+///   before shutdown begins removes that registration. Once shutdown begins, the callback set is fixed and disposal
+///   has no effect. Repeated disposal is safe. A non-default registration must be disposed on its owning thread.
 ///  </para>
 /// </remarks>
-internal readonly struct ShutdownRegistration : IDisposable
+public readonly struct ShutdownRegistration : IDisposable
 {
     private readonly ThreadContext? _context;
     private readonly long _id;
@@ -31,7 +31,7 @@ internal readonly struct ShutdownRegistration : IDisposable
 
     /// <summary>
     ///  Removes the represented callback registration when shutdown has not begun. Disposal from a different thread
-    ///  throws.
+    ///  throws; repeated disposal has no effect.
     /// </summary>
     public void Dispose() => _context?.RemoveShutdownCallback(_id);
 }

--- a/src/thirtytwo_tests/Threading/DispatcherTestWorker.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTestWorker.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.Threading;
 
 internal static class DispatcherTestWorker
 {

--- a/src/thirtytwo_tests/Threading/DispatcherTimerTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherTimerTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Win32;
+
+namespace Windows.Threading;
 
 [TestClass]
 public class DispatcherTimerTests

--- a/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
+++ b/src/thirtytwo_tests/Threading/DispatcherWakeTests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Support;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.Threading;
 
 [TestClass]
 public class DispatcherWakeTests

--- a/src/thirtytwo_tests/Threading/FakeDispatcherWake.cs
+++ b/src/thirtytwo_tests/Threading/FakeDispatcherWake.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Support;
 using Windows.Win32.Foundation;
+
+namespace Windows.Threading;
 
 internal sealed class FakeDispatcherWake(Dispatcher dispatcher) : IDispatcherWake
 {

--- a/src/thirtytwo_tests/Threading/MessageFilterTests.cs
+++ b/src/thirtytwo_tests/Threading/MessageFilterTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.Threading;
 
 [TestClass]
 public class MessageFilterTests

--- a/src/thirtytwo_tests/Threading/ThreadContextTests.cs
+++ b/src/thirtytwo_tests/Threading/ThreadContextTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Jeremy W. Kuhne. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Windows.Threading;
-
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.Threading;
 
 [TestClass]
 public class ThreadContextTests
@@ -74,6 +74,91 @@ public class ThreadContextTests
         context.RunMessageLoop();
 
         order.Should().Equal(2, 1);
+    }
+
+    [STATestMethod]
+    public void DispatcherRegisterShutdownCallback_RunsOnOwnerThreadBeforeCompletion()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        uint ownerThreadId = PInvoke.GetCurrentThreadId();
+        uint callbackThreadId = 0;
+        bool completionObserved = true;
+        using ShutdownRegistration registration = context.Dispatcher.RegisterShutdownCallback(() =>
+        {
+            callbackThreadId = PInvoke.GetCurrentThreadId();
+            completionObserved = context.Dispatcher.Completion.IsCompleted;
+        });
+
+        PInvoke.PostQuitMessage(0);
+        context.RunMessageLoop();
+
+        callbackThreadId.Should().Be(ownerThreadId);
+        completionObserved.Should().BeFalse();
+        context.Dispatcher.Completion.IsCompleted.Should().BeFalse();
+        context.Dispose();
+        context.Dispatcher.Completion.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DispatcherRegisterShutdownCallback_ForeignThread_Throws()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Exception? failure = null;
+        Thread thread = new(() =>
+        {
+            try
+            {
+                _ = context.Dispatcher.RegisterShutdownCallback(static () => { });
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        });
+
+        thread.Start();
+        thread.Join();
+
+        failure.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be("The calling thread does not own this dispatcher.");
+    }
+
+    [TestMethod]
+    public void DispatcherRegisterShutdownCallback_NullCallback_Throws()
+    {
+        using ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+
+        Action action = () => context.Dispatcher.RegisterShutdownCallback(null!);
+
+        action.Should().Throw<ArgumentNullException>()
+            .Which.ParamName.Should().Be("callback");
+    }
+
+    [TestMethod]
+    public void DispatcherRegisterShutdownCallback_NoActiveContext_Throws()
+    {
+        ThreadContext context = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher dispatcher = context.Dispatcher;
+        context.Dispose();
+
+        Action action = () => dispatcher.RegisterShutdownCallback(static () => { });
+
+        action.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Be("A message loop is not running on this thread.");
+    }
+
+    [TestMethod]
+    public void DispatcherRegisterShutdownCallback_DifferentActiveContext_Throws()
+    {
+        ThreadContext previousContext = ThreadingTestAccessors.CreateThreadContext();
+        Dispatcher previousDispatcher = previousContext.Dispatcher;
+        previousContext.Dispose();
+        using ThreadContext currentContext = ThreadingTestAccessors.CreateThreadContext();
+
+        Action action = () => previousDispatcher.RegisterShutdownCallback(static () => { });
+
+        action.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Be("The current message loop does not own this dispatcher.");
     }
 
     [STATestMethod]

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
@@ -23,7 +23,7 @@ internal sealed class WinUIIntegrationRunner
     };
 
     private readonly string _artifactRoot;
-    private readonly string _controlHostExecutable;
+    private readonly string? _scenarioExecutableOverride;
 
     internal WinUIIntegrationRunner()
         : this(Path.Combine(
@@ -35,16 +35,17 @@ internal sealed class WinUIIntegrationRunner
     }
 
     internal WinUIIntegrationRunner(string artifactRoot)
-        : this(FindControlHostExecutable(), artifactRoot)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactRoot);
+        _artifactRoot = Path.GetFullPath(artifactRoot);
     }
 
-    internal WinUIIntegrationRunner(string controlHostExecutable, string artifactRoot)
+    internal WinUIIntegrationRunner(string scenarioExecutable, string artifactRoot)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(controlHostExecutable);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scenarioExecutable);
         ArgumentException.ThrowIfNullOrWhiteSpace(artifactRoot);
 
-        _controlHostExecutable = Path.GetFullPath(controlHostExecutable);
+        _scenarioExecutableOverride = Path.GetFullPath(scenarioExecutable);
         _artifactRoot = Path.GetFullPath(artifactRoot);
     }
 
@@ -58,9 +59,10 @@ internal sealed class WinUIIntegrationRunner
             throw new ArgumentOutOfRangeException(nameof(timeout));
         }
 
-        if (!File.Exists(_controlHostExecutable))
+        string scenarioExecutable = _scenarioExecutableOverride ?? FindScenarioExecutable(scenario);
+        if (!File.Exists(scenarioExecutable))
         {
-            throw new FileNotFoundException("The ControlHost scenario executable was not built.", _controlHostExecutable);
+            throw new FileNotFoundException("The WinUI scenario executable was not built.", scenarioExecutable);
         }
 
         string scenarioName = GetScenarioName(scenario);
@@ -72,8 +74,8 @@ internal sealed class WinUIIntegrationRunner
 
         ProcessStartInfo startInfo = new()
         {
-            FileName = _controlHostExecutable,
-            WorkingDirectory = Path.GetDirectoryName(_controlHostExecutable)!,
+            FileName = scenarioExecutable,
+            WorkingDirectory = Path.GetDirectoryName(scenarioExecutable)!,
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -152,6 +154,16 @@ internal sealed class WinUIIntegrationRunner
                             break;
                         case WinUIIntegrationScenario.Startup:
                         case WinUIIntegrationScenario.ShutdownTimeout:
+                        case WinUIIntegrationScenario.EnvironmentOwned:
+                        case WinUIIntegrationScenario.EnvironmentBorrowed:
+                        case WinUIIntegrationScenario.EnvironmentComposition:
+                        case WinUIIntegrationScenario.EnvironmentMultipleLeases:
+                        case WinUIIntegrationScenario.EnvironmentCompatibleApplication:
+                        case WinUIIntegrationScenario.EnvironmentIncompatibleApplication:
+                        case WinUIIntegrationScenario.EnvironmentMtaRejected:
+                        case WinUIIntegrationScenario.EnvironmentWrongThreadRejected:
+                        case WinUIIntegrationScenario.EnvironmentSecondThreadRejected:
+                        case WinUIIntegrationScenario.EnvironmentFinalRelease:
                             break;
                         default:
                             throw new InvalidOperationException($"Unknown WinUI integration scenario '{scenario}'.");
@@ -371,7 +383,7 @@ internal sealed class WinUIIntegrationRunner
         }
     }
 
-    private static unsafe void RequestClose(long windowHandle, int expectedProcessId)
+    private static void RequestClose(long windowHandle, int expectedProcessId)
     {
         HWND window = WindowHandleValidation.Validate(windowHandle, expectedProcessId);
         if (!PInvoke.PostMessage(window, Interop.WM_CLOSE, default, default))
@@ -468,31 +480,46 @@ internal sealed class WinUIIntegrationRunner
         WinUIIntegrationScenario.UiaTree => "uia-tree",
         WinUIIntegrationScenario.NormalClose => "normal-close",
         WinUIIntegrationScenario.ShutdownTimeout => "shutdown-timeout",
+        WinUIIntegrationScenario.EnvironmentOwned => "environment-owned",
+        WinUIIntegrationScenario.EnvironmentBorrowed => "environment-borrowed",
+        WinUIIntegrationScenario.EnvironmentComposition => "environment-composition",
+        WinUIIntegrationScenario.EnvironmentMultipleLeases => "environment-multiple-leases",
+        WinUIIntegrationScenario.EnvironmentCompatibleApplication => "environment-compatible-application",
+        WinUIIntegrationScenario.EnvironmentIncompatibleApplication => "environment-incompatible-application",
+        WinUIIntegrationScenario.EnvironmentMtaRejected => "environment-mta-rejected",
+        WinUIIntegrationScenario.EnvironmentWrongThreadRejected => "environment-wrong-thread-rejected",
+        WinUIIntegrationScenario.EnvironmentSecondThreadRejected => "environment-second-thread-rejected",
+        WinUIIntegrationScenario.EnvironmentFinalRelease => "environment-final-release",
         _ => throw new ArgumentOutOfRangeException(nameof(scenario))
     };
 
-    private static string FindControlHostExecutable()
+    private static string FindScenarioExecutable(WinUIIntegrationScenario scenario)
+        => scenario <= WinUIIntegrationScenario.ShutdownTimeout
+            ? FindExecutable("ControlHost", "ControlHost.exe")
+            : FindExecutable("IntegrationHost", "IntegrationHost.exe");
+
+    private static string FindExecutable(string projectName, string executableName)
     {
         DirectoryInfo artifacts = GetArtifactsDirectory();
-        string controlHostDirectory = Path.Combine(
+        string outputDirectory = Path.Combine(
             artifacts.FullName,
             "x64",
             GetConfigurationName(),
-            "ControlHost");
-        if (!Directory.Exists(controlHostDirectory))
+            projectName);
+        if (!Directory.Exists(outputDirectory))
         {
-            throw new DirectoryNotFoundException($"ControlHost output directory '{controlHostDirectory}' does not exist.");
+            throw new DirectoryNotFoundException($"Scenario output directory '{outputDirectory}' does not exist.");
         }
 
         string[] candidates = Directory.GetFiles(
-            controlHostDirectory,
-            "ControlHost.exe",
+            outputDirectory,
+            executableName,
             SearchOption.AllDirectories);
         return candidates.Length switch
         {
             1 => candidates[0],
-            0 => throw new FileNotFoundException($"ControlHost.exe was not found under '{controlHostDirectory}'."),
-            _ => throw new InvalidOperationException($"Multiple ControlHost executables were found under '{controlHostDirectory}'.")
+            0 => throw new FileNotFoundException($"{executableName} was not found under '{outputDirectory}'."),
+            _ => throw new InvalidOperationException($"Multiple {executableName} files were found under '{outputDirectory}'.")
         };
     }
 

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
@@ -8,5 +8,15 @@ internal enum WinUIIntegrationScenario
     Startup,
     UiaTree,
     NormalClose,
-    ShutdownTimeout
+    ShutdownTimeout,
+    EnvironmentOwned,
+    EnvironmentBorrowed,
+    EnvironmentComposition,
+    EnvironmentMultipleLeases,
+    EnvironmentCompatibleApplication,
+    EnvironmentIncompatibleApplication,
+    EnvironmentMtaRejected,
+    EnvironmentWrongThreadRejected,
+    EnvironmentSecondThreadRejected,
+    EnvironmentFinalRelease
 }

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostEnvironmentIntegrationTests.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostEnvironmentIntegrationTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Windows.WinUI.IntegrationHarness;
+
+[TestClass]
+[DoNotParallelize]
+public class XamlHostEnvironmentIntegrationTests
+{
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentOwned_OwnsAndStopsQueue()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentOwned,
+            "queue-owned",
+            "application-owned",
+            "environment-acquired",
+            "environment-stopped",
+            "application-retained",
+            "owned-queue-stopped");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentBorrowed_RetainsExternalQueue()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentBorrowed,
+            "external-queue-created",
+            "queue-borrowed",
+            "application-owned",
+            "borrowed-queue-retained");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentComposition_ComposesProvidersResourcesAndThemes()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentComposition,
+            "metadata-composed",
+            "metadata-collision-reported",
+            "resource-registration-rolled-back",
+            "resources-composed",
+            "resource-collision-reported",
+            "theme-dictionaries-preserved");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentMultipleLeases_ReferenceCountsEnvironment()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentMultipleLeases,
+            "lease-count-two",
+            "lease-count-one",
+            "environment-stopped");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentCompatibleApplication_BorrowsApplication()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentCompatibleApplication,
+            "external-application-created",
+            "application-borrowed",
+            "borrowed-queue-retained");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentIncompatibleApplication_RejectsApplication()
+    {
+        WinUIIntegrationResult result = AssertScenario(
+            WinUIIntegrationScenario.EnvironmentIncompatibleApplication,
+            "external-application-created",
+            "incompatible-application-rejected",
+            "borrowed-queue-retained");
+
+        FindEvent(result, "incompatible-application-rejected").Message.Should().Contain("does not implement");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentMtaRejected_ReportsThreadFailure()
+    {
+        WinUIIntegrationResult result = AssertScenario(
+            WinUIIntegrationScenario.EnvironmentMtaRejected,
+            "mta-rejected");
+
+        FindEvent(result, "mta-rejected").Message.Should().Contain("requires an STA thread");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentWrongThreadRejected_RejectsDisposal()
+    {
+        WinUIIntegrationResult result = AssertScenario(
+            WinUIIntegrationScenario.EnvironmentWrongThreadRejected,
+            "wrong-thread-rejected");
+
+        FindEvent(result, "wrong-thread-rejected").Message.Should().Contain("Expected managed thread");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentSecondThreadRejected_RejectsSecondXamlThread()
+    {
+        WinUIIntegrationResult result = AssertScenario(
+            WinUIIntegrationScenario.EnvironmentSecondThreadRejected,
+            "second-thread-rejected");
+
+        FindEvent(result, "second-thread-rejected").Message.Should().Contain("designated to managed thread");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_EnvironmentFinalRelease_ReleasesEnvironmentAndRetainsApplication()
+        => AssertScenario(
+            WinUIIntegrationScenario.EnvironmentFinalRelease,
+            "double-dispose-idempotent",
+            "final-lease-released",
+            "environment-reacquired",
+            "application-retained",
+            "owned-queue-stopped");
+
+    private static WinUIIntegrationResult AssertScenario(
+        WinUIIntegrationScenario scenario,
+        params string[] expectedEvents)
+    {
+        WinUIIntegrationResult result = new WinUIIntegrationRunner()
+            .RunAsync(scenario, TimeSpan.FromSeconds(20))
+            .GetAwaiter()
+            .GetResult();
+
+        result.DiagnosticMessage.Should().BeNull();
+        result.TimedOut.Should().BeFalse();
+        result.ExitCode.Should().Be(0);
+        result.ProcessId.Should().BePositive();
+        result.MainThreadId.Should().BePositive();
+        result.WindowHandle.Should().NotBe(0);
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(expectedEvents);
+        result.Events.Select(entry => entry.Event).Should().Contain("product-diagnostics-observed");
+        result.Events.Select(entry => entry.Event).Should().EndWith("scenario-completed");
+        result.StandardError.Should().BeEmpty();
+        File.Exists(result.ResultPath).Should().BeTrue();
+        AssertProcessExited(result.ProcessId);
+        return result;
+    }
+
+    private static WinUIIntegrationEvent FindEvent(WinUIIntegrationResult result, string eventName)
+        => result.Events.Should().ContainSingle(entry => entry.Event == eventName).Subject;
+
+    private static void AssertProcessExited(int processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            process.HasExited.Should().BeTrue($"IntegrationHost process {processId} should have exited");
+        }
+        catch (ArgumentException)
+        {
+        }
+    }
+}

--- a/src/thirtytwo_tests/thirtytwo_tests.csproj
+++ b/src/thirtytwo_tests/thirtytwo_tests.csproj
@@ -32,6 +32,10 @@
                       PrivateAssets="all"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\thirtytwo.winui_tests\IntegrationHost\IntegrationHost.csproj"
+              PrivateAssets="all"
+              ReferenceOutputAssembly="false"
+              SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/thirtytwo.slnx
+++ b/thirtytwo.slnx
@@ -37,6 +37,12 @@
     <Project Path="src/samples/WinUI/ControlHost/ControlHost.csproj">
       <Platform Project="x64" />
     </Project>
+    <Project Path="src/samples/WinUI/SampleWinUIClassLibraryA/SampleWinUIClassLibraryA.csproj">
+      <Platform Project="x64" />
+    </Project>
+    <Project Path="src/samples/WinUI/SampleWinUIClassLibraryB/SampleWinUIClassLibraryB.csproj">
+      <Platform Project="x64" />
+    </Project>
   </Folder>
   <Folder Name="/Samples/Petzold/">
     <Project Path="src/samples/Petzold/5th/AltWind/AltWind.csproj">
@@ -87,7 +93,13 @@
   <Project Path="src/thirtytwo/thirtytwo.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="src/thirtytwo.winui/thirtytwo.winui.csproj">
+    <Platform Project="x64" />
+  </Project>
   <Project Path="src/thirtytwo_tests/thirtytwo_tests.csproj">
+    <Platform Project="x64" />
+  </Project>
+  <Project Path="src/thirtytwo.winui_tests/IntegrationHost/IntegrationHost.csproj">
     <Platform Project="x64" />
   </Project>
 </Solution>


### PR DESCRIPTION
## Summary

Add an optional WinUI 3 host environment that coordinates Windows App SDK state with a thirtytwo UI thread without introducing a Windows App SDK dependency into the core package.

## Changes

- Add a reference-counted `XamlHostEnvironment`, process application contract, metadata and resource registries, lifecycle diagnostics, and owner-thread dispatcher shutdown registration.
- Add two WinUI fixture libraries and ten out-of-process scenarios covering owned and borrowed queues, application compatibility, composition, leases, thread failures, and reacquisition.
- Add isolated package consumers and a CI gate proving core package isolation and deployment-neutral optional-library properties.

## Validation

- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (375 passed, 1 skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (375 passed, 1 skipped)
- [x] `./eng/verify-winui-package-isolation.ps1 -Configuration Release` passes
- [x] New and changed behavior has focused tests
- [x] Native ownership, failure cleanup, and thread affinity were reviewed
- [x] Agent-file validation is not applicable; no agent files changed

## Related issues

None.