### PR TITLE
Add WinUI host control lifecycle

### DIFF
--- a/src/package-tests/WinUIConsumer/Consumer.cs
+++ b/src/package-tests/WinUIConsumer/Consumer.cs
@@ -6,4 +6,8 @@ namespace WinUIConsumer;
 public static class Consumer
 {
     public static Type EnvironmentType => typeof(Windows.WinUI.XamlHostEnvironment);
+
+    public static Type HostControlType => typeof(Windows.WinUI.XamlHostControl);
+
+    public static Type ColorPickerType => typeof(Windows.WinUI.WinUIColorPicker);
 }

--- a/src/thirtytwo.winui/WinUIColorChangedEventArgs.cs
+++ b/src/thirtytwo.winui/WinUIColorChangedEventArgs.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Provides the previous and current colors for a <see cref="WinUIColorPicker.ColorChanged"/> event.
+/// </summary>
+public sealed class WinUIColorChangedEventArgs(Color oldColor, Color newColor) : EventArgs
+{
+    /// <summary>Gets the color before the change.</summary>
+    public Color OldColor { get; } = oldColor;
+
+    /// <summary>Gets the color after the change.</summary>
+    public Color NewColor { get; } = newColor;
+}

--- a/src/thirtytwo.winui/WinUIColorPicker.cs
+++ b/src/thirtytwo.winui/WinUIColorPicker.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Runtime.ExceptionServices;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Win32.Foundation;
+using WinUIColor = Windows.UI.Color;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Hosts a WinUI color picker and projects its common color contract through .NET types.
+/// </summary>
+public sealed class WinUIColorPicker : XamlHostControl
+{
+    private ColorPicker? _colorPicker;
+
+    /// <summary>Creates a WinUI color picker attached to <paramref name="parentWindow"/>.</summary>
+    /// <param name="bounds">The host bounds in parent-client pixels.</param>
+    /// <param name="parentWindow">The managed parent window.</param>
+    public WinUIColorPicker(Rectangle bounds, Window parentWindow)
+        : base(bounds, parentWindow)
+    {
+        ColorPicker? colorPicker = null;
+        try
+        {
+            colorPicker = new();
+            colorPicker.ColorChanged += ColorPickerColorChanged;
+            _colorPicker = colorPicker;
+            Content = colorPicker;
+        }
+        catch (Exception constructionFailure)
+        {
+            ThrowAfterFailedConstruction(constructionFailure, colorPicker);
+        }
+    }
+
+    /// <summary>Occurs when the selected color changes.</summary>
+    public event EventHandler<WinUIColorChangedEventArgs>? ColorChanged;
+
+    /// <summary>Gets the hosted WinUI color picker.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   The typed wrapper fixes its content during construction. Assigning another element would detach the picker
+    ///   controlled by <see cref="Color"/> and <see cref="IsAlphaEnabled"/> and is therefore rejected.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException"><paramref name="value"/> is not the hosted color picker.</exception>
+    public override Microsoft.UI.Xaml.UIElement? Content
+    {
+        get => base.Content;
+        set
+        {
+            if (!ReferenceEquals(value, _colorPicker))
+            {
+                throw new InvalidOperationException("WinUIColorPicker content cannot be replaced.");
+            }
+
+            base.Content = value;
+        }
+    }
+
+    /// <summary>Gets or sets the selected color.</summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own this control.</exception>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
+    public Color Color
+    {
+        get
+        {
+            VerifyUsable();
+            return ToDrawingColor(_colorPicker!.Color);
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.Color = WinUIColor.FromArgb(value.A, value.R, value.G, value.B);
+        }
+    }
+
+    /// <summary>Gets or sets whether the picker allows alpha-channel selection.</summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own this control.</exception>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
+    public bool IsAlphaEnabled
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsAlphaEnabled;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsAlphaEnabled = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            base.Dispose(disposing: false);
+            return;
+        }
+
+        VerifyAccess();
+        Exception? eventCleanupFailure = null;
+        try
+        {
+            DetachColorPicker();
+        }
+        catch (Exception exception)
+        {
+            eventCleanupFailure = exception;
+        }
+
+        try
+        {
+            base.Dispose(disposing: true);
+        }
+        catch (Exception hostCleanupFailure) when (eventCleanupFailure is not null)
+        {
+            throw new AggregateException(eventCleanupFailure, hostCleanupFailure);
+        }
+
+        if (eventCleanupFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(eventCleanupFailure).Throw();
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    {
+        if (message == MessageType.Destroy)
+        {
+            try
+            {
+                DetachColorPicker();
+            }
+            catch (Exception exception)
+            {
+                ReportNativeCallbackFailure("ColorPickerDestroy", exception);
+            }
+        }
+
+        return base.WindowProcedure(window, message, wParam, lParam);
+    }
+
+    private static Color ToDrawingColor(WinUIColor color)
+        => Color.FromArgb(color.A, color.R, color.G, color.B);
+
+    private void ColorPickerColorChanged(ColorPicker sender, ColorChangedEventArgs eventArgs)
+        => ColorChanged?.Invoke(
+            this,
+            new(ToDrawingColor(eventArgs.OldColor), ToDrawingColor(eventArgs.NewColor)));
+
+    private void DetachColorPicker()
+    {
+        ColorPicker? colorPicker = _colorPicker;
+        if (colorPicker is null)
+        {
+            return;
+        }
+
+        _colorPicker = null;
+        colorPicker.ColorChanged -= ColorPickerColorChanged;
+    }
+
+    [DoesNotReturn]
+    private void ThrowAfterFailedConstruction(Exception constructionFailure, ColorPicker? colorPicker)
+    {
+        List<Exception>? cleanupFailures = null;
+        try
+        {
+            if (colorPicker is not null)
+            {
+                colorPicker.ColorChanged -= ColorPickerColorChanged;
+            }
+        }
+        catch (Exception eventCleanupFailure)
+        {
+            cleanupFailures = [eventCleanupFailure];
+        }
+
+        try
+        {
+            base.Dispose(disposing: true);
+        }
+        catch (Exception hostCleanupFailure)
+        {
+            (cleanupFailures ??= []).Add(hostCleanupFailure);
+        }
+
+        if (cleanupFailures is not null)
+        {
+            cleanupFailures.Insert(0, constructionFailure);
+            throw new AggregateException("WinUI color picker construction and cleanup failed.", cleanupFailures);
+        }
+
+        ExceptionDispatchInfo.Capture(constructionFailure).Throw();
+        throw new UnreachableException();
+    }
+
+    private void VerifyUsable()
+    {
+        VerifyAccess();
+        ObjectDisposedException.ThrowIf(IsXamlSourceDisposed, this);
+        ObjectDisposedException.ThrowIf(_colorPicker is null, this);
+    }
+}

--- a/src/thirtytwo.winui/XamlHostControl.cs
+++ b/src/thirtytwo.winui/XamlHostControl.cs
@@ -1,0 +1,434 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Hosting;
+using Windows.Graphics;
+using Windows.Threading;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Hosts WinUI content in a managed thirtytwo child window.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Construction must occur on the designated XAML UI thread inside an active
+///   <see cref="Application.Run(Window, bool)"/> loop. The host acquires its own
+///   <see cref="XamlHostEnvironment"/> lease, creates one <see cref="DesktopWindowXamlSource"/>, and attaches the
+///   source only after the <see cref="CustomControl"/> constructor returns.
+///  </para>
+///  <para>
+///   The host owns the XAML source but not the assigned content. Disposal clears <see cref="Content"/>, disposes the
+///   source, and releases the environment lease before destroying the managed host window. Parent destruction performs
+///   the same cleanup. A host not otherwise destroyed is retained for owner-thread cleanup during dispatcher shutdown.
+///  </para>
+/// </remarks>
+public unsafe partial class XamlHostControl : CustomControl
+{
+    private static readonly WindowClass s_windowClass = new(
+        className: "ThirtyTwoXamlHostControl",
+        backgroundBrush: HBRUSH.Invalid);
+
+    private readonly XamlThreadAffinity _affinity = new();
+    private XamlHostEnvironment? _environment;
+    private DesktopWindowXamlSource? _xamlSource;
+    private ShutdownRegistration _shutdownRegistration;
+    private bool _xamlStateDisposed;
+
+    /// <summary>
+    ///  Creates an empty WinUI host attached to <paramref name="parentWindow"/>.
+    /// </summary>
+    /// <param name="bounds">The host bounds in parent-client pixels.</param>
+    /// <param name="parentWindow">The managed parent window.</param>
+    public XamlHostControl(Rectangle bounds, Window parentWindow)
+        : base(
+            bounds,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.ClipChildren | WindowStyles.ClipSiblings,
+            parentWindow: ValidateParent(parentWindow),
+            windowClass: s_windowClass)
+    {
+        try
+        {
+            _environment = XamlHostEnvironment.Acquire();
+            _xamlSource = CreateXamlSource();
+            _shutdownRegistration = Dispatcher.RegisterShutdownCallback(Dispose);
+        }
+        catch (Exception constructionFailure)
+        {
+            ThrowAfterFailedConstruction(constructionFailure);
+        }
+    }
+
+    /// <summary>
+    ///  Creates a WinUI host and assigns content produced after the host environment and XAML source are initialized.
+    /// </summary>
+    /// <param name="bounds">The host bounds in parent-client pixels.</param>
+    /// <param name="parentWindow">The managed parent window.</param>
+    /// <param name="contentFactory">Creates the content on the host thread.</param>
+    public XamlHostControl(Rectangle bounds, Window parentWindow, Func<UIElement> contentFactory)
+        : this(bounds, parentWindow)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(contentFactory);
+            Content = contentFactory()
+                ?? throw new InvalidOperationException("The WinUI content factory returned null.");
+        }
+        catch (Exception constructionFailure)
+        {
+            ThrowAfterFailedConstruction(constructionFailure);
+        }
+    }
+
+    /// <summary>Gets or sets the WinUI element displayed by this host.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   Assignment and access must occur on the owner thread. Replacing or clearing content does not dispose the
+    ///   previously assigned element.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The calling thread does not own this host.</exception>
+    /// <exception cref="ObjectDisposedException">The host or its parent window has been destroyed.</exception>
+    public virtual UIElement? Content
+    {
+        get
+        {
+            DesktopWindowXamlSource xamlSource = GetXamlSource();
+            return xamlSource.Content;
+        }
+        set
+        {
+            DesktopWindowXamlSource xamlSource = GetXamlSource();
+            xamlSource.Content = value;
+        }
+    }
+
+    /// <summary>Changes the managed host window's parent and reattaches its content through a new XAML source.</summary>
+    /// <param name="parentWindow">The new parent window on the host's owner thread.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parentWindow"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///  The calling thread does not own the host, the parent has been destroyed, or the parent belongs to another
+    ///  native thread.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
+    /// <exception cref="Win32Exception">The native parent could not be changed.</exception>
+    /// <exception cref="AggregateException">
+    ///  Reparenting failed and the original parent and XAML source could not be restored. The host is disposed before
+    ///  the exception is thrown.
+    /// </exception>
+    public void Reparent(Window parentWindow)
+    {
+        ArgumentNullException.ThrowIfNull(parentWindow);
+        _ = GetXamlSource();
+
+        uint parentThreadId = PInvoke.GetWindowThreadProcessId(parentWindow.Handle, null);
+        if (parentThreadId == 0)
+        {
+            throw new InvalidOperationException("The new parent window has been destroyed.");
+        }
+
+        if (parentThreadId != _affinity.NativeThreadId)
+        {
+            throw new InvalidOperationException(
+                $"The new parent window belongs to native thread {parentThreadId}; expected native thread {_affinity.NativeThreadId}.");
+        }
+
+        HWND originalParent = PInvoke.GetParent(Handle);
+        if (originalParent == parentWindow.Handle)
+        {
+            return;
+        }
+
+        UIElement? content = null;
+
+        try
+        {
+            DetachXamlSource(out content);
+            SetNativeParent(Handle, parentWindow.Handle);
+            _xamlSource = CreateXamlSource(content);
+        }
+        catch (Exception reparentFailure)
+        {
+            try
+            {
+                if (!originalParent.IsNull && PInvoke.GetParent(Handle) != originalParent)
+                {
+                    SetNativeParent(Handle, originalParent);
+                }
+
+                _xamlSource ??= CreateXamlSource(content);
+            }
+            catch (Exception recoveryFailure)
+            {
+                List<Exception> failures = [reparentFailure, recoveryFailure];
+                try
+                {
+                    DisposeXamlState();
+                }
+                catch (Exception cleanupFailure)
+                {
+                    failures.Add(cleanupFailure);
+                }
+
+                try
+                {
+                    base.Dispose(disposing: true);
+                }
+                catch (Exception windowFailure)
+                {
+                    failures.Add(windowFailure);
+                }
+
+                throw new AggregateException(
+                    "Reparenting failed and the original XAML host state could not be restored.",
+                    failures);
+            }
+
+            throw;
+        }
+        finally
+        {
+            GC.KeepAlive(parentWindow);
+        }
+    }
+
+    /// <summary>Verifies that the calling thread owns this host.</summary>
+    /// <exception cref="InvalidOperationException">The calling thread does not own this host.</exception>
+    protected void VerifyAccess() => _affinity.VerifyAccess();
+
+    /// <summary>Gets whether the XAML source has been disposed.</summary>
+    protected bool IsXamlSourceDisposed => _xamlStateDisposed;
+
+    /// <inheritdoc/>
+    protected override void OnSize(Size size)
+    {
+        DesktopWindowXamlSource? xamlSource = _xamlSource;
+        if (xamlSource is not null)
+        {
+            try
+            {
+                ResizeSiteBridge(xamlSource, size);
+            }
+            catch (Exception exception)
+            {
+                ReportNativeCallbackFailure("Resize", exception);
+            }
+        }
+
+        base.OnSize(size);
+    }
+
+    /// <inheritdoc/>
+    protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    {
+        if (message == MessageType.Destroy)
+        {
+            try
+            {
+                DisposeXamlState();
+            }
+            catch (Exception exception)
+            {
+                ReportNativeCallbackFailure("Destroy", exception);
+            }
+        }
+
+        return base.WindowProcedure(window, message, wParam, lParam);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            base.Dispose(disposing: false);
+            return;
+        }
+
+        VerifyAccess();
+        Exception? cleanupFailure = null;
+        try
+        {
+            DisposeXamlState();
+        }
+        catch (Exception exception)
+        {
+            cleanupFailure = exception;
+        }
+
+        try
+        {
+            base.Dispose(disposing: true);
+        }
+        catch (Exception windowFailure) when (cleanupFailure is not null)
+        {
+            throw new AggregateException(cleanupFailure, windowFailure);
+        }
+
+        if (cleanupFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+        }
+    }
+
+    /// <summary>Reports a failure caught at a native window-procedure boundary.</summary>
+    protected static void ReportNativeCallbackFailure(string operation, Exception exception)
+    {
+        try
+        {
+            XamlHostEventSource.Log.HostCallbackFailed(
+                PInvoke.GetCurrentThreadId(),
+                operation,
+                exception.HResult,
+                exception.GetType().FullName ?? exception.GetType().Name);
+        }
+        catch
+        {
+        }
+    }
+
+    private static Window ValidateParent(Window? parentWindow)
+    {
+        ArgumentNullException.ThrowIfNull(parentWindow);
+        return parentWindow;
+    }
+
+    private static void ResizeSiteBridge(DesktopWindowXamlSource xamlSource, Size size)
+        => xamlSource.SiteBridge?.MoveAndResize(new RectInt32(0, 0, size.Width, size.Height));
+
+    private static void SetNativeParent(HWND window, HWND parent)
+    {
+        Marshal.SetLastPInvokeError(0);
+        HWND previousParent = PInvoke.SetParent(window, parent);
+        int error = Marshal.GetLastPInvokeError();
+        if (previousParent.IsNull && error != 0)
+        {
+            throw new Win32Exception(error);
+        }
+    }
+
+    [DoesNotReturn]
+    private void ThrowAfterFailedConstruction(Exception constructionFailure)
+    {
+        List<Exception>? cleanupFailures = null;
+        try
+        {
+            DisposeXamlState();
+        }
+        catch (Exception cleanupFailure)
+        {
+            cleanupFailures = [cleanupFailure];
+        }
+
+        try
+        {
+            base.Dispose(disposing: true);
+        }
+        catch (Exception windowFailure)
+        {
+            (cleanupFailures ??= []).Add(windowFailure);
+        }
+
+        if (cleanupFailures is not null)
+        {
+            cleanupFailures.Insert(0, constructionFailure);
+            throw new AggregateException("XAML host construction and cleanup failed.", cleanupFailures);
+        }
+
+        ExceptionDispatchInfo.Capture(constructionFailure).Throw();
+        throw new UnreachableException();
+    }
+
+    private DesktopWindowXamlSource CreateXamlSource(UIElement? content = null)
+    {
+        DesktopWindowXamlSource xamlSource = new();
+        try
+        {
+            xamlSource.Initialize(Win32Interop.GetWindowIdFromWindow((nint)Handle.Value));
+            xamlSource.ShouldConstrainPopupsToWorkArea = true;
+            ResizeSiteBridge(xamlSource, this.GetClientRectangle().Size);
+            xamlSource.Content = content;
+            return xamlSource;
+        }
+        catch
+        {
+            xamlSource.Dispose();
+            throw;
+        }
+    }
+
+    private void DetachXamlSource(out UIElement? content)
+    {
+        DesktopWindowXamlSource xamlSource = GetXamlSource();
+        content = xamlSource.Content;
+        _xamlSource = null;
+        try
+        {
+            xamlSource.Content = null;
+        }
+        finally
+        {
+            xamlSource.Dispose();
+        }
+    }
+
+    private DesktopWindowXamlSource GetXamlSource()
+    {
+        VerifyAccess();
+        ObjectDisposedException.ThrowIf(_xamlStateDisposed, this);
+        return _xamlSource ?? throw new InvalidOperationException("The WinUI XAML source has not been initialized.");
+    }
+
+    private void DisposeXamlState()
+    {
+        if (_xamlStateDisposed)
+        {
+            return;
+        }
+
+        _xamlStateDisposed = true;
+        DesktopWindowXamlSource? xamlSource = _xamlSource;
+        XamlHostEnvironment? environment = _environment;
+        ShutdownRegistration shutdownRegistration = _shutdownRegistration;
+        _xamlSource = null;
+        _environment = null;
+        _shutdownRegistration = default;
+
+        try
+        {
+            shutdownRegistration.Dispose();
+        }
+        finally
+        {
+            try
+            {
+                if (xamlSource is not null)
+                {
+                    try
+                    {
+                        xamlSource.Content = null;
+                    }
+                    finally
+                    {
+                        xamlSource.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                environment?.Dispose();
+            }
+        }
+    }
+}

--- a/src/thirtytwo.winui/XamlHostEventSource.cs
+++ b/src/thirtytwo.winui/XamlHostEventSource.cs
@@ -36,4 +36,8 @@ internal sealed class XamlHostEventSource : EventSource
     [Event(6, Level = EventLevel.Warning)]
     public void ResourceCollision(string key)
         => WriteEvent(6, key);
+
+    [Event(7, Level = EventLevel.Error)]
+    public void HostCallbackFailed(uint nativeThreadId, string operation, int hresult, string exceptionType)
+        => WriteEvent(7, nativeThreadId, operation, hresult, exceptionType);
 }

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
@@ -14,5 +14,14 @@ internal enum EnvironmentScenario
     MtaRejected,
     WrongThreadRejected,
     SecondThreadRejected,
-    FinalRelease
+    FinalRelease,
+    HostBasic,
+    HostColorPicker,
+    HostStress,
+    HostMultiple,
+    HostLayout,
+    HostReparent,
+    HostReplacement,
+    HostPopupClose,
+    HostShutdownCleanup
 }

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -2,8 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Drawing;
 using System.Runtime.InteropServices;
+using Microsoft.UI;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Markup;
 using SampleWinUIClassLibraryA;
 using SampleWinUIClassLibraryB;
@@ -11,6 +15,7 @@ using Touki.TestSupport;
 using Windows;
 using Windows.Threading;
 using Windows.Win32;
+using Windows.Win32.Foundation;
 using Windows.WinUI;
 using ResourceDictionary = Microsoft.UI.Xaml.ResourceDictionary;
 
@@ -21,6 +26,11 @@ internal sealed class EnvironmentWindow : Window
     private readonly ScenarioReporter _reporter;
     private XamlHostEnvironment? _environment;
     private XamlHostEnvironment? _secondEnvironment;
+    private XamlHostControl? _xamlHost;
+    private WinUIColorPicker? _colorPickerHost;
+    private XamlHostControl? _popupHost;
+    private Window? _shutdownParent;
+    private XamlHostControl? _shutdownHost;
 
     internal EnvironmentWindow(EnvironmentScenario scenario, ScenarioReporter reporter)
         : base(DefaultBounds, text: "ThirtyTwo WinUI Environment Host")
@@ -31,6 +41,7 @@ internal sealed class EnvironmentWindow : Window
 
         if (!Dispatcher.TryPost(() =>
             {
+                ExecuteAfterShow(scenario);
                 if (!PInvoke.DestroyWindow(Handle))
                 {
                     throw new Win32Exception(Marshal.GetLastPInvokeError());
@@ -105,10 +116,350 @@ internal sealed class EnvironmentWindow : Window
                 Ensure(application.TryGetTarget(out _), "The process application was not retained.");
                 _reporter.Write("application-retained");
                 break;
+            case EnvironmentScenario.HostBasic:
+                VerifyHostBasic();
+                break;
+            case EnvironmentScenario.HostColorPicker:
+                VerifyHostColorPicker();
+                break;
+            case EnvironmentScenario.HostStress:
+                VerifyHostStress();
+                break;
+            case EnvironmentScenario.HostMultiple:
+                VerifyHostMultiple();
+                break;
+            case EnvironmentScenario.HostReparent:
+                VerifyHostReparent();
+                break;
+            case EnvironmentScenario.HostReplacement:
+                VerifyHostReplacement();
+                break;
+            case EnvironmentScenario.HostLayout:
+            case EnvironmentScenario.HostPopupClose:
+            case EnvironmentScenario.HostShutdownCleanup:
+                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(scenario));
         }
     }
+
+    internal void VerifyAfterRun(EnvironmentScenario scenario)
+    {
+        XamlHostControl? xamlHost = scenario switch
+        {
+            EnvironmentScenario.HostBasic => _xamlHost,
+            EnvironmentScenario.HostPopupClose => _popupHost,
+            EnvironmentScenario.HostShutdownCleanup => _shutdownHost,
+            _ => null
+        };
+
+        if (xamlHost is null)
+        {
+            return;
+        }
+
+        Ensure(xamlHost.Handle.IsNull, "Parent destruction left the managed host HWND alive.");
+        DesktopWindowXamlSource? xamlSource = xamlHost.TestAccessor.Dynamic._xamlSource;
+        Ensure(xamlSource is null, "Parent destruction left the XAML source alive.");
+        if (scenario == EnvironmentScenario.HostShutdownCleanup)
+        {
+            Window shutdownParent = _shutdownParent
+                ?? throw new InvalidOperationException("The shutdown parent was not created.");
+            Ensure(!shutdownParent.Handle.IsNull, "The shutdown parent was destroyed with the root window.");
+            shutdownParent.Dispose();
+            _shutdownParent = null;
+        }
+
+        string eventName = scenario switch
+        {
+            EnvironmentScenario.HostPopupClose => "popup-parent-destroyed",
+            EnvironmentScenario.HostShutdownCleanup => "host-shutdown-cleaned",
+            _ => "host-parent-destroyed"
+        };
+        _reporter.Write(eventName);
+    }
+
+    private void ExecuteAfterShow(EnvironmentScenario scenario)
+    {
+        switch (scenario)
+        {
+            case EnvironmentScenario.HostLayout:
+                VerifyHostLayout();
+                break;
+            case EnvironmentScenario.HostPopupClose:
+                VerifyHostPopupClose();
+                break;
+            case EnvironmentScenario.HostShutdownCleanup:
+                VerifyHostShutdownCleanup();
+                break;
+        }
+    }
+
+    private void VerifyHostBasic()
+    {
+        bool contentFactoryCalled = false;
+        _xamlHost = new(new Rectangle(20, 30, 320, 240), this, () =>
+        {
+            Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "The content factory ran before host initialization.");
+            contentFactoryCalled = true;
+            return new Grid();
+        });
+
+        Ensure(contentFactoryCalled, "The host content factory did not run.");
+        Ensure(_xamlHost.Content is Grid, "The host did not retain its factory content.");
+        Grid replacement = new();
+        _xamlHost.Content = replacement;
+        Ensure(ReferenceEquals(_xamlHost.Content, replacement), "The host did not replace its content.");
+        _xamlHost.Content = null;
+        Ensure(_xamlHost.Content is null, "The host did not clear its content.");
+        _xamlHost.Content = replacement;
+        Ensure(ReferenceEquals(Window.FromHandle(_xamlHost), _xamlHost), "The managed host HWND was not registered.");
+
+        Exception? wrongThreadFailure = null;
+        Thread thread = new(() =>
+        {
+            try
+            {
+                _ = _xamlHost.Content;
+            }
+            catch (Exception exception)
+            {
+                wrongThreadFailure = exception;
+            }
+        });
+        thread.Start();
+        thread.Join();
+        Ensure(wrongThreadFailure is InvalidOperationException, "Wrong-thread host access was not rejected.");
+        Ensure(ReferenceEquals(_xamlHost.Content, replacement), "Wrong-thread access changed the hosted content.");
+
+        DesktopWindowXamlSource xamlSource = _xamlHost.TestAccessor.Dynamic._xamlSource;
+        HWND siteBridge = (HWND)Win32Interop.GetWindowFromWindowId(xamlSource.SiteBridge.WindowId);
+        Ensure(!siteBridge.IsNull, "The XAML source did not create a site-bridge HWND.");
+        Ensure(Window.FromHandle(siteBridge) is null, "The WinUI-owned site bridge was registered as a managed window.");
+        Ensure(PInvoke.GetParent(siteBridge) == _xamlHost.Handle, "The site bridge is not parented to the managed host.");
+        _reporter.Write("host-attached", _xamlHost.Handle);
+        _reporter.Write("site-bridge-owned-by-winui", siteBridge);
+        _reporter.Write("host-content-created");
+        _reporter.Write("host-wrong-thread-rejected");
+    }
+
+    private void VerifyHostColorPicker()
+    {
+        _colorPickerHost = new(new Rectangle(20, 30, 400, 300), this);
+        WinUIColorChangedEventArgs? observedChange = null;
+        _colorPickerHost.ColorChanged += (_, eventArgs) => observedChange = eventArgs;
+        _colorPickerHost.IsAlphaEnabled = true;
+        Color expected = Color.FromArgb(128, 12, 34, 56);
+
+        _colorPickerHost.Color = expected;
+
+        Ensure(_colorPickerHost.IsAlphaEnabled, "The alpha-enabled setting was not retained.");
+        Ensure(_colorPickerHost.Color == expected, "The selected color did not round-trip through the wrapper.");
+        Ensure(observedChange?.NewColor == expected, "The projected color-change event reported the wrong color.");
+        try
+        {
+            _colorPickerHost.Content = new Grid();
+            throw new InvalidOperationException("The typed wrapper accepted replacement content.");
+        }
+        catch (InvalidOperationException exception) when (exception.Message == "WinUIColorPicker content cannot be replaced.")
+        {
+        }
+
+        Ensure(_colorPickerHost.Color == expected, "Rejected content replacement changed the selected color.");
+        _reporter.Write("color-picker-projected", _colorPickerHost.Handle);
+    }
+
+    private void VerifyHostStress()
+    {
+        int initialChildCount = CountChildWindows();
+        try
+        {
+            _ = new XamlHostControl(
+                new Rectangle(0, 0, 10, 10),
+                this,
+                static () => throw new InvalidOperationException("Expected content factory failure."));
+            throw new InvalidOperationException("A throwing content factory did not fail host construction.");
+        }
+        catch (InvalidOperationException exception) when (exception.Message == "Expected content factory failure.")
+        {
+        }
+
+        try
+        {
+            _ = new XamlHostControl(new Rectangle(0, 0, 10, 10), this, null!);
+            throw new InvalidOperationException("A null content factory did not fail host construction.");
+        }
+        catch (ArgumentNullException exception) when (exception.ParamName == "contentFactory")
+        {
+        }
+
+        Ensure(CountChildWindows() == initialChildCount, "Failed host construction left native child windows behind.");
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "Failed host construction retained an environment lease.");
+        _reporter.Write("host-constructor-failure-cleaned");
+
+        for (int iteration = 0; iteration < 1_000; iteration++)
+        {
+            using XamlHostControl host = new(new Rectangle(0, 0, 1 + (iteration % 7), 1 + (iteration % 11)), this);
+            HWND handle = host.Handle;
+            Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "A stress host did not acquire one lease.");
+
+            host.Dispose();
+
+            Ensure(host.Handle.IsNull, "A stress host retained its managed HWND after disposal.");
+            Ensure(Window.FromHandle(handle) is null, "A disposed stress host remained in managed HWND lookup.");
+            Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "A stress host retained its environment lease.");
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        Ensure(CountChildWindows() == initialChildCount, "Host stress left native child windows behind.");
+        _reporter.Write("host-stress-completed");
+    }
+
+    private void VerifyHostMultiple()
+    {
+        using XamlHostControl first = new(new Rectangle(0, 0, 80, 60), this, static () => new Grid());
+        using XamlHostControl second = new(new Rectangle(80, 0, 80, 60), this, static () => new Grid());
+        using XamlHostControl third = new(new Rectangle(160, 0, 80, 60), this, static () => new Grid());
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 3, "Three hosts did not acquire three leases.");
+
+        second.Dispose();
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 2, "Disposing the middle host did not release one lease.");
+        Ensure(first.Content is Grid && third.Content is Grid, "Disposing one host invalidated another host.");
+        first.Dispose();
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "Disposing the first host did not release one lease.");
+        third.Dispose();
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "Disposing all hosts retained a lease.");
+
+        using XamlHostControl fourth = new(new Rectangle(0, 60, 80, 60), this);
+        using XamlHostControl fifth = new(new Rectangle(80, 60, 80, 60), this);
+        fifth.Dispose();
+        fourth.Dispose();
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 0, "Reverse-order disposal retained a lease.");
+        _reporter.Write("multiple-host-disposal-completed");
+    }
+
+    private void VerifyHostLayout()
+    {
+        using XamlHostControl host = new(new Rectangle(0, 0, 1, 1), this, static () => new Grid());
+        DesktopWindowXamlSource xamlSource = GetXamlSource(host);
+        HWND siteBridge = GetSiteBridge(xamlSource);
+
+        host.MoveWindow(Rectangle.Empty, repaint: false);
+        Ensure(host.GetClientRectangle().Size == Size.Empty, "The managed host did not accept zero size.");
+        Ensure(siteBridge.GetClientRectangle().Size == Size.Empty, "The site bridge did not accept zero size.");
+        _reporter.Write("host-zero-size");
+
+        host.MoveWindow(new Rectangle(10, 10, 120, 90), repaint: false);
+        host.ShowWindow(ShowWindowCommand.Hide);
+        Ensure(!PInvoke.IsWindowVisible(host.Handle), "The managed host remained visible after hide.");
+        Ensure(!PInvoke.IsWindowVisible(siteBridge), "The site bridge remained visible after its host was hidden.");
+        host.ShowWindow(ShowWindowCommand.Show);
+        Ensure(PInvoke.IsWindowVisible(host.Handle), "The managed host did not become visible.");
+        Ensure(PInvoke.IsWindowVisible(siteBridge), "The site bridge did not become visible with its host.");
+        _reporter.Write("host-visibility-synchronized");
+
+        Size expectedSize = default;
+        for (int iteration = 1; iteration <= 250; iteration++)
+        {
+            expectedSize = new(1 + ((iteration * 17) % 480), 1 + ((iteration * 29) % 320));
+            host.MoveWindow(new Rectangle(iteration % 31, iteration % 23, expectedSize.Width, expectedSize.Height), repaint: false);
+        }
+
+        Ensure(siteBridge.GetClientRectangle().Size == expectedSize, "The site bridge did not track the resize storm.");
+        Ensure(ReferenceEquals(GetXamlSource(host), xamlSource), "Resizing replaced the XAML source.");
+        _reporter.Write("host-resize-storm-completed");
+    }
+
+    private void VerifyHostReparent()
+    {
+        using CustomControl firstParent = new(new Rectangle(0, 0, 300, 220), parentWindow: this);
+        using CustomControl secondParent = new(new Rectangle(300, 0, 300, 220), parentWindow: this);
+        using XamlHostControl host = new(new Rectangle(5, 7, 180, 140), firstParent, static () => new Grid());
+        DesktopWindowXamlSource xamlSource = GetXamlSource(host);
+        HWND siteBridge = GetSiteBridge(xamlSource);
+        using CustomControl destroyedParent = new(new Rectangle(0, 220, 100, 80), parentWindow: this);
+        destroyedParent.Dispose();
+
+        try
+        {
+            host.Reparent(destroyedParent);
+            throw new InvalidOperationException("A destroyed reparent target was accepted.");
+        }
+        catch (InvalidOperationException exception) when (exception.Message == "The new parent window has been destroyed.")
+        {
+        }
+
+        Ensure(PInvoke.GetParent(host.Handle) == firstParent.Handle, "Rejected reparenting changed the native parent.");
+        Ensure(ReferenceEquals(GetXamlSource(host), xamlSource), "Rejected reparenting replaced the XAML source.");
+        Ensure(host.Content is Grid, "Rejected reparenting lost the hosted content.");
+        _reporter.Write("destroyed-reparent-target-rejected");
+
+        host.Reparent(secondParent);
+        host.MoveWindow(new Rectangle(11, 13, 200, 150), repaint: false);
+
+        Ensure(PInvoke.GetParent(host.Handle) == secondParent.Handle, "The host did not move to the new parent.");
+        HWND reattachedSiteBridge = GetSiteBridge(GetXamlSource(host));
+        Ensure(PInvoke.GetParent(reattachedSiteBridge) == host.Handle, "Reparenting detached the site bridge from its host.");
+        Ensure(!ReferenceEquals(GetXamlSource(host), xamlSource), "Reparenting reused the source attached to the old parent.");
+        Ensure(reattachedSiteBridge != siteBridge, "Reparenting reused the site bridge attached to the old parent.");
+        Ensure(host.Content is Grid, "Reparenting lost the hosted content.");
+        _reporter.Write("host-reparented");
+    }
+
+    private void VerifyHostReplacement()
+    {
+        DesktopWindowXamlSource firstSource;
+        using (XamlHostControl first = new(new Rectangle(0, 0, 160, 120), this, static () => new Grid()))
+        {
+            firstSource = GetXamlSource(first);
+        }
+
+        using XamlHostControl replacement = new(new Rectangle(0, 0, 160, 120), this, static () => new Grid());
+        Ensure(!ReferenceEquals(GetXamlSource(replacement), firstSource), "A replacement host reused a disposed XAML source.");
+        Ensure(replacement.Content is Grid, "The replacement host did not create content.");
+        _reporter.Write("host-replacement-created");
+    }
+
+    private void VerifyHostPopupClose()
+    {
+        ComboBox? comboBox = null;
+        _popupHost = new(new Rectangle(20, 30, 240, 80), this, () => comboBox = new());
+        ComboBox createdComboBox = comboBox
+            ?? throw new InvalidOperationException("The popup content factory did not run.");
+        createdComboBox.Items.Add("First");
+        createdComboBox.Items.Add("Second");
+        createdComboBox.IsDropDownOpen = true;
+        Ensure(createdComboBox.IsDropDownOpen, "The hosted popup did not open.");
+        _reporter.Write("host-popup-open", _popupHost.Handle);
+    }
+
+    private void VerifyHostShutdownCleanup()
+    {
+        _shutdownParent = new(new Rectangle(0, 0, 320, 240), text: "Shutdown cleanup parent");
+        _shutdownHost = new(new Rectangle(20, 30, 200, 150), _shutdownParent, static () => new Grid());
+        Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "The shutdown-cleanup host did not acquire a lease.");
+        _reporter.Write("host-left-for-shutdown", _shutdownHost.Handle);
+    }
+
+    private int CountChildWindows()
+    {
+        int count = 0;
+        this.EnumerateChildWindows(_ =>
+        {
+            count++;
+            return true;
+        });
+        return count;
+    }
+
+    private static DesktopWindowXamlSource GetXamlSource(XamlHostControl host)
+        => host.TestAccessor.Dynamic._xamlSource
+            ?? throw new InvalidOperationException("The host has no XAML source.");
+
+    private static HWND GetSiteBridge(DesktopWindowXamlSource xamlSource)
+        => (HWND)Win32Interop.GetWindowFromWindowId(xamlSource.SiteBridge.WindowId);
 
     private void AcquireAndReport()
     {
@@ -336,6 +687,9 @@ internal sealed class EnvironmentWindow : Window
     {
         if (disposing)
         {
+            _popupHost?.Dispose();
+            _colorPickerHost?.Dispose();
+            _xamlHost?.Dispose();
             _secondEnvironment?.Dispose();
             _environment?.Dispose();
         }

--- a/src/thirtytwo.winui_tests/IntegrationHost/Program.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/Program.cs
@@ -68,6 +68,7 @@ internal static class Program
                 return createdWindow;
             });
 
+            window?.VerifyAfterRun(scenario);
             Ensure(XamlHostEnvironment.Current is null, "The environment survived core dispatcher shutdown.");
             reporter.Write("environment-stopped");
             if (environmentApplication is not null)

--- a/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
@@ -25,6 +25,15 @@ internal static class ScenarioArguments
             "environment-wrong-thread-rejected" => EnvironmentScenario.WrongThreadRejected,
             "environment-second-thread-rejected" => EnvironmentScenario.SecondThreadRejected,
             "environment-final-release" => EnvironmentScenario.FinalRelease,
+            "host-basic" => EnvironmentScenario.HostBasic,
+            "host-color-picker" => EnvironmentScenario.HostColorPicker,
+            "host-stress" => EnvironmentScenario.HostStress,
+            "host-multiple" => EnvironmentScenario.HostMultiple,
+            "host-layout" => EnvironmentScenario.HostLayout,
+            "host-reparent" => EnvironmentScenario.HostReparent,
+            "host-replacement" => EnvironmentScenario.HostReplacement,
+            "host-popup-close" => EnvironmentScenario.HostPopupClose,
+            "host-shutdown-cleanup" => EnvironmentScenario.HostShutdownCleanup,
             _ => throw new ArgumentException($"Unknown environment scenario '{arguments[1]}'.")
         };
     }
@@ -41,6 +50,15 @@ internal static class ScenarioArguments
         EnvironmentScenario.WrongThreadRejected => "environment-wrong-thread-rejected",
         EnvironmentScenario.SecondThreadRejected => "environment-second-thread-rejected",
         EnvironmentScenario.FinalRelease => "environment-final-release",
+        EnvironmentScenario.HostBasic => "host-basic",
+        EnvironmentScenario.HostColorPicker => "host-color-picker",
+        EnvironmentScenario.HostStress => "host-stress",
+        EnvironmentScenario.HostMultiple => "host-multiple",
+        EnvironmentScenario.HostLayout => "host-layout",
+        EnvironmentScenario.HostReparent => "host-reparent",
+        EnvironmentScenario.HostReplacement => "host-replacement",
+        EnvironmentScenario.HostPopupClose => "host-popup-close",
+        EnvironmentScenario.HostShutdownCleanup => "host-shutdown-cleanup",
         _ => throw new ArgumentOutOfRangeException(nameof(scenario))
     };
 }

--- a/src/thirtytwo/NativeMethods.txt
+++ b/src/thirtytwo/NativeMethods.txt
@@ -353,6 +353,7 @@ SetFocus
 SetGraphicsMode
 SetLayeredWindowAttributes
 SetMapMode
+SetParent
 SetPolyFillMode
 SetROP2
 SetTextColor

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -8,6 +8,9 @@ using Windows.Win32.Graphics.Direct2D;
 
 namespace Windows;
 
+/// <summary>
+///  Represents a managed wrapper around a native Win32 window.
+/// </summary>
 public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandler
 {
     private static readonly object s_lock = new();
@@ -595,9 +598,12 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 }
                 else
                 {
-                    Handle.SendMessage(MessageType.Close);
-                    bool success = s_windows.TryRemove(Handle, out _);
+                    HWND handle = Handle;
+                    handle.SendMessage(MessageType.Close);
+                    bool success = s_windows.TryRemove(handle, out _);
                     Debug.Assert(success);
+                    _handle = default;
+                    _destroyed = true;
                 }
             }
         }

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
@@ -164,6 +164,15 @@ internal sealed class WinUIIntegrationRunner
                         case WinUIIntegrationScenario.EnvironmentWrongThreadRejected:
                         case WinUIIntegrationScenario.EnvironmentSecondThreadRejected:
                         case WinUIIntegrationScenario.EnvironmentFinalRelease:
+                        case WinUIIntegrationScenario.HostBasic:
+                        case WinUIIntegrationScenario.HostColorPicker:
+                        case WinUIIntegrationScenario.HostStress:
+                        case WinUIIntegrationScenario.HostMultiple:
+                        case WinUIIntegrationScenario.HostLayout:
+                        case WinUIIntegrationScenario.HostReparent:
+                        case WinUIIntegrationScenario.HostReplacement:
+                        case WinUIIntegrationScenario.HostPopupClose:
+                        case WinUIIntegrationScenario.HostShutdownCleanup:
                             break;
                         default:
                             throw new InvalidOperationException($"Unknown WinUI integration scenario '{scenario}'.");
@@ -490,6 +499,15 @@ internal sealed class WinUIIntegrationRunner
         WinUIIntegrationScenario.EnvironmentWrongThreadRejected => "environment-wrong-thread-rejected",
         WinUIIntegrationScenario.EnvironmentSecondThreadRejected => "environment-second-thread-rejected",
         WinUIIntegrationScenario.EnvironmentFinalRelease => "environment-final-release",
+        WinUIIntegrationScenario.HostBasic => "host-basic",
+        WinUIIntegrationScenario.HostColorPicker => "host-color-picker",
+        WinUIIntegrationScenario.HostStress => "host-stress",
+        WinUIIntegrationScenario.HostMultiple => "host-multiple",
+        WinUIIntegrationScenario.HostLayout => "host-layout",
+        WinUIIntegrationScenario.HostReparent => "host-reparent",
+        WinUIIntegrationScenario.HostReplacement => "host-replacement",
+        WinUIIntegrationScenario.HostPopupClose => "host-popup-close",
+        WinUIIntegrationScenario.HostShutdownCleanup => "host-shutdown-cleanup",
         _ => throw new ArgumentOutOfRangeException(nameof(scenario))
     };
 

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
@@ -18,5 +18,14 @@ internal enum WinUIIntegrationScenario
     EnvironmentMtaRejected,
     EnvironmentWrongThreadRejected,
     EnvironmentSecondThreadRejected,
-    EnvironmentFinalRelease
+    EnvironmentFinalRelease,
+    HostBasic,
+    HostColorPicker,
+    HostStress,
+    HostMultiple,
+    HostLayout,
+    HostReparent,
+    HostReplacement,
+    HostPopupClose,
+    HostShutdownCleanup
 }

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostControlIntegrationTests.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostControlIntegrationTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Windows.WinUI.IntegrationHarness;
+
+[TestClass]
+[DoNotParallelize]
+public class XamlHostControlIntegrationTests
+{
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostBasic_AttachesContentAndDisposesWithParent()
+    {
+        WinUIIntegrationResult result = AssertScenario(WinUIIntegrationScenario.HostBasic);
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(
+            "host-attached",
+            "site-bridge-owned-by-winui",
+            "host-content-created",
+            "host-wrong-thread-rejected",
+            "ready",
+            "host-parent-destroyed",
+            "environment-stopped",
+            "scenario-completed");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostColorPicker_ProjectsColorAndEvent()
+    {
+        WinUIIntegrationResult result = AssertScenario(WinUIIntegrationScenario.HostColorPicker);
+
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(
+            "color-picker-projected",
+            "ready",
+            "environment-stopped",
+            "scenario-completed");
+    }
+
+    [TestMethod]
+    [Timeout(180_000)]
+    public void RunAsync_HostStress_CleansUpOneThousandHostsAndConstructorFailures()
+    {
+        WinUIIntegrationResult result = AssertScenario(
+            WinUIIntegrationScenario.HostStress,
+            TimeSpan.FromSeconds(150));
+
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(
+            "host-constructor-failure-cleaned",
+            "host-stress-completed",
+            "ready",
+            "environment-stopped",
+            "scenario-completed");
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostMultiple_DisposesIndependentHostsInDifferentOrders()
+        => AssertScenario(WinUIIntegrationScenario.HostMultiple)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "multiple-host-disposal-completed",
+                "ready",
+                "scenario-completed");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostLayout_TracksZeroSizeVisibilityAndResizeStorm()
+        => AssertScenario(WinUIIntegrationScenario.HostLayout)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "ready",
+                "host-zero-size",
+                "host-visibility-synchronized",
+                "host-resize-storm-completed",
+                "scenario-completed");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostReparent_ReattachesSourceAndPreservesContent()
+        => AssertScenario(WinUIIntegrationScenario.HostReparent)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "destroyed-reparent-target-rejected",
+                "host-reparented",
+                "ready",
+                "scenario-completed");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostReplacement_CreatesFreshSourceAndContent()
+        => AssertScenario(WinUIIntegrationScenario.HostReplacement)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "host-replacement-created",
+                "ready",
+                "scenario-completed");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostPopupClose_DisposesWhilePopupIsOpen()
+        => AssertScenario(WinUIIntegrationScenario.HostPopupClose)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "ready",
+                "host-popup-open",
+                "popup-parent-destroyed",
+                "environment-stopped",
+                "scenario-completed");
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_HostShutdownCleanup_ReleasesLeakedHostOnOwnerThread()
+        => AssertScenario(WinUIIntegrationScenario.HostShutdownCleanup)
+            .Events.Select(entry => entry.Event).Should().ContainInOrder(
+                "ready",
+                "host-left-for-shutdown",
+                "host-shutdown-cleaned",
+                "environment-stopped",
+                "scenario-completed");
+
+    private static WinUIIntegrationResult AssertScenario(
+        WinUIIntegrationScenario scenario,
+        TimeSpan? timeout = null)
+    {
+        WinUIIntegrationResult result = new WinUIIntegrationRunner()
+            .RunAsync(scenario, timeout ?? TimeSpan.FromSeconds(20))
+            .GetAwaiter()
+            .GetResult();
+
+        result.DiagnosticMessage.Should().BeNull();
+        result.TimedOut.Should().BeFalse();
+        result.ExitCode.Should().Be(0);
+        result.StandardError.Should().BeEmpty();
+        AssertProcessExited(result.ProcessId);
+        return result;
+    }
+
+    private static void AssertProcessExited(int processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            process.HasExited.Should().BeTrue($"IntegrationHost process {processId} should have exited");
+        }
+        catch (ArgumentException)
+        {
+        }
+    }
+}

--- a/src/thirtytwo_tests/WindowTests.cs
+++ b/src/thirtytwo_tests/WindowTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Windows;
+
+[TestClass]
+public class WindowTests
+{
+    [STATestMethod]
+    public unsafe void Dispose_CreatedWindow_ClearsHandleAndLookup()
+    {
+        using Window window = new(new Rectangle(0, 0, 100, 100));
+        HWND handle = window.Handle;
+        Window.FromHandle(handle).Should().BeSameAs(window);
+
+        window.Dispose();
+
+        window.Handle.Should().Be(HWND.Null);
+        Window.FromHandle(handle).Should().BeNull();
+        PInvoke.GetWindowThreadProcessId(handle, null).Should().Be(0);
+        window.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Add a managed WinUI child-HWND host and first typed wrapper, with deterministic source, environment lease, and native-window lifecycle behavior.

## Changes

- Add `XamlHostControl` with constructor-safe XAML attachment, content assignment, resizing, visibility, safe reparenting, and explicit/parent/dispatcher-shutdown cleanup.
- Add `WinUIColorPicker`, projecting `System.Drawing.Color`, alpha enablement, and a .NET color-change event while protecting typed content invariants.
- Correct explicit `Window.Dispose` handle/lookup state and add generated `SetParent` support.
- Add nine bounded out-of-process lifecycle scenarios covering 1,000 create/dispose cycles, multiple hosts, layout storms, reparenting, replacement, popup close, parent destruction, and shutdown cleanup.

## Validation

- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (385 passed, 1 skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (385 passed, 1 skipped)
- [x] `./eng/verify-winui-package-isolation.ps1 -Configuration Release` passes
- [x] New and changed behavior has focused tests
- [x] Native ownership, HWND lifetime, reparent rollback, and failure cleanup were reviewed
- [x] Agent-file validation is not applicable; no agent files changed

## Related issues

None.