### PR TITLE
Add WinUI focus and input integration

### DIFF
--- a/src/package-tests/WinUIConsumer/Consumer.cs
+++ b/src/package-tests/WinUIConsumer/Consumer.cs
@@ -9,5 +9,23 @@ public static class Consumer
 
     public static Type HostControlType => typeof(Windows.WinUI.XamlHostControl);
 
+    public static Type HostContextType => typeof(Windows.WinUI.XamlHostContext);
+
     public static Type ColorPickerType => typeof(Windows.WinUI.WinUIColorPicker);
+
+    public static void ConfigureColorPicker(Windows.WinUI.WinUIColorPicker colorPicker)
+    {
+        colorPicker.IsAlphaEnabled = true;
+        colorPicker.IsColorSpectrumVisible = true;
+        colorPicker.IsColorPreviewVisible = true;
+        colorPicker.IsColorSliderVisible = true;
+        colorPicker.IsColorChannelTextInputVisible = true;
+        colorPicker.IsAlphaSliderVisible = true;
+        colorPicker.IsAlphaTextInputVisible = true;
+        colorPicker.IsHexInputVisible = true;
+        colorPicker.ColorSpectrumShape = Windows.WinUI.WinUIColorSpectrumShape.Box;
+        colorPicker.ColorSpectrumComponents = Windows.WinUI.WinUIColorSpectrumComponents.HueSaturation;
+        colorPicker.Orientation = Windows.WinUI.WinUIColorPickerOrientation.Vertical;
+        colorPicker.RequestedTheme = Windows.WinUI.WinUIElementTheme.Light;
+    }
 }

--- a/src/samples/WinUI/AdvancedUsage/AdvancedUsage.csproj
+++ b/src/samples/WinUI/AdvancedUsage/AdvancedUsage.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/WinUI/AdvancedUsage/AdvancedUsageWindow.cs
+++ b/src/samples/WinUI/AdvancedUsage/AdvancedUsageWindow.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Windows;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.WinUI;
+using ThirtyTwoLayout = Windows.Layout;
+using XamlHorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment;
+using XamlVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
+
+namespace AdvancedUsage;
+
+/// <summary>
+///  Demonstrates generic and typed WinUI hosting in a thirtytwo window.
+/// </summary>
+internal sealed class AdvancedUsageWindow : MainWindow
+{
+    private readonly ButtonControl _beforeButton;
+    private readonly XamlHostControl _overviewHost;
+    private readonly WinUIColorPicker _colorPicker;
+    private readonly TextLabelControl _statusLabel;
+    private readonly ButtonControl _afterButton;
+
+    internal AdvancedUsageWindow()
+        : base(
+            bounds: new Rectangle(24, 4, 960, 720),
+            title: "thirtytwo WinUI Advanced Usage",
+            backgroundColor: Color.White)
+    {
+        ButtonControl? beforeButton = null;
+        XamlHostControl? overviewHost = null;
+        WinUIColorPicker? colorPicker = null;
+        TextLabelControl? statusLabel = null;
+        ButtonControl? afterButton = null;
+
+        try
+        {
+            beforeButton = new(
+                text: "Native control before WinUI",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this);
+            overviewHost = new(default, this, CreateOverviewContent);
+            colorPicker = new(default, this)
+            {
+                IsAlphaEnabled = true,
+                Color = Color.CornflowerBlue,
+                Orientation = WinUIColorPickerOrientation.Horizontal,
+                RequestedTheme = WinUIElementTheme.Light
+            };
+            statusLabel = new(
+                text: string.Empty,
+                parentWindow: this,
+                textColor: Color.FromArgb(31, 41, 55),
+                backgroundColor: Color.White,
+                features: Features.EnableDirect2d);
+            afterButton = new(
+                text: "Native control after WinUI",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this);
+
+            _beforeButton = beforeButton;
+            _overviewHost = overviewHost;
+            _colorPicker = colorPicker;
+            _statusLabel = statusLabel;
+            _afterButton = afterButton;
+            _statusLabel.SetFont("Consolas", 10);
+
+            _colorPicker.ColorChanged += ColorPickerColorChanged;
+            this.AddLayoutHandler(ThirtyTwoLayout.Horizontal(
+                (.0625f, ThirtyTwoLayout.Margin((16, 16, 16, 4), ThirtyTwoLayout.Fill(_beforeButton))),
+                (.4375f, ThirtyTwoLayout.Margin((16, 4, 16, 4), ThirtyTwoLayout.Fill(_overviewHost))),
+                (.4375f, ThirtyTwoLayout.Vertical(
+                    (.75f, ThirtyTwoLayout.Margin((16, 4, 8, 4), ThirtyTwoLayout.Fill(_colorPicker))),
+                    (.25f, ThirtyTwoLayout.Margin((8, 4, 16, 4), ThirtyTwoLayout.Fill(_statusLabel))))),
+                (.0625f, ThirtyTwoLayout.Margin((16, 4, 16, 16), ThirtyTwoLayout.Fill(_afterButton)))));
+            UpdateStatus(_colorPicker.Color);
+        }
+        catch
+        {
+            if (colorPicker is not null)
+            {
+                colorPicker.ColorChanged -= ColorPickerColorChanged;
+            }
+
+            afterButton?.Dispose();
+            statusLabel?.Dispose();
+            colorPicker?.Dispose();
+            overviewHost?.Dispose();
+            beforeButton?.Dispose();
+            base.Dispose(disposing: true);
+            throw;
+        }
+    }
+
+    private static UIElement CreateOverviewContent(XamlHostContext context)
+    {
+        string applicationOwnership = context.OwnsApplication ? "created" : "adopted";
+        string queueOwnership = context.OwnsDispatcherQueue ? "created" : "borrowed";
+        Border border = new()
+        {
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(8),
+            RequestedTheme = ElementTheme.Light
+        };
+        StackPanel panel = new() { Spacing = 4 };
+        panel.Children.Add(new TextBlock
+        {
+            Text = "Generic XamlHostControl",
+            FontSize = 18
+        });
+        panel.Children.Add(new TextBlock
+        {
+            Text = $"Application: {applicationOwnership}  |  Dispatcher queue: {queueOwnership}",
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap
+        });
+        TabView inputTabs = new()
+        {
+            Height = 210,
+            IsAddTabButtonVisible = false,
+            TabWidthMode = TabViewWidthMode.Equal
+        };
+        inputTabs.TabItems.Add(new TabViewItem
+        {
+            Header = "Keyboard",
+            IsClosable = false,
+            Content = CreateKeyboardInputPage()
+        });
+        inputTabs.TabItems.Add(new TabViewItem
+        {
+            Header = "Pointer",
+            IsClosable = false,
+            Content = CreatePointerInputPage()
+        });
+        inputTabs.TabItems.Add(new TabViewItem
+        {
+            Header = "Drag and drop",
+            IsClosable = false,
+            Content = CreateDragDropPage()
+        });
+        panel.Children.Add(inputTabs);
+        border.Child = panel;
+        return border;
+    }
+
+    private static UIElement CreateKeyboardInputPage()
+    {
+        Grid grid = new()
+        {
+            ColumnSpacing = 16,
+            Padding = new Thickness(8)
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition());
+        grid.ColumnDefinitions.Add(new ColumnDefinition());
+
+        TextBlock actionStatus = new()
+        {
+            Text = "Waiting for Enter, Space, or Alt+A",
+            TextWrapping = TextWrapping.Wrap
+        };
+        int buttonActivationCount = 0;
+        int acceleratorInvocationCount = 0;
+        Button actionButton = new() { Content = "Keyboard action (Alt+A)" };
+        KeyboardAccelerator accelerator = new()
+        {
+            Key = global::Windows.System.VirtualKey.A,
+            Modifiers = global::Windows.System.VirtualKeyModifiers.Menu
+        };
+        actionButton.KeyboardAccelerators.Add(accelerator);
+        actionButton.Click += (sender, eventArgs)
+            => actionStatus.Text = $"Button activations: {++buttonActivationCount}";
+        accelerator.Invoked += (sender, eventArgs) =>
+        {
+            actionStatus.Text = $"Alt+A invocations: {++acceleratorInvocationCount}";
+            eventArgs.Handled = true;
+        };
+
+        StackPanel textColumn = new() { Spacing = 8 };
+        textColumn.Children.Add(new TextBox
+        {
+            Header = "Text and IME",
+            PlaceholderText = "Type or compose text"
+        });
+        textColumn.Children.Add(actionButton);
+        textColumn.Children.Add(actionStatus);
+        grid.Children.Add(textColumn);
+
+        StackPanel controlColumn = new() { Spacing = 8 };
+        controlColumn.Children.Add(new TextBlock { Text = "Arrow-key slider" });
+        controlColumn.Children.Add(new Slider { Minimum = 0, Maximum = 100, SmallChange = 5, Value = 50 });
+        ComboBox popup = new() { Header = "Popup" };
+        popup.Items.Add("First item");
+        popup.Items.Add("Second item");
+        popup.SelectedIndex = 0;
+        controlColumn.Children.Add(popup);
+        Grid.SetColumn(controlColumn, 1);
+        grid.Children.Add(controlColumn);
+        return grid;
+    }
+
+    private static UIElement CreatePointerInputPage()
+    {
+        TextBlock pointerStatus = new()
+        {
+            Text = "Pointer idle",
+            TextWrapping = TextWrapping.Wrap,
+            HorizontalAlignment = XamlHorizontalAlignment.Center,
+            VerticalAlignment = XamlVerticalAlignment.Center
+        };
+        Border interactionSurface = new()
+        {
+            MinHeight = 150,
+            Margin = new Thickness(8),
+            Padding = new Thickness(20),
+            Background = new SolidColorBrush(Microsoft.UI.Colors.AliceBlue),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.SteelBlue),
+            BorderThickness = new Thickness(2),
+            CornerRadius = new CornerRadius(6),
+            Child = pointerStatus
+        };
+        interactionSurface.PointerPressed += (sender, eventArgs) =>
+        {
+            bool captured = interactionSurface.CapturePointer(eventArgs.Pointer);
+            string captureStatus = captured ? "captured" : "capture declined";
+            pointerStatus.Text = $"{DescribePointer(eventArgs, interactionSurface, "Pressed")}; {captureStatus}";
+            eventArgs.Handled = true;
+        };
+        interactionSurface.PointerMoved += (sender, eventArgs)
+            => pointerStatus.Text = DescribePointer(eventArgs, interactionSurface, "Moved");
+        interactionSurface.PointerReleased += (sender, eventArgs) =>
+        {
+            interactionSurface.ReleasePointerCapture(eventArgs.Pointer);
+            pointerStatus.Text = DescribePointer(eventArgs, interactionSurface, "Released");
+            eventArgs.Handled = true;
+        };
+        interactionSurface.PointerCaptureLost += (sender, eventArgs)
+            => pointerStatus.Text = DescribePointer(eventArgs, interactionSurface, "Capture released");
+        interactionSurface.PointerWheelChanged += (sender, eventArgs) =>
+        {
+            int wheelDelta = eventArgs.GetCurrentPoint(interactionSurface).Properties.MouseWheelDelta;
+            pointerStatus.Text = $"{DescribePointer(eventArgs, interactionSurface, "Wheel")}; delta {wheelDelta}";
+            eventArgs.Handled = true;
+        };
+        return interactionSurface;
+    }
+
+    private static UIElement CreateDragDropPage()
+    {
+        TextBlock dragText = new()
+        {
+            Text = "Drag source",
+            HorizontalAlignment = XamlHorizontalAlignment.Center,
+            VerticalAlignment = XamlVerticalAlignment.Center
+        };
+        Border dragSource = new()
+        {
+            Width = 260,
+            MinHeight = 112,
+            CanDrag = true,
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Honeydew),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.SeaGreen),
+            BorderThickness = new Thickness(2),
+            CornerRadius = new CornerRadius(6),
+            Child = dragText
+        };
+        dragSource.DragStarting += (sender, eventArgs) =>
+        {
+            eventArgs.Data.SetText("Text transferred from WinUI");
+            eventArgs.Data.RequestedOperation = DataPackageOperation.Copy;
+            dragText.Text = "Dragging text";
+        };
+
+        TextBlock dropText = new()
+        {
+            Text = "Drop target",
+            HorizontalAlignment = XamlHorizontalAlignment.Center,
+            VerticalAlignment = XamlVerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap
+        };
+        Border dropTarget = new()
+        {
+            Width = 260,
+            MinHeight = 112,
+            AllowDrop = true,
+            Background = new SolidColorBrush(Microsoft.UI.Colors.MistyRose),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.IndianRed),
+            BorderThickness = new Thickness(2),
+            CornerRadius = new CornerRadius(6),
+            Child = dropText
+        };
+        dropTarget.DragOver += (sender, eventArgs) =>
+        {
+            eventArgs.AcceptedOperation = DataPackageOperation.Copy;
+            eventArgs.Handled = true;
+        };
+        dropTarget.Drop += async (sender, eventArgs) =>
+        {
+            eventArgs.Handled = true;
+            try
+            {
+                dropText.Text = eventArgs.DataView.Contains(StandardDataFormats.Text)
+                    ? await eventArgs.DataView.GetTextAsync()
+                    : "Unsupported drop data";
+            }
+            catch (Exception exception)
+            {
+                dropText.Text = $"Drop failed: {exception.Message}";
+            }
+        };
+
+        StackPanel panel = new()
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 24,
+            Padding = new Thickness(12),
+            HorizontalAlignment = XamlHorizontalAlignment.Center
+        };
+        panel.Children.Add(dragSource);
+        panel.Children.Add(dropTarget);
+        return panel;
+    }
+
+    private static string DescribePointer(PointerRoutedEventArgs eventArgs, UIElement relativeTo, string action)
+    {
+        Microsoft.UI.Input.PointerPoint pointerPoint = eventArgs.GetCurrentPoint(relativeTo);
+        return $"{action}: {pointerPoint.PointerDeviceType}, X {Math.Round(pointerPoint.Position.X)}, Y {Math.Round(pointerPoint.Position.Y)}";
+    }
+
+    private void ColorPickerColorChanged(object? sender, WinUIColorChangedEventArgs eventArgs)
+        => UpdateStatus(eventArgs.NewColor);
+
+    private void UpdateStatus(Color color)
+    {
+        _statusLabel.Text = $"ARGB  {color.A}, {color.R}, {color.G}, {color.B}";
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _colorPicker.ColorChanged -= ColorPickerColorChanged;
+            _afterButton.Dispose();
+            _statusLabel.Dispose();
+            _colorPicker.Dispose();
+            _overviewHost.Dispose();
+            _beforeButton.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/samples/WinUI/AdvancedUsage/Program.cs
+++ b/src/samples/WinUI/AdvancedUsage/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows;
+
+namespace AdvancedUsage;
+
+/// <summary>
+///  Starts the AdvancedUsage WinUI hosting sample.
+/// </summary>
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+        => Application.Run(static () => new AdvancedUsageWindow());
+}

--- a/src/samples/WinUI/AdvancedUsage/app.manifest
+++ b/src/samples/WinUI/AdvancedUsage/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <maxversiontested Id="10.0.26100.0" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/samples/WinUI/BasicUsage/BasicUsage.csproj
+++ b/src/samples/WinUI/BasicUsage/BasicUsage.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/WinUI/BasicUsage/BasicUsageWindow.cs
+++ b/src/samples/WinUI/BasicUsage/BasicUsageWindow.cs
@@ -1,0 +1,342 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows;
+using Windows.WinUI;
+
+namespace BasicUsage;
+
+/// <summary>Demonstrates WinUI wrapper controls with native thirtytwo controls and layout.</summary>
+internal sealed class BasicUsageWindow : MainWindow
+{
+    private static readonly (string Label, Color Value)[] s_colorPresets =
+    [
+        ("Custom", Color.Empty),
+        ("Cornflower blue", Color.CornflowerBlue),
+        ("Crimson", Color.Crimson),
+        ("Sea green", Color.SeaGreen),
+        ("Gold", Color.Gold),
+        ("Slate blue", Color.SlateBlue)
+    ];
+
+    private static readonly (string Label, WinUIColorSpectrumShape Value)[] s_spectrumShapes =
+    [
+        ("Square", WinUIColorSpectrumShape.Box),
+        ("Circle", WinUIColorSpectrumShape.Ring)
+    ];
+
+    private static readonly (string Label, WinUIColorSpectrumComponents Value)[] s_spectrumComponents =
+    [
+        ("Hue / saturation", WinUIColorSpectrumComponents.HueSaturation),
+        ("Hue / value", WinUIColorSpectrumComponents.HueValue),
+        ("Saturation / hue", WinUIColorSpectrumComponents.SaturationHue),
+        ("Saturation / value", WinUIColorSpectrumComponents.SaturationValue),
+        ("Value / hue", WinUIColorSpectrumComponents.ValueHue),
+        ("Value / saturation", WinUIColorSpectrumComponents.ValueSaturation)
+    ];
+
+    private static readonly (string Label, WinUIColorPickerOrientation Value)[] s_orientations =
+    [
+        ("Vertical", WinUIColorPickerOrientation.Vertical),
+        ("Horizontal", WinUIColorPickerOrientation.Horizontal)
+    ];
+
+    private readonly Dictionary<ButtonControl, Action<bool>> _featureBindings = [];
+    private readonly TextLabelControl _titleLabel;
+    private readonly WinUIColorPicker _colorPicker;
+    private readonly TextLabelControl _statusLabel;
+    private readonly StaticControl[] _selectorLabels;
+    private readonly ComboBoxControl _colorPresetSelector;
+    private readonly ComboBoxControl _spectrumShapeSelector;
+    private readonly ComboBoxControl _spectrumComponentsSelector;
+    private readonly ComboBoxControl _orientationSelector;
+    private readonly ButtonControl[] _featureToggles;
+    private readonly Window[] _ownedControls;
+
+    internal BasicUsageWindow()
+        : base(
+            bounds: new Rectangle(24, 4, 960, 720),
+            title: "thirtytwo WinUI Basic Usage",
+            backgroundColor: Color.White)
+    {
+        List<Window> ownedControls = [];
+
+        try
+        {
+            _titleLabel = Track(new TextLabelControl(
+                text: "WinUI ColorPicker",
+                textColor: Color.FromArgb(17, 24, 39),
+                parentWindow: this,
+                backgroundColor: Color.White,
+                features: Features.EnableDirect2d), ownedControls);
+            _titleLabel.SetFont("Segoe UI", 20);
+
+            _colorPicker = Track(new WinUIColorPicker(default, this)
+            {
+                Color = Color.CornflowerBlue,
+                IsAlphaEnabled = true,
+                RequestedTheme = WinUIElementTheme.Light
+            }, ownedControls);
+
+            _statusLabel = Track(new TextLabelControl(
+                textColor: Color.FromArgb(31, 41, 55),
+                parentWindow: this,
+                backgroundColor: Color.FromArgb(243, 244, 246),
+                features: Features.EnableDirect2d), ownedControls);
+            _statusLabel.SetFont("Consolas", 12);
+
+            _selectorLabels =
+            [
+                Track(CreateLabel("Color preset"), ownedControls),
+                Track(CreateLabel("Spectrum shape"), ownedControls),
+                Track(CreateLabel("Spectrum axes"), ownedControls),
+                Track(CreateLabel("Editor layout"), ownedControls)
+            ];
+
+            _colorPresetSelector = Track(CreateSelector(), ownedControls);
+            _spectrumShapeSelector = Track(CreateSelector(), ownedControls);
+            _spectrumComponentsSelector = Track(CreateSelector(), ownedControls);
+            _orientationSelector = Track(CreateSelector(), ownedControls);
+
+            PopulateSelector(_colorPresetSelector, s_colorPresets.Select(item => item.Label));
+            PopulateSelector(_spectrumShapeSelector, s_spectrumShapes.Select(item => item.Label));
+            PopulateSelector(_spectrumComponentsSelector, s_spectrumComponents.Select(item => item.Label));
+            PopulateSelector(_orientationSelector, s_orientations.Select(item => item.Label));
+
+            _spectrumShapeSelector.SelectedIndex = FindIndex(
+                s_spectrumShapes,
+                _colorPicker.ColorSpectrumShape);
+            _spectrumComponentsSelector.SelectedIndex = FindIndex(
+                s_spectrumComponents,
+                _colorPicker.ColorSpectrumComponents);
+            _orientationSelector.SelectedIndex = FindIndex(
+                s_orientations,
+                _colorPicker.Orientation);
+
+            _featureToggles =
+            [
+                CreateFeatureToggle("Color spectrum", _colorPicker.IsColorSpectrumVisible,
+                    value => _colorPicker.IsColorSpectrumVisible = value, ownedControls),
+                CreateFeatureToggle("Color preview", _colorPicker.IsColorPreviewVisible,
+                    value => _colorPicker.IsColorPreviewVisible = value, ownedControls),
+                CreateFeatureToggle("Color slider", _colorPicker.IsColorSliderVisible,
+                    value => _colorPicker.IsColorSliderVisible = value, ownedControls),
+                CreateFeatureToggle("Channel inputs", _colorPicker.IsColorChannelTextInputVisible,
+                    value => _colorPicker.IsColorChannelTextInputVisible = value, ownedControls),
+                CreateFeatureToggle("Hex input", _colorPicker.IsHexInputVisible,
+                    value => _colorPicker.IsHexInputVisible = value, ownedControls),
+                CreateFeatureToggle("Alpha enabled", _colorPicker.IsAlphaEnabled,
+                    value => _colorPicker.IsAlphaEnabled = value, ownedControls),
+                CreateFeatureToggle("Alpha slider", _colorPicker.IsAlphaSliderVisible,
+                    value => _colorPicker.IsAlphaSliderVisible = value, ownedControls),
+                CreateFeatureToggle("Alpha input", _colorPicker.IsAlphaTextInputVisible,
+                    value => _colorPicker.IsAlphaTextInputVisible = value, ownedControls)
+            ];
+
+            _ownedControls = [.. ownedControls];
+            _colorPicker.ColorChanged += ColorPickerColorChanged;
+            _colorPresetSelector.SelectionChanged += ColorPresetSelectionChanged;
+            _spectrumShapeSelector.SelectionChanged += SpectrumShapeSelectionChanged;
+            _spectrumComponentsSelector.SelectionChanged += SpectrumComponentsSelectionChanged;
+            _orientationSelector.SelectionChanged += OrientationSelectionChanged;
+
+            this.AddLayoutHandler(CreateWindowLayout());
+            SynchronizeSelectedColor(_colorPicker.Color);
+        }
+        catch
+        {
+            for (int index = ownedControls.Count - 1; index >= 0; index--)
+            {
+                ownedControls[index].Dispose();
+            }
+
+            base.Dispose(disposing: true);
+            throw;
+        }
+    }
+
+    private static TControl Track<TControl>(TControl control, List<Window> ownedControls)
+        where TControl : Window
+    {
+        ownedControls.Add(control);
+        return control;
+    }
+
+    private StaticControl CreateLabel(string text)
+        => new(
+            text: text,
+            staticStyle: StaticControl.Styles.Left | StaticControl.Styles.CenterImage | StaticControl.Styles.NoPrefix,
+            parentWindow: this);
+
+    private ComboBoxControl CreateSelector()
+        => new(
+            comboBoxStyle: ComboBoxControl.Styles.DropDownList,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.VerticalScroll,
+            parentWindow: this);
+
+    private ButtonControl CreateFeatureToggle(
+        string text,
+        bool initialValue,
+        Action<bool> updateFeature,
+        List<Window> ownedControls)
+    {
+        ButtonControl toggle = Track(new ButtonControl(
+            text: text,
+            buttonStyle: ButtonControl.Styles.AutoCheckBox | ButtonControl.Styles.Left
+                | ButtonControl.Styles.VerticallyCenter,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+            parentWindow: this), ownedControls);
+        toggle.CheckState = initialValue ? ButtonCheckState.Checked : ButtonCheckState.Unchecked;
+        toggle.Click += FeatureToggleClick;
+        _featureBindings.Add(toggle, updateFeature);
+        return toggle;
+    }
+
+    private static void PopulateSelector(ComboBoxControl selector, IEnumerable<string> labels)
+    {
+        foreach (string label in labels)
+        {
+            selector.AddItem(label);
+        }
+    }
+
+    private static int FindIndex<TValue>((string Label, TValue Value)[] items, TValue value)
+        where TValue : struct, Enum
+    {
+        for (int index = 0; index < items.Length; index++)
+        {
+            if (EqualityComparer<TValue>.Default.Equals(items[index].Value, value))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private ILayoutHandler CreateWindowLayout()
+    {
+        ILayoutHandler selectorLayout = Layout.Horizontal(
+            (.25f, CreateSelectorRow(_selectorLabels[0], _colorPresetSelector)),
+            (.25f, CreateSelectorRow(_selectorLabels[1], _spectrumShapeSelector)),
+            (.25f, CreateSelectorRow(_selectorLabels[2], _spectrumComponentsSelector)),
+            (.25f, CreateSelectorRow(_selectorLabels[3], _orientationSelector)));
+
+        ILayoutHandler featureLayout = Layout.Horizontal(
+            (.25f, CreateFeatureRow(_featureToggles[0], _featureToggles[1])),
+            (.25f, CreateFeatureRow(_featureToggles[2], _featureToggles[3])),
+            (.25f, CreateFeatureRow(_featureToggles[4], _featureToggles[5])),
+            (.25f, CreateFeatureRow(_featureToggles[6], _featureToggles[7])));
+
+        ILayoutHandler settingsLayout = Layout.Horizontal(
+            (.5f, selectorLayout),
+            (.5f, featureLayout));
+
+        ILayoutHandler contentLayout = Layout.Vertical(
+            (.375f, Layout.Margin((16, 0, 8, 0), settingsLayout)),
+            (.625f, Layout.Margin((8, 0, 16, 0), Layout.Fill(_colorPicker))));
+
+        return Layout.Horizontal(
+            (.0625f, Layout.Margin((16, 4, 16, 0), Layout.Fill(_titleLabel))),
+            (.875f, contentLayout),
+            (.0625f, Layout.Margin((16, 4, 16, 8), Layout.Fill(_statusLabel))));
+    }
+
+    private static ILayoutHandler CreateSelectorRow(StaticControl label, ComboBoxControl selector)
+        => Layout.Vertical(
+            (.375f, Layout.Margin((0, 8, 8, 8), Layout.FixedPercent(1f, .5f, Layout.Fill(label)))),
+            (.625f, Layout.Margin((8, 8, 0, 8), Layout.FixedPercent(1f, .5f, Layout.Fill(selector)))));
+
+    private static ILayoutHandler CreateFeatureRow(ButtonControl left, ButtonControl right)
+        => Layout.Vertical(
+            (.5f, Layout.Margin((0, 8, 8, 8), Layout.Fill(left))),
+            (.5f, Layout.Margin((8, 8, 0, 8), Layout.Fill(right))));
+
+    private void ColorPresetSelectionChanged(object? sender, EventArgs eventArgs)
+    {
+        int selectedIndex = _colorPresetSelector.SelectedIndex;
+        if (selectedIndex > 0)
+        {
+            _colorPicker.Color = s_colorPresets[selectedIndex].Value;
+        }
+    }
+
+    private void SpectrumShapeSelectionChanged(object? sender, EventArgs eventArgs)
+    {
+        int selectedIndex = _spectrumShapeSelector.SelectedIndex;
+        if (selectedIndex >= 0)
+        {
+            _colorPicker.ColorSpectrumShape = s_spectrumShapes[selectedIndex].Value;
+        }
+    }
+
+    private void SpectrumComponentsSelectionChanged(object? sender, EventArgs eventArgs)
+    {
+        int selectedIndex = _spectrumComponentsSelector.SelectedIndex;
+        if (selectedIndex >= 0)
+        {
+            _colorPicker.ColorSpectrumComponents = s_spectrumComponents[selectedIndex].Value;
+        }
+    }
+
+    private void OrientationSelectionChanged(object? sender, EventArgs eventArgs)
+    {
+        int selectedIndex = _orientationSelector.SelectedIndex;
+        if (selectedIndex >= 0)
+        {
+            _colorPicker.Orientation = s_orientations[selectedIndex].Value;
+        }
+    }
+
+    private void FeatureToggleClick(object? sender, EventArgs eventArgs)
+    {
+        if (sender is ButtonControl toggle && _featureBindings.TryGetValue(toggle, out Action<bool>? updateFeature))
+        {
+            updateFeature(toggle.CheckState == ButtonCheckState.Checked);
+        }
+    }
+
+    private void ColorPickerColorChanged(object? sender, WinUIColorChangedEventArgs eventArgs)
+        => SynchronizeSelectedColor(eventArgs.NewColor);
+
+    private void SynchronizeSelectedColor(Color color)
+    {
+        int selectedIndex = 0;
+        for (int index = 1; index < s_colorPresets.Length; index++)
+        {
+            if (s_colorPresets[index].Value.ToArgb() == color.ToArgb())
+            {
+                selectedIndex = index;
+                break;
+            }
+        }
+
+        _colorPresetSelector.SelectedIndex = selectedIndex;
+        _statusLabel.Text = $"Selected  #{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}    ARGB  {color.A}, {color.R}, {color.G}, {color.B}";
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _colorPicker.ColorChanged -= ColorPickerColorChanged;
+            _colorPresetSelector.SelectionChanged -= ColorPresetSelectionChanged;
+            _spectrumShapeSelector.SelectionChanged -= SpectrumShapeSelectionChanged;
+            _spectrumComponentsSelector.SelectionChanged -= SpectrumComponentsSelectionChanged;
+            _orientationSelector.SelectionChanged -= OrientationSelectionChanged;
+            foreach (ButtonControl toggle in _featureToggles)
+            {
+                toggle.Click -= FeatureToggleClick;
+            }
+
+            _featureBindings.Clear();
+            for (int index = _ownedControls.Length - 1; index >= 0; index--)
+            {
+                _ownedControls[index].Dispose();
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/samples/WinUI/BasicUsage/Program.cs
+++ b/src/samples/WinUI/BasicUsage/Program.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows;
+
+namespace BasicUsage;
+
+/// <summary>Starts the wrapper-only WinUI hosting sample.</summary>
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+        => Application.Run(static () => new BasicUsageWindow());
+}

--- a/src/samples/WinUI/BasicUsage/app.manifest
+++ b/src/samples/WinUI/BasicUsage/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <maxversiontested Id="10.0.26100.0" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/thirtytwo.winui/ContentPreTranslateMessageFilter.cs
+++ b/src/thirtytwo.winui/ContentPreTranslateMessageFilter.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Gives the Windows App SDK the first opportunity to preprocess messages retrieved by the UI thread.
+/// </summary>
+internal sealed unsafe partial class ContentPreTranslateMessageFilter : IMessageFilter
+{
+    /// <inheritdoc/>
+    public bool PreFilterMessage(ref MSG message)
+    {
+        bool isTabKeyDown = message.message == Interop.WM_KEYDOWN
+            && (ushort)message.wParam.Value == (ushort)VirtualKey.Tab;
+
+        bool handledByXaml;
+        fixed (MSG* messagePointer = &message)
+        {
+            handledByXaml = ContentPreTranslateMessage(messagePointer) != 0;
+        }
+
+        if (!isTabKeyDown)
+        {
+            return handledByXaml;
+        }
+
+        bool targetsXamlHost = Window.FromHandle(message.hwnd, walkParents: true) is XamlHostControl;
+        if (targetsXamlHost && handledByXaml)
+        {
+            return true;
+        }
+
+        bool movedFocus = XamlFocusNavigation.TryMoveFocus(
+            message.hwnd,
+            forward: !XamlFocusNavigation.IsShiftPressed());
+        return movedFocus || handledByXaml;
+    }
+
+    // Native BOOL is a 32-bit integer; LibraryImport cannot generate the projected BOOL wrapper in this WinRT assembly.
+    [LibraryImport("Microsoft.UI.Windowing.Core.dll", EntryPoint = "ContentPreTranslateMessage")]
+    private static partial int ContentPreTranslateMessage(MSG* message);
+}

--- a/src/thirtytwo.winui/WinUIColorPicker.cs
+++ b/src/thirtytwo.winui/WinUIColorPicker.cs
@@ -8,6 +8,10 @@ using System.Runtime.ExceptionServices;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Win32.Foundation;
 using WinUIColor = Windows.UI.Color;
+using XamlColorSpectrumComponents = Microsoft.UI.Xaml.Controls.ColorSpectrumComponents;
+using XamlColorSpectrumShape = Microsoft.UI.Xaml.Controls.ColorSpectrumShape;
+using XamlElementTheme = Microsoft.UI.Xaml.ElementTheme;
+using XamlOrientation = Microsoft.UI.Xaml.Controls.Orientation;
 
 namespace Windows.WinUI;
 
@@ -45,7 +49,7 @@ public sealed class WinUIColorPicker : XamlHostControl
     /// <remarks>
     ///  <para>
     ///   The typed wrapper fixes its content during construction. Assigning another element would detach the picker
-    ///   controlled by <see cref="Color"/> and <see cref="IsAlphaEnabled"/> and is therefore rejected.
+    ///   controlled by this wrapper and is therefore rejected.
     ///  </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException"><paramref name="value"/> is not the hosted color picker.</exception>
@@ -94,6 +98,221 @@ public sealed class WinUIColorPicker : XamlHostControl
         {
             VerifyUsable();
             _colorPicker!.IsAlphaEnabled = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the color spectrum is visible.</summary>
+    public bool IsColorSpectrumVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsColorSpectrumVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsColorSpectrumVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the color preview bar is visible.</summary>
+    public bool IsColorPreviewVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsColorPreviewVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsColorPreviewVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the color-value slider is visible.</summary>
+    public bool IsColorSliderVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsColorSliderVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsColorSliderVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the color-channel text inputs are visible.</summary>
+    public bool IsColorChannelTextInputVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsColorChannelTextInputVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsColorChannelTextInputVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the alpha slider is visible when alpha is enabled.</summary>
+    public bool IsAlphaSliderVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsAlphaSliderVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsAlphaSliderVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the alpha text input is visible when alpha is enabled.</summary>
+    public bool IsAlphaTextInputVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsAlphaTextInputVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsAlphaTextInputVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets whether the hexadecimal color input is visible.</summary>
+    public bool IsHexInputVisible
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.IsHexInputVisible;
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.IsHexInputVisible = value;
+        }
+    }
+
+    /// <summary>Gets or sets the shape of the color spectrum.</summary>
+    public WinUIColorSpectrumShape ColorSpectrumShape
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.ColorSpectrumShape switch
+            {
+                XamlColorSpectrumShape.Box => WinUIColorSpectrumShape.Box,
+                XamlColorSpectrumShape.Ring => WinUIColorSpectrumShape.Ring,
+                _ => throw new InvalidOperationException("The color picker returned an unknown spectrum shape.")
+            };
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.ColorSpectrumShape = value switch
+            {
+                WinUIColorSpectrumShape.Box => XamlColorSpectrumShape.Box,
+                WinUIColorSpectrumShape.Ring => XamlColorSpectrumShape.Ring,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown color spectrum shape.")
+            };
+        }
+    }
+
+    /// <summary>Gets or sets how HSV components map to the color spectrum axes.</summary>
+    public WinUIColorSpectrumComponents ColorSpectrumComponents
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.ColorSpectrumComponents switch
+            {
+                XamlColorSpectrumComponents.HueSaturation => WinUIColorSpectrumComponents.HueSaturation,
+                XamlColorSpectrumComponents.HueValue => WinUIColorSpectrumComponents.HueValue,
+                XamlColorSpectrumComponents.SaturationHue => WinUIColorSpectrumComponents.SaturationHue,
+                XamlColorSpectrumComponents.SaturationValue => WinUIColorSpectrumComponents.SaturationValue,
+                XamlColorSpectrumComponents.ValueHue => WinUIColorSpectrumComponents.ValueHue,
+                XamlColorSpectrumComponents.ValueSaturation => WinUIColorSpectrumComponents.ValueSaturation,
+                _ => throw new InvalidOperationException("The color picker returned an unknown spectrum-component mapping.")
+            };
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.ColorSpectrumComponents = value switch
+            {
+                WinUIColorSpectrumComponents.HueSaturation => XamlColorSpectrumComponents.HueSaturation,
+                WinUIColorSpectrumComponents.HueValue => XamlColorSpectrumComponents.HueValue,
+                WinUIColorSpectrumComponents.SaturationHue => XamlColorSpectrumComponents.SaturationHue,
+                WinUIColorSpectrumComponents.SaturationValue => XamlColorSpectrumComponents.SaturationValue,
+                WinUIColorSpectrumComponents.ValueHue => XamlColorSpectrumComponents.ValueHue,
+                WinUIColorSpectrumComponents.ValueSaturation => XamlColorSpectrumComponents.ValueSaturation,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown color spectrum-component mapping.")
+            };
+        }
+    }
+
+    /// <summary>Gets or sets the orientation of the color picker's editing controls.</summary>
+    public WinUIColorPickerOrientation Orientation
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.Orientation switch
+            {
+                XamlOrientation.Vertical => WinUIColorPickerOrientation.Vertical,
+                XamlOrientation.Horizontal => WinUIColorPickerOrientation.Horizontal,
+                _ => throw new InvalidOperationException("The color picker returned an unknown orientation.")
+            };
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.Orientation = value switch
+            {
+                WinUIColorPickerOrientation.Vertical => XamlOrientation.Vertical,
+                WinUIColorPickerOrientation.Horizontal => XamlOrientation.Horizontal,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown color picker orientation.")
+            };
+        }
+    }
+
+    /// <summary>Gets or sets the theme requested for the hosted color picker.</summary>
+    public WinUIElementTheme RequestedTheme
+    {
+        get
+        {
+            VerifyUsable();
+            return _colorPicker!.RequestedTheme switch
+            {
+                XamlElementTheme.Default => WinUIElementTheme.Default,
+                XamlElementTheme.Light => WinUIElementTheme.Light,
+                XamlElementTheme.Dark => WinUIElementTheme.Dark,
+                _ => throw new InvalidOperationException("The color picker returned an unknown requested theme.")
+            };
+        }
+        set
+        {
+            VerifyUsable();
+            _colorPicker!.RequestedTheme = value switch
+            {
+                WinUIElementTheme.Default => XamlElementTheme.Default,
+                WinUIElementTheme.Light => XamlElementTheme.Light,
+                WinUIElementTheme.Dark => XamlElementTheme.Dark,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown WinUI element theme.")
+            };
         }
     }
 

--- a/src/thirtytwo.winui/WinUIColorPickerOrientation.cs
+++ b/src/thirtytwo.winui/WinUIColorPickerOrientation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>Specifies how a WinUI color picker arranges its editing controls.</summary>
+public enum WinUIColorPickerOrientation
+{
+    /// <summary>Places editing controls below the color spectrum.</summary>
+    Vertical,
+
+    /// <summary>Places editing controls beside the color spectrum.</summary>
+    Horizontal
+}

--- a/src/thirtytwo.winui/WinUIColorSpectrumComponents.cs
+++ b/src/thirtytwo.winui/WinUIColorSpectrumComponents.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>Specifies how HSV components map to a WinUI color picker's spectrum axes.</summary>
+public enum WinUIColorSpectrumComponents
+{
+    /// <summary>Maps hue to the horizontal axis and saturation to the vertical axis.</summary>
+    HueSaturation,
+
+    /// <summary>Maps hue to the horizontal axis and value to the vertical axis.</summary>
+    HueValue,
+
+    /// <summary>Maps saturation to the horizontal axis and hue to the vertical axis.</summary>
+    SaturationHue,
+
+    /// <summary>Maps saturation to the horizontal axis and value to the vertical axis.</summary>
+    SaturationValue,
+
+    /// <summary>Maps value to the horizontal axis and hue to the vertical axis.</summary>
+    ValueHue,
+
+    /// <summary>Maps value to the horizontal axis and saturation to the vertical axis.</summary>
+    ValueSaturation
+}

--- a/src/thirtytwo.winui/WinUIColorSpectrumShape.cs
+++ b/src/thirtytwo.winui/WinUIColorSpectrumShape.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>Specifies the shape of a WinUI color picker's color spectrum.</summary>
+public enum WinUIColorSpectrumShape
+{
+    /// <summary>Displays the color spectrum as a square.</summary>
+    Box,
+
+    /// <summary>Displays the color spectrum as a circle.</summary>
+    Ring
+}

--- a/src/thirtytwo.winui/WinUIElementTheme.cs
+++ b/src/thirtytwo.winui/WinUIElementTheme.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.WinUI;
+
+/// <summary>Specifies the theme requested for a hosted WinUI element.</summary>
+public enum WinUIElementTheme
+{
+    /// <summary>Uses the theme inherited from the WinUI application.</summary>
+    Default,
+
+    /// <summary>Uses the light theme.</summary>
+    Light,
+
+    /// <summary>Uses the dark theme.</summary>
+    Dark
+}

--- a/src/thirtytwo.winui/XamlFocusNavigation.cs
+++ b/src/thirtytwo.winui/XamlFocusNavigation.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Windows.WinUI;
+
+/// <summary>
+///  Coordinates tab direction and native sibling traversal at a XAML island boundary.
+/// </summary>
+internal static class XamlFocusNavigation
+{
+    [ThreadStatic]
+    private static bool? t_pendingForward;
+
+    internal static bool EntryIsForward
+        => t_pendingForward ?? !IsShiftPressed();
+
+    internal static bool IsShiftPressed()
+        => PInvoke.GetKeyState((int)VirtualKey.Shift) < 0;
+
+    internal static bool TryMoveFocus(HWND current, bool forward)
+    {
+        Window? currentWindow = Window.FromHandle(current, walkParents: true);
+        if (currentWindow is null || currentWindow.Handle.IsNull)
+        {
+            return false;
+        }
+
+        HWND parent = PInvoke.GetParent(currentWindow.Handle);
+        if (parent.IsNull)
+        {
+            return false;
+        }
+
+        HWND next = PInvoke.GetNextDlgTabItem(parent, currentWindow.Handle, !forward);
+        if (next.IsNull || next == currentWindow.Handle)
+        {
+            return false;
+        }
+
+        HWND previousFocus = PInvoke.GetFocus();
+        bool? previousPendingForward = t_pendingForward;
+        t_pendingForward = forward;
+        try
+        {
+            next.SetFocus();
+            return PInvoke.GetFocus() != previousFocus;
+        }
+        finally
+        {
+            t_pendingForward = previousPendingForward;
+        }
+    }
+}

--- a/src/thirtytwo.winui/XamlHostContext.cs
+++ b/src/thirtytwo.winui/XamlHostContext.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Dispatching;
+
+namespace Windows.WinUI;
+
+/// <summary>Provides WinUI services through the environment lease owned by a XAML host control.</summary>
+/// <remarks>
+///  <para>
+///   This context is not independently disposable. Its properties remain available while the host that supplied it is
+///   active and throw <see cref="ObjectDisposedException"/> after that host is disposed.
+///  </para>
+/// </remarks>
+public sealed class XamlHostContext
+{
+    private readonly XamlHostEnvironment _environment;
+
+    internal XamlHostContext(XamlHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    /// <summary>Gets the process WinUI application.</summary>
+    public Microsoft.UI.Xaml.Application Application => _environment.Application;
+
+    /// <summary>Gets the current thread's Windows App SDK dispatcher queue.</summary>
+    public DispatcherQueue DispatcherQueue => _environment.DispatcherQueue;
+
+    /// <summary>Gets the application-wide metadata provider registry.</summary>
+    public XamlMetadataProviderRegistry MetadataProviders => _environment.MetadataProviders;
+
+    /// <summary>Gets the application-wide resource dictionary registry.</summary>
+    public XamlResourceDictionaryRegistry ResourceDictionaries => _environment.ResourceDictionaries;
+
+    /// <summary>Gets whether the host environment created the process WinUI application.</summary>
+    public bool OwnsApplication => _environment.OwnsApplication;
+
+    /// <summary>Gets whether the host environment created the current thread's dispatcher queue.</summary>
+    public bool OwnsDispatcherQueue => _environment.OwnsDispatcherQueue;
+}

--- a/src/thirtytwo.winui/XamlHostControl.cs
+++ b/src/thirtytwo.winui/XamlHostControl.cs
@@ -41,9 +41,11 @@ public unsafe partial class XamlHostControl : CustomControl
         backgroundBrush: HBRUSH.Invalid);
 
     private readonly XamlThreadAffinity _affinity = new();
+    private XamlHostContext? _context;
     private XamlHostEnvironment? _environment;
     private DesktopWindowXamlSource? _xamlSource;
     private ShutdownRegistration _shutdownRegistration;
+    private Guid _reportedFocusRequestId;
     private bool _xamlStateDisposed;
 
     /// <summary>
@@ -54,13 +56,15 @@ public unsafe partial class XamlHostControl : CustomControl
     public XamlHostControl(Rectangle bounds, Window parentWindow)
         : base(
             bounds,
-            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.ClipChildren | WindowStyles.ClipSiblings,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop
+                | WindowStyles.ClipChildren | WindowStyles.ClipSiblings,
             parentWindow: ValidateParent(parentWindow),
             windowClass: s_windowClass)
     {
         try
         {
             _environment = XamlHostEnvironment.Acquire();
+            _context = new(_environment);
             _xamlSource = CreateXamlSource();
             _shutdownRegistration = Dispatcher.RegisterShutdownCallback(Dispose);
         }
@@ -91,6 +95,41 @@ public unsafe partial class XamlHostControl : CustomControl
         }
     }
 
+    /// <summary>
+    ///  Creates a WinUI host and passes its non-disposable context to the content factory after initialization.
+    /// </summary>
+    /// <param name="bounds">The host bounds in parent-client pixels.</param>
+    /// <param name="parentWindow">The managed parent window.</param>
+    /// <param name="contentFactory">Creates content using services owned by this host.</param>
+    public XamlHostControl(
+        Rectangle bounds,
+        Window parentWindow,
+        Func<XamlHostContext, UIElement> contentFactory)
+        : this(bounds, parentWindow)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(contentFactory);
+            Content = contentFactory(Context)
+                ?? throw new InvalidOperationException("The WinUI content factory returned null.");
+        }
+        catch (Exception constructionFailure)
+        {
+            ThrowAfterFailedConstruction(constructionFailure);
+        }
+    }
+
+    /// <summary>Gets WinUI services backed by the environment lease owned by this host.</summary>
+    /// <exception cref="ObjectDisposedException">The host or its parent window has been destroyed.</exception>
+    public XamlHostContext Context
+    {
+        get
+        {
+            _ = GetXamlSource();
+            return _context ?? throw new ObjectDisposedException(nameof(XamlHostControl));
+        }
+    }
+
     /// <summary>Gets or sets the WinUI element displayed by this host.</summary>
     /// <remarks>
     ///  <para>
@@ -113,6 +152,9 @@ public unsafe partial class XamlHostControl : CustomControl
             xamlSource.Content = value;
         }
     }
+
+    /// <summary>Occurs when focus enters the hosted XAML content.</summary>
+    public event EventHandler? XamlGotFocus;
 
     /// <summary>Changes the managed host window's parent and reattaches its content through a new XAML source.</summary>
     /// <param name="parentWindow">The new parent window on the host's owner thread.</param>
@@ -232,16 +274,22 @@ public unsafe partial class XamlHostControl : CustomControl
     /// <inheritdoc/>
     protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
     {
-        if (message == MessageType.Destroy)
+        switch (message)
         {
-            try
-            {
-                DisposeXamlState();
-            }
-            catch (Exception exception)
-            {
-                ReportNativeCallbackFailure("Destroy", exception);
-            }
+            case MessageType.SetFocus:
+                NavigateIntoXaml();
+                return (LRESULT)0;
+            case MessageType.Destroy:
+                try
+                {
+                    DisposeXamlState();
+                }
+                catch (Exception exception)
+                {
+                    ReportNativeCallbackFailure("Destroy", exception);
+                }
+
+                break;
         }
 
         return base.WindowProcedure(window, message, wParam, lParam);
@@ -357,12 +405,16 @@ public unsafe partial class XamlHostControl : CustomControl
         {
             xamlSource.Initialize(Win32Interop.GetWindowIdFromWindow((nint)Handle.Value));
             xamlSource.ShouldConstrainPopupsToWorkArea = true;
+            xamlSource.GotFocus += XamlSourceGotFocus;
+            xamlSource.TakeFocusRequested += XamlSourceTakeFocusRequested;
             ResizeSiteBridge(xamlSource, this.GetClientRectangle().Size);
             xamlSource.Content = content;
             return xamlSource;
         }
         catch
         {
+            xamlSource.GotFocus -= XamlSourceGotFocus;
+            xamlSource.TakeFocusRequested -= XamlSourceTakeFocusRequested;
             xamlSource.Dispose();
             throw;
         }
@@ -373,6 +425,9 @@ public unsafe partial class XamlHostControl : CustomControl
         DesktopWindowXamlSource xamlSource = GetXamlSource();
         content = xamlSource.Content;
         _xamlSource = null;
+        _reportedFocusRequestId = Guid.Empty;
+        xamlSource.GotFocus -= XamlSourceGotFocus;
+        xamlSource.TakeFocusRequested -= XamlSourceTakeFocusRequested;
         try
         {
             xamlSource.Content = null;
@@ -402,8 +457,10 @@ public unsafe partial class XamlHostControl : CustomControl
         XamlHostEnvironment? environment = _environment;
         ShutdownRegistration shutdownRegistration = _shutdownRegistration;
         _xamlSource = null;
+        _context = null;
         _environment = null;
         _shutdownRegistration = default;
+        _reportedFocusRequestId = Guid.Empty;
 
         try
         {
@@ -415,6 +472,8 @@ public unsafe partial class XamlHostControl : CustomControl
             {
                 if (xamlSource is not null)
                 {
+                    xamlSource.GotFocus -= XamlSourceGotFocus;
+                    xamlSource.TakeFocusRequested -= XamlSourceTakeFocusRequested;
                     try
                     {
                         xamlSource.Content = null;
@@ -429,6 +488,84 @@ public unsafe partial class XamlHostControl : CustomControl
             {
                 environment?.Dispose();
             }
+        }
+    }
+
+    private void NavigateIntoXaml()
+    {
+        DesktopWindowXamlSource? xamlSource = _xamlSource;
+        if (xamlSource is null)
+        {
+            return;
+        }
+
+        bool forward = XamlFocusNavigation.EntryIsForward;
+        try
+        {
+            XamlSourceFocusNavigationRequest request = new(
+                forward ? XamlSourceFocusNavigationReason.First : XamlSourceFocusNavigationReason.Last);
+            XamlSourceFocusNavigationResult result = xamlSource.NavigateFocus(request);
+            if (result.WasFocusMoved)
+            {
+                ReportXamlGotFocus(request.CorrelationId);
+            }
+            else
+            {
+                _ = XamlFocusNavigation.TryMoveFocus(Handle, forward);
+            }
+        }
+        catch (Exception exception)
+        {
+            ReportNativeCallbackFailure("NavigateFocus", exception);
+        }
+    }
+
+    private void XamlSourceGotFocus(
+        DesktopWindowXamlSource sender,
+        DesktopWindowXamlSourceGotFocusEventArgs eventArgs)
+        => ReportXamlGotFocus(eventArgs.Request.CorrelationId);
+
+    private void ReportXamlGotFocus(Guid correlationId)
+    {
+        if (correlationId != Guid.Empty && correlationId == _reportedFocusRequestId)
+        {
+            return;
+        }
+
+        _reportedFocusRequestId = correlationId;
+        try
+        {
+            XamlGotFocus?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception exception)
+        {
+            ReportNativeCallbackFailure("XamlGotFocus", exception);
+        }
+    }
+
+    private void XamlSourceTakeFocusRequested(
+        DesktopWindowXamlSource sender,
+        DesktopWindowXamlSourceTakeFocusRequestedEventArgs eventArgs)
+    {
+        bool? forward = eventArgs.Request.Reason switch
+        {
+            XamlSourceFocusNavigationReason.First => true,
+            XamlSourceFocusNavigationReason.Last => false,
+            _ => null
+        };
+
+        if (!forward.HasValue)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = XamlFocusNavigation.TryMoveFocus(Handle, forward.Value);
+        }
+        catch (Exception exception)
+        {
+            ReportNativeCallbackFailure("TakeFocusRequested", exception);
         }
     }
 }

--- a/src/thirtytwo.winui/XamlHostEnvironment.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironment.cs
@@ -11,6 +11,11 @@ namespace Windows.WinUI;
 /// </summary>
 /// <remarks>
 ///  <para>
+///   <see cref="XamlHostControl"/> and typed wrappers acquire their own environment leases. Applications using those
+///   controls do not need to acquire another lease. Acquire directly only when WinUI services are needed independently
+///   of a host control.
+///  </para>
+///  <para>
 ///   Acquire the environment from the window factory passed to <see cref="Application.Run(Window, bool)"/>, typically
 ///   at the start of the primary window's construction. At that point the thirtytwo dispatcher is active on the STA
 ///   thread. Acquire it before creating or loading WinUI content and before registering metadata providers or resource

--- a/src/thirtytwo.winui/XamlHostEnvironmentState.cs
+++ b/src/thirtytwo.winui/XamlHostEnvironmentState.cs
@@ -13,6 +13,7 @@ namespace Windows.WinUI;
 internal sealed class XamlHostEnvironmentState
 {
     private readonly XamlThreadAffinity _affinity = new();
+    private readonly MessageFilterRegistration _messageFilterRegistration;
     private readonly DispatcherQueueController? _queueController;
     private readonly WindowsXamlManager _xamlManager;
     private ShutdownRegistration _shutdownRegistration;
@@ -25,6 +26,7 @@ internal sealed class XamlHostEnvironmentState
         WindowsXamlManager xamlManager,
         Microsoft.UI.Xaml.Application application,
         IXamlHostApplication hostApplication,
+        MessageFilterRegistration messageFilterRegistration,
         bool ownsApplication)
     {
         Dispatcher = dispatcher;
@@ -33,6 +35,7 @@ internal sealed class XamlHostEnvironmentState
         _xamlManager = xamlManager;
         Application = application;
         HostApplication = hostApplication;
+        _messageFilterRegistration = messageFilterRegistration;
         OwnsApplication = ownsApplication;
         LeaseCount = 1;
     }
@@ -88,6 +91,7 @@ internal sealed class XamlHostEnvironmentState
             ?? throw CreateThreadValidationException(nativeThreadId);
 
         DispatcherQueueController? queueController = null;
+        MessageFilterRegistration messageFilterRegistration = default;
         WindowsXamlManager? xamlManager = null;
         Microsoft.UI.Xaml.Application? preexistingApplication = Microsoft.UI.Xaml.Application.Current;
         XamlApplication? createdApplication = null;
@@ -179,7 +183,8 @@ internal sealed class XamlHostEnvironmentState
                     nativeThreadId);
             }
 
-                XamlHostEnvironment.RetainProcessApplication(application);
+            XamlHostEnvironment.RetainProcessApplication(application);
+            messageFilterRegistration = Windows.Application.AddMessageFilter(new ContentPreTranslateMessageFilter());
 
             XamlHostEnvironmentState state = new(
                 dispatcher,
@@ -188,9 +193,11 @@ internal sealed class XamlHostEnvironmentState
                 xamlManager,
                 application,
                 hostApplication,
+                messageFilterRegistration,
                 ownsApplication);
             state._shutdownRegistration = dispatcher.RegisterShutdownCallback(
                 () => XamlHostEnvironment.Shutdown(state));
+            messageFilterRegistration = default;
             queueController = null;
             xamlManager = null;
             XamlHostEventSource.Log.EnvironmentCreated(
@@ -210,6 +217,7 @@ internal sealed class XamlHostEnvironmentState
                 (int)stage,
                 exception.HResult,
                 exception.GetType().FullName ?? exception.GetType().Name);
+            messageFilterRegistration.Dispose();
             xamlManager?.Dispose();
             queueController?.ShutdownQueue();
             throw;
@@ -255,18 +263,25 @@ internal sealed class XamlHostEnvironmentState
         LeaseCount = 0;
         try
         {
-            _xamlManager.Dispose();
+            _messageFilterRegistration.Dispose();
         }
         finally
         {
             try
             {
-                _queueController?.ShutdownQueue();
+                _xamlManager.Dispose();
             }
             finally
             {
-                _shutdownRegistration.Dispose();
-                XamlHostEventSource.Log.EnvironmentStopped(OwnerNativeThreadId);
+                try
+                {
+                    _queueController?.ShutdownQueue();
+                }
+                finally
+                {
+                    _shutdownRegistration.Dispose();
+                    XamlHostEventSource.Log.EnvironmentStopped(OwnerNativeThreadId);
+                }
             }
         }
     }

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentScenario.cs
@@ -23,5 +23,7 @@ internal enum EnvironmentScenario
     HostReparent,
     HostReplacement,
     HostPopupClose,
-    HostShutdownCleanup
+    HostShutdownCleanup,
+    FocusTraversal,
+    InputSemantics
 }

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -31,6 +31,8 @@ internal sealed class EnvironmentWindow : Window
     private XamlHostControl? _popupHost;
     private Window? _shutdownParent;
     private XamlHostControl? _shutdownHost;
+    private FocusScenario? _focusScenario;
+    private InputScenario? _inputScenario;
 
     internal EnvironmentWindow(EnvironmentScenario scenario, ScenarioReporter reporter)
         : base(DefaultBounds, text: "ThirtyTwo WinUI Environment Host")
@@ -42,9 +44,9 @@ internal sealed class EnvironmentWindow : Window
         if (!Dispatcher.TryPost(() =>
             {
                 ExecuteAfterShow(scenario);
-                if (!PInvoke.DestroyWindow(Handle))
+                if (scenario is not (EnvironmentScenario.FocusTraversal or EnvironmentScenario.InputSemantics))
                 {
-                    throw new Win32Exception(Marshal.GetLastPInvokeError());
+                    DestroyWindow();
                 }
             }))
         {
@@ -137,6 +139,8 @@ internal sealed class EnvironmentWindow : Window
             case EnvironmentScenario.HostLayout:
             case EnvironmentScenario.HostPopupClose:
             case EnvironmentScenario.HostShutdownCleanup:
+            case EnvironmentScenario.FocusTraversal:
+            case EnvironmentScenario.InputSemantics:
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(scenario));
@@ -192,20 +196,66 @@ internal sealed class EnvironmentWindow : Window
             case EnvironmentScenario.HostShutdownCleanup:
                 VerifyHostShutdownCleanup();
                 break;
+            case EnvironmentScenario.FocusTraversal:
+                _focusScenario = new(this, _reporter);
+                if (!Dispatcher.TryPost(() => _focusScenario.Start(DestroyWindow)))
+                {
+                    throw new InvalidOperationException("Failed to schedule focus traversal after XAML content loading.");
+                }
+
+                break;
+            case EnvironmentScenario.InputSemantics:
+                _inputScenario = new(this, _reporter);
+                if (!Dispatcher.TryPost(() => _inputScenario.Start(DestroyWindow)))
+                {
+                    throw new InvalidOperationException("Failed to schedule input validation after XAML content loading.");
+                }
+
+                break;
+        }
+    }
+
+    private void DestroyWindow()
+    {
+        if (!PInvoke.DestroyWindow(Handle))
+        {
+            throw new Win32Exception(Marshal.GetLastPInvokeError());
         }
     }
 
     private void VerifyHostBasic()
     {
         bool contentFactoryCalled = false;
-        _xamlHost = new(new Rectangle(20, 30, 320, 240), this, () =>
+        XamlHostContext? hostContext = null;
+        _xamlHost = new(new Rectangle(20, 30, 320, 240), this, context =>
         {
             Ensure(XamlHostEnvironment.Current?.LeaseCount == 1, "The content factory ran before host initialization.");
+            hostContext = context;
             contentFactoryCalled = true;
             return new Grid();
         });
 
         Ensure(contentFactoryCalled, "The host content factory did not run.");
+        XamlHostContext createdContext = hostContext
+            ?? throw new InvalidOperationException("The content factory did not receive the host context.");
+        Ensure(ReferenceEquals(_xamlHost.Context, createdContext), "The content factory received a different host context.");
+        Ensure(
+            ReferenceEquals(createdContext.Application, Microsoft.UI.Xaml.Application.Current),
+            "The host context returned the wrong process application.");
+        XamlHostEnvironmentInfo environmentInfo = XamlHostEnvironment.Current
+            ?? throw new InvalidOperationException("The host context has no active environment.");
+        Ensure(createdContext.OwnsApplication == environmentInfo.OwnsApplication, "The host context returned the wrong application ownership.");
+        Ensure(createdContext.OwnsDispatcherQueue == environmentInfo.OwnsDispatcherQueue, "The host context returned the wrong queue ownership.");
+        Ensure(
+            ReferenceEquals(createdContext.DispatcherQueue, DispatcherQueue.GetForCurrentThread()),
+            "The host context returned the wrong dispatcher queue.");
+        IXamlHostApplication hostApplication = (IXamlHostApplication)createdContext.Application;
+        Ensure(
+            ReferenceEquals(createdContext.MetadataProviders, hostApplication.MetadataProviders),
+            "The host context returned the wrong metadata registry.");
+        Ensure(
+            ReferenceEquals(createdContext.ResourceDictionaries, hostApplication.ResourceDictionaries),
+            "The host context returned the wrong resource registry.");
         Ensure(_xamlHost.Content is Grid, "The host did not retain its factory content.");
         Grid replacement = new();
         _xamlHost.Content = replacement;
@@ -214,6 +264,33 @@ internal sealed class EnvironmentWindow : Window
         Ensure(_xamlHost.Content is null, "The host did not clear its content.");
         _xamlHost.Content = replacement;
         Ensure(ReferenceEquals(Window.FromHandle(_xamlHost), _xamlHost), "The managed host HWND was not registered.");
+
+        XamlHostContext? disposedContext = null;
+        using (XamlHostControl temporaryHost = new(
+            new Rectangle(0, 0, 10, 10),
+            this,
+            context =>
+            {
+                disposedContext = context;
+                return new Grid();
+            }))
+        {
+            XamlHostContext temporaryContext = disposedContext
+                ?? throw new InvalidOperationException("The temporary content factory did not receive the host context.");
+            Ensure(temporaryContext.OwnsApplication == _xamlHost.Context.OwnsApplication, "Host contexts disagreed on application ownership.");
+        }
+
+        XamlHostContext retainedContext = disposedContext
+            ?? throw new InvalidOperationException("The temporary host context was not retained for disposal validation.");
+
+        try
+        {
+            _ = retainedContext.OwnsApplication;
+            throw new InvalidOperationException("A retained host context remained usable after host disposal.");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
 
         Exception? wrongThreadFailure = null;
         Thread thread = new(() =>
@@ -249,11 +326,67 @@ internal sealed class EnvironmentWindow : Window
         WinUIColorChangedEventArgs? observedChange = null;
         _colorPickerHost.ColorChanged += (_, eventArgs) => observedChange = eventArgs;
         _colorPickerHost.IsAlphaEnabled = true;
+        _colorPickerHost.IsColorSpectrumVisible = false;
+        _colorPickerHost.IsColorPreviewVisible = false;
+        _colorPickerHost.IsColorSliderVisible = false;
+        _colorPickerHost.IsColorChannelTextInputVisible = false;
+        _colorPickerHost.IsAlphaSliderVisible = false;
+        _colorPickerHost.IsAlphaTextInputVisible = false;
+        _colorPickerHost.IsHexInputVisible = false;
+        foreach (WinUIColorSpectrumShape shape in Enum.GetValues<WinUIColorSpectrumShape>())
+        {
+            _colorPickerHost.ColorSpectrumShape = shape;
+            Ensure(_colorPickerHost.ColorSpectrumShape == shape, $"The {shape} spectrum shape did not round-trip.");
+        }
+
+        foreach (WinUIColorSpectrumComponents components in Enum.GetValues<WinUIColorSpectrumComponents>())
+        {
+            _colorPickerHost.ColorSpectrumComponents = components;
+            Ensure(_colorPickerHost.ColorSpectrumComponents == components, $"The {components} spectrum mapping did not round-trip.");
+        }
+
+        foreach (WinUIColorPickerOrientation orientation in Enum.GetValues<WinUIColorPickerOrientation>())
+        {
+            _colorPickerHost.Orientation = orientation;
+            Ensure(_colorPickerHost.Orientation == orientation, $"The {orientation} orientation did not round-trip.");
+        }
+
+        foreach (WinUIElementTheme theme in Enum.GetValues<WinUIElementTheme>())
+        {
+            _colorPickerHost.RequestedTheme = theme;
+            Ensure(_colorPickerHost.RequestedTheme == theme, $"The {theme} requested theme did not round-trip.");
+        }
+
+        EnsureThrows<ArgumentOutOfRangeException>(
+            () => _colorPickerHost.ColorSpectrumShape = (WinUIColorSpectrumShape)int.MaxValue,
+            "The color picker accepted an unknown spectrum shape.");
+        EnsureThrows<ArgumentOutOfRangeException>(
+            () => _colorPickerHost.ColorSpectrumComponents = (WinUIColorSpectrumComponents)int.MaxValue,
+            "The color picker accepted an unknown spectrum mapping.");
+        EnsureThrows<ArgumentOutOfRangeException>(
+            () => _colorPickerHost.Orientation = (WinUIColorPickerOrientation)int.MaxValue,
+            "The color picker accepted an unknown orientation.");
+        EnsureThrows<ArgumentOutOfRangeException>(
+            () => _colorPickerHost.RequestedTheme = (WinUIElementTheme)int.MaxValue,
+            "The color picker accepted an unknown requested theme.");
         Color expected = Color.FromArgb(128, 12, 34, 56);
 
         _colorPickerHost.Color = expected;
 
         Ensure(_colorPickerHost.IsAlphaEnabled, "The alpha-enabled setting was not retained.");
+        Ensure(!_colorPickerHost.IsColorSpectrumVisible, "The color-spectrum visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsColorPreviewVisible, "The color-preview visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsColorSliderVisible, "The color-slider visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsColorChannelTextInputVisible, "The channel-input visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsAlphaSliderVisible, "The alpha-slider visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsAlphaTextInputVisible, "The alpha-input visibility setting was not retained.");
+        Ensure(!_colorPickerHost.IsHexInputVisible, "The hexadecimal-input visibility setting was not retained.");
+        Ensure(_colorPickerHost.ColorSpectrumShape == WinUIColorSpectrumShape.Ring, "The spectrum shape was not retained.");
+        Ensure(
+            _colorPickerHost.ColorSpectrumComponents == WinUIColorSpectrumComponents.ValueSaturation,
+            "The spectrum-component mapping was not retained.");
+        Ensure(_colorPickerHost.Orientation == WinUIColorPickerOrientation.Horizontal, "The orientation was not retained.");
+        Ensure(_colorPickerHost.RequestedTheme == WinUIElementTheme.Dark, "The requested theme was not retained.");
         Ensure(_colorPickerHost.Color == expected, "The selected color did not round-trip through the wrapper.");
         Ensure(observedChange?.NewColor == expected, "The projected color-change event reported the wrong color.");
         try
@@ -277,7 +410,7 @@ internal sealed class EnvironmentWindow : Window
             _ = new XamlHostControl(
                 new Rectangle(0, 0, 10, 10),
                 this,
-                static () => throw new InvalidOperationException("Expected content factory failure."));
+                static context => throw new InvalidOperationException("Expected content factory failure."));
             throw new InvalidOperationException("A throwing content factory did not fail host construction.");
         }
         catch (InvalidOperationException exception) when (exception.Message == "Expected content factory failure.")
@@ -286,7 +419,10 @@ internal sealed class EnvironmentWindow : Window
 
         try
         {
-            _ = new XamlHostControl(new Rectangle(0, 0, 10, 10), this, null!);
+            _ = new XamlHostControl(
+                new Rectangle(0, 0, 10, 10),
+                this,
+                (Func<XamlHostContext, Microsoft.UI.Xaml.UIElement>)null!);
             throw new InvalidOperationException("A null content factory did not fail host construction.");
         }
         catch (ArgumentNullException exception) when (exception.ParamName == "contentFactory")
@@ -683,10 +819,27 @@ internal sealed class EnvironmentWindow : Window
         }
     }
 
+    private static void EnsureThrows<TException>(Action action, string message)
+        where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(message);
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
+            _inputScenario?.Dispose();
+            _focusScenario?.Dispose();
             _popupHost?.Dispose();
             _colorPickerHost?.Dispose();
             _xamlHost?.Dispose();

--- a/src/thirtytwo.winui_tests/IntegrationHost/FocusScenario.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/FocusScenario.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows;
+using Windows.Threading;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.WinUI;
+using NativeButton = Windows.ButtonControl;
+using RoutedEventArgs = Microsoft.UI.Xaml.RoutedEventArgs;
+using Thickness = Microsoft.UI.Xaml.Thickness;
+using XamlButton = Microsoft.UI.Xaml.Controls.Button;
+
+namespace IntegrationHost;
+
+internal sealed class FocusScenario : IDisposable
+{
+    private readonly NativeButton _beforeButton;
+    private readonly Window _parent;
+    private readonly Window _activationWindow;
+    private readonly XamlHostControl _host;
+    private readonly XamlButton _firstXamlButton;
+    private readonly XamlButton _secondXamlButton;
+    private readonly StackPanel _panel;
+    private readonly NativeButton _afterButton;
+    private readonly ScenarioReporter _reporter;
+    private Action? _pendingCompletion;
+    private bool _contentLoaded;
+    private bool _shiftStateInjected;
+    private byte _previousShiftState;
+    private int _hostXamlFocusEntryCount;
+
+    internal FocusScenario(Window parent, ScenarioReporter reporter)
+    {
+        _parent = parent;
+        _reporter = reporter;
+        _activationWindow = new(new Rectangle(0, 0, 100, 100), text: "Focus activation peer");
+        _beforeButton = new(
+            bounds: new Rectangle(20, 20, 180, 40),
+            text: "Before XAML",
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+            parentWindow: parent);
+
+        XamlButton? firstXamlButton = null;
+        XamlButton? secondXamlButton = null;
+        StackPanel? panel = null;
+        _host = new(new Rectangle(20, 80, 360, 180), parent, () =>
+        {
+            firstXamlButton = new() { Content = "First XAML button" };
+            secondXamlButton = new() { Content = "Second XAML button" };
+            panel = new() { Spacing = 12, Padding = new Thickness(20) };
+            panel.Children.Add(firstXamlButton);
+            panel.Children.Add(secondXamlButton);
+            return panel;
+        });
+        _firstXamlButton = firstXamlButton
+            ?? throw new InvalidOperationException("The first XAML button was not created.");
+        _secondXamlButton = secondXamlButton
+            ?? throw new InvalidOperationException("The second XAML button was not created.");
+        _panel = panel ?? throw new InvalidOperationException("The XAML focus panel was not created.");
+        _panel.Loaded += PanelLoaded;
+
+        _afterButton = new(
+            bounds: new Rectangle(20, 280, 180, 40),
+            text: "After XAML",
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+            parentWindow: parent);
+
+        _host.XamlGotFocus += HostXamlGotFocus;
+    }
+
+    internal void Start(Action completed)
+    {
+        ArgumentNullException.ThrowIfNull(completed);
+        if (!_contentLoaded)
+        {
+            _pendingCompletion = completed;
+            return;
+        }
+
+        HWND parent = PInvoke.GetParent(_beforeButton.Handle);
+        HWND nextTabStop = PInvoke.GetNextDlgTabItem(parent, _beforeButton.Handle, false);
+        Ensure(
+            nextTabStop == _host.Handle,
+            $"Native tab order did not resolve the XAML host after the before button. Actual HWND: {nextTabStop}.");
+        _beforeButton.SetFocus();
+        Ensure(PInvoke.GetFocus() == _beforeButton.Handle, "The before button did not receive initial focus.");
+        _reporter.Write("focus-native-before", _beforeButton.Handle);
+
+        PostTab(_beforeButton.Handle, backward: false);
+        QueueCheckpoint(VerifyForwardFirst);
+
+        void VerifyForwardFirst()
+        {
+            Ensure(
+                ReferenceEquals(GetFocusedXamlElement(), _firstXamlButton),
+                $"Forward Tab did not enter the first XAML element. Focus: {PInvoke.GetFocus()}, before: {_beforeButton.Handle}, host: {_host.Handle}, after: {_afterButton.Handle}.");
+            _reporter.Write("focus-xaml-first", _host.Handle);
+            PostTab(PInvoke.GetFocus(), backward: false);
+            QueueCheckpoint(VerifyForwardSecond);
+        }
+
+        void VerifyForwardSecond()
+        {
+            Ensure(ReferenceEquals(GetFocusedXamlElement(), _secondXamlButton), "Forward Tab did not reach the second XAML element.");
+            _reporter.Write("focus-xaml-second", _host.Handle);
+            PostTab(PInvoke.GetFocus(), backward: false);
+            QueueCheckpoint(VerifyForwardAfter);
+        }
+
+        void VerifyForwardAfter()
+        {
+            Ensure(PInvoke.GetFocus() == _afterButton.Handle, "Forward Tab did not leave XAML for the after button.");
+            _reporter.Write("focus-native-after", _afterButton.Handle);
+            PostTab(_afterButton.Handle, backward: false);
+            QueueCheckpoint(VerifyForwardWrap);
+        }
+
+        void VerifyForwardWrap()
+        {
+            Ensure(PInvoke.GetFocus() == _beforeButton.Handle, "Forward Tab did not wrap to the before button.");
+            _reporter.Write("focus-forward-wrapped", _beforeButton.Handle);
+            PostTab(_beforeButton.Handle, backward: true);
+            QueueCheckpoint(VerifyBackwardWrap);
+        }
+
+        void VerifyBackwardWrap()
+        {
+            Ensure(PInvoke.GetFocus() == _afterButton.Handle, "Backward Tab did not wrap to the after button.");
+            _reporter.Write("focus-backward-wrapped", _afterButton.Handle);
+            PostTab(_afterButton.Handle, backward: true);
+            QueueCheckpoint(VerifyBackwardSecond);
+        }
+
+        void VerifyBackwardSecond()
+        {
+            Ensure(ReferenceEquals(GetFocusedXamlElement(), _secondXamlButton), "Backward Tab did not enter the last XAML element.");
+            _reporter.Write("focus-backward-xaml-second", _host.Handle);
+            PostTab(PInvoke.GetFocus(), backward: true);
+            QueueCheckpoint(VerifyBackwardFirst);
+        }
+
+        void VerifyBackwardFirst()
+        {
+            object? focusedElement = GetFocusedXamlElement();
+            Ensure(
+                ReferenceEquals(focusedElement, _firstXamlButton),
+                $"Backward Tab did not reach the first XAML element. XAML focus: {focusedElement?.GetType().FullName ?? "null"}; HWND focus: {PInvoke.GetFocus()}.");
+            _reporter.Write("focus-backward-xaml-first", _host.Handle);
+            PostTab(PInvoke.GetFocus(), backward: true);
+            QueueCheckpoint(VerifyBackwardBefore);
+        }
+
+        void VerifyBackwardBefore()
+        {
+            Ensure(PInvoke.GetFocus() == _beforeButton.Handle, "Backward Tab did not leave XAML for the before button.");
+            Ensure(_hostXamlFocusEntryCount == 2, $"The host reported {_hostXamlFocusEntryCount} XAML focus entries instead of 2.");
+            _host.ShowWindow(ShowWindowCommand.Hide);
+            PostTab(_beforeButton.Handle, backward: false);
+            QueueCheckpoint(VerifyHiddenHostSkipped);
+        }
+
+        void VerifyHiddenHostSkipped()
+        {
+            Ensure(PInvoke.GetFocus() == _afterButton.Handle, "Forward Tab did not skip the hidden XAML host.");
+            _reporter.Write("focus-hidden-host-skipped", _afterButton.Handle);
+            _host.ShowWindow(ShowWindowCommand.Show);
+            PInvoke.EnableWindow(_host.Handle, false);
+            _beforeButton.SetFocus();
+            PostTab(_beforeButton.Handle, backward: false);
+            QueueCheckpoint(VerifyDisabledHostSkipped);
+        }
+
+        void VerifyDisabledHostSkipped()
+        {
+            Ensure(PInvoke.GetFocus() == _afterButton.Handle, "Forward Tab did not skip the disabled XAML host.");
+            PInvoke.EnableWindow(_host.Handle, true);
+            _reporter.Write("focus-disabled-host-skipped", _afterButton.Handle);
+            for (int iteration = 0; iteration < 20; iteration++)
+            {
+                PInvoke.SetActiveWindow(_activationWindow.Handle);
+                PInvoke.SetActiveWindow(_parent.Handle);
+            }
+
+            _beforeButton.SetFocus();
+            Ensure(PInvoke.GetFocus() == _beforeButton.Handle, "Focus could not be restored after reactivation.");
+            _reporter.Write("focus-reactivation-stable", _beforeButton.Handle);
+            _reporter.Write("focus-traversal-completed", _afterButton.Handle);
+            completed();
+        }
+    }
+
+    public void Dispose()
+    {
+        RestoreShiftState();
+        _panel.Loaded -= PanelLoaded;
+        _host.XamlGotFocus -= HostXamlGotFocus;
+        _afterButton.Dispose();
+        _host.Dispose();
+        _beforeButton.Dispose();
+        _activationWindow.Dispose();
+    }
+
+    private static void Ensure(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private void PostTab(HWND target, bool backward)
+    {
+        if (backward)
+        {
+            _previousShiftState = KeyboardInput.SetKeyState(VirtualKey.Shift, pressed: true);
+            _shiftStateInjected = true;
+        }
+
+        KeyboardInput.PostKeyPress(target, VirtualKey.Tab);
+    }
+
+    private object? GetFocusedXamlElement()
+        => FocusManager.GetFocusedElement(_panel.XamlRoot);
+
+    private void HostXamlGotFocus(object? sender, EventArgs eventArgs)
+    {
+        _hostXamlFocusEntryCount++;
+        _reporter.Write("focus-entered-xaml", _host.Handle);
+    }
+
+    private void PanelLoaded(object sender, RoutedEventArgs eventArgs)
+    {
+        _contentLoaded = true;
+        Action? pendingCompletion = _pendingCompletion;
+        _pendingCompletion = null;
+        if (pendingCompletion is not null)
+        {
+            QueueCheckpoint(() => Start(pendingCompletion));
+        }
+    }
+
+    private void QueueCheckpoint(Action callback)
+    {
+        if (Dispatcher.Current?.TryPost(() =>
+            {
+                RestoreShiftState();
+                callback();
+            }) != true)
+        {
+            throw new InvalidOperationException("Failed to queue a focus scenario checkpoint.");
+        }
+    }
+
+    private void RestoreShiftState()
+    {
+        if (!_shiftStateInjected)
+        {
+            return;
+        }
+
+        KeyboardInput.RestoreKeyState(VirtualKey.Shift, _previousShiftState);
+        _shiftStateInjected = false;
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/InputScenario.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/InputScenario.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows;
+using Windows.Threading;
+using Windows.Win32;
+using Windows.WinUI;
+using FocusState = Microsoft.UI.Xaml.FocusState;
+using KeyboardAccelerator = Microsoft.UI.Xaml.Input.KeyboardAccelerator;
+using KeyboardAcceleratorInvokedEventArgs = Microsoft.UI.Xaml.Input.KeyboardAcceleratorInvokedEventArgs;
+using KeyEventHandler = Microsoft.UI.Xaml.Input.KeyEventHandler;
+using RoutedEventArgs = Microsoft.UI.Xaml.RoutedEventArgs;
+using Thickness = Microsoft.UI.Xaml.Thickness;
+using UIElement = Microsoft.UI.Xaml.UIElement;
+using XamlButton = Microsoft.UI.Xaml.Controls.Button;
+using XamlComboBox = Microsoft.UI.Xaml.Controls.ComboBox;
+using XamlSlider = Microsoft.UI.Xaml.Controls.Slider;
+using XamlTextBox = Microsoft.UI.Xaml.Controls.TextBox;
+
+namespace IntegrationHost;
+
+internal sealed class InputScenario : IDisposable
+{
+    private readonly XamlHostControl _host;
+    private readonly XamlButton _button;
+    private readonly XamlSlider _slider;
+    private readonly XamlComboBox _comboBox;
+    private readonly XamlTextBox _textBox;
+    private readonly StackPanel _panel;
+    private readonly ScenarioReporter _reporter;
+    private readonly KeyboardAccelerator _accelerator;
+    private readonly KeyEventHandler _buttonKeyDownHandler;
+    private Action? _pendingCompletion;
+    private bool _contentLoaded;
+    private bool _menuStateInjected;
+    private byte _previousMenuState;
+    private int _acceleratorInvocationCount;
+    private int _buttonClickCount;
+    private int _enterKeyDownCount;
+
+    internal InputScenario(Window parent, ScenarioReporter reporter)
+    {
+        _reporter = reporter;
+        XamlButton? button = null;
+        XamlSlider? slider = null;
+        XamlComboBox? comboBox = null;
+        XamlTextBox? textBox = null;
+        StackPanel? panel = null;
+        KeyboardAccelerator? accelerator = null;
+
+        _host = new(new Rectangle(20, 20, 500, 360), parent, () =>
+        {
+            button = new() { Content = "Keyboard action" };
+            accelerator = new()
+            {
+                Key = Windows.System.VirtualKey.A,
+                Modifiers = Windows.System.VirtualKeyModifiers.Menu
+            };
+            button.KeyboardAccelerators.Add(accelerator);
+            slider = new() { Minimum = 0, Maximum = 100, SmallChange = 5, Value = 50 };
+            comboBox = new();
+            comboBox.Items.Add("First item");
+            comboBox.Items.Add("Second item");
+            comboBox.SelectedIndex = 0;
+            textBox = new() { PlaceholderText = "IME and text input" };
+            panel = new() { Spacing = 12, Padding = new Thickness(20) };
+            panel.Children.Add(button);
+            panel.Children.Add(slider);
+            panel.Children.Add(comboBox);
+            panel.Children.Add(textBox);
+            return panel;
+        });
+
+        _button = button ?? throw new InvalidOperationException("The XAML button was not created.");
+        _slider = slider ?? throw new InvalidOperationException("The XAML slider was not created.");
+        _comboBox = comboBox ?? throw new InvalidOperationException("The XAML combo box was not created.");
+        _textBox = textBox ?? throw new InvalidOperationException("The XAML text box was not created.");
+        _panel = panel ?? throw new InvalidOperationException("The XAML input panel was not created.");
+        _accelerator = accelerator ?? throw new InvalidOperationException("The XAML keyboard accelerator was not created.");
+        _panel.Loaded += PanelLoaded;
+        _button.Click += ButtonClick;
+        _accelerator.Invoked += AcceleratorInvoked;
+        _buttonKeyDownHandler = ButtonKeyDown;
+        _button.AddHandler(UIElement.KeyDownEvent, _buttonKeyDownHandler, handledEventsToo: true);
+    }
+
+    internal void Start(Action completed)
+    {
+        ArgumentNullException.ThrowIfNull(completed);
+        if (!_contentLoaded)
+        {
+            _pendingCompletion = completed;
+            return;
+        }
+
+        Ensure(_button.Focus(FocusState.Programmatic), "The XAML button did not accept focus.");
+        KeyboardInput.PostKeyPress(PInvoke.GetFocus(), VirtualKey.Space);
+        QueueCheckpoint(VerifySpace);
+
+        void VerifySpace()
+        {
+            Ensure(_buttonClickCount == 1, $"Space activated the XAML button {_buttonClickCount} times.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _button), "Space moved focus out of the XAML button.");
+            _reporter.Write("input-space-single-activation", _host.Handle);
+            KeyboardInput.PostKeyPress(PInvoke.GetFocus(), VirtualKey.Return);
+            QueueCheckpoint(VerifyEnter);
+        }
+
+        void VerifyEnter()
+        {
+            Ensure(_enterKeyDownCount == 1, $"Enter reached the XAML button {_enterKeyDownCount} times.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _button), "Enter moved focus out of the XAML button.");
+            _reporter.Write("input-enter-single-delivery", _host.Handle);
+            _previousMenuState = KeyboardInput.SetKeyState(VirtualKey.Menu, pressed: true);
+            _menuStateInjected = true;
+            KeyboardInput.PostKeyPress(PInvoke.GetFocus(), VirtualKey.A, systemKey: true);
+            QueueCheckpoint(VerifyAccelerator);
+        }
+
+        void VerifyAccelerator()
+        {
+            Ensure(_acceleratorInvocationCount == 1, $"Alt+A invoked the accelerator {_acceleratorInvocationCount} times.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _button), "The accelerator moved focus out of the XAML button.");
+            _reporter.Write("input-accelerator-single-invocation", _host.Handle);
+            Ensure(_slider.Focus(FocusState.Programmatic), "The XAML slider did not accept focus.");
+            KeyboardInput.PostKeyPress(PInvoke.GetFocus(), VirtualKey.Right);
+            QueueCheckpoint(VerifyArrow);
+        }
+
+        void VerifyArrow()
+        {
+            Ensure(_slider.Value == 55, $"Right Arrow changed the slider to {_slider.Value} instead of 55.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _slider), "Right Arrow moved focus out of the XAML slider.");
+            _reporter.Write("input-arrow-remained-in-xaml", _host.Handle);
+            Ensure(_comboBox.Focus(FocusState.Programmatic), "The XAML combo box did not accept focus.");
+            _comboBox.IsDropDownOpen = true;
+            Ensure(_comboBox.IsDropDownOpen, "The XAML combo-box popup did not open.");
+            KeyboardInput.PostKeyPress(PInvoke.GetFocus(), VirtualKey.Escape);
+            QueueCheckpoint(VerifyEscape);
+        }
+
+        void VerifyEscape()
+        {
+            Ensure(!_comboBox.IsDropDownOpen, "Escape did not close the XAML combo-box popup.");
+            Ensure(Window.FromHandle(PInvoke.GetFocus(), walkParents: true) == _host, "Escape moved focus to a native sibling.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _comboBox), "Escape did not restore focus to the XAML combo box.");
+            _reporter.Write("input-popup-closed-focus-retained", _host.Handle);
+            Ensure(_textBox.Focus(FocusState.Programmatic), "The XAML text box did not accept focus.");
+            Ensure(ReferenceEquals(GetFocusedElement(), _textBox), "The XAML text box did not retain focus.");
+            _reporter.Write("input-text-page-ready", _host.Handle);
+            completed();
+        }
+    }
+
+    public void Dispose()
+    {
+        RestoreMenuState();
+        _button.RemoveHandler(UIElement.KeyDownEvent, _buttonKeyDownHandler);
+        _accelerator.Invoked -= AcceleratorInvoked;
+        _button.Click -= ButtonClick;
+        _panel.Loaded -= PanelLoaded;
+        _host.Dispose();
+    }
+
+    private void ButtonClick(object sender, RoutedEventArgs eventArgs)
+        => _buttonClickCount++;
+
+    private void AcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs eventArgs)
+    {
+        _acceleratorInvocationCount++;
+        eventArgs.Handled = true;
+    }
+
+    private void ButtonKeyDown(object sender, KeyRoutedEventArgs eventArgs)
+    {
+        if (eventArgs.Key == Windows.System.VirtualKey.Enter)
+        {
+            _enterKeyDownCount++;
+        }
+    }
+
+    private static void Ensure(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private object? GetFocusedElement()
+        => FocusManager.GetFocusedElement(_panel.XamlRoot);
+
+    private void PanelLoaded(object sender, RoutedEventArgs eventArgs)
+    {
+        _contentLoaded = true;
+        Action? pendingCompletion = _pendingCompletion;
+        _pendingCompletion = null;
+        if (pendingCompletion is not null)
+        {
+            QueueCheckpoint(() => Start(pendingCompletion));
+        }
+    }
+
+    private void QueueCheckpoint(Action callback)
+    {
+        if (Dispatcher.Current?.TryPost(() =>
+            {
+                RestoreMenuState();
+                callback();
+            }) != true)
+        {
+            throw new InvalidOperationException("Failed to queue an input scenario checkpoint.");
+        }
+    }
+
+    private void RestoreMenuState()
+    {
+        if (!_menuStateInjected)
+        {
+            return;
+        }
+
+        KeyboardInput.RestoreKeyState(VirtualKey.Menu, _previousMenuState);
+        _menuStateInjected = false;
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/KeyboardInput.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/KeyboardInput.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Windows;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+
+namespace IntegrationHost;
+
+internal static unsafe class KeyboardInput
+{
+    internal static void PostKey(HWND target, VirtualKey key, bool keyDown, bool systemKey = false)
+    {
+        uint scanCode = PInvoke.MapVirtualKey((uint)key, MAP_VIRTUAL_KEY_TYPE.MAPVK_VK_TO_VSC);
+        nint keyData = 1 | ((nint)scanCode << 16);
+        if (systemKey)
+        {
+            keyData |= 0x20000000;
+        }
+
+        if (!keyDown)
+        {
+            keyData |= unchecked((nint)0xC0000000);
+        }
+
+        uint message = (keyDown, systemKey) switch
+        {
+            (true, true) => Interop.WM_SYSKEYDOWN,
+            (false, true) => Interop.WM_SYSKEYUP,
+            (true, false) => Interop.WM_KEYDOWN,
+            _ => Interop.WM_KEYUP
+        };
+        if (!PInvoke.PostMessage(target, message, (WPARAM)(nuint)key, (LPARAM)keyData))
+        {
+            throw new Win32Exception(Marshal.GetLastPInvokeError());
+        }
+    }
+
+    internal static void PostKeyPress(HWND target, VirtualKey key, bool systemKey = false)
+    {
+        PostKey(target, key, keyDown: true, systemKey);
+        PostKey(target, key, keyDown: false, systemKey);
+    }
+
+    internal static byte SetKeyState(VirtualKey key, bool pressed)
+    {
+        int keyIndex = (ushort)key;
+        if (keyIndex >= 256)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), key, "The virtual-key value must fit in the keyboard-state table.");
+        }
+
+        Span<byte> keyboardState = stackalloc byte[256];
+        fixed (byte* keyboardStatePointer = keyboardState)
+        {
+            if (!PInvoke.GetKeyboardState(keyboardStatePointer))
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError());
+            }
+
+            byte previousState = keyboardState[keyIndex];
+            keyboardState[keyIndex] = pressed
+                ? (byte)(previousState | 0x80)
+                : (byte)(previousState & 0x7F);
+            if (!PInvoke.SetKeyboardState(keyboardStatePointer))
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError());
+            }
+
+            return previousState;
+        }
+    }
+
+    internal static void RestoreKeyState(VirtualKey key, byte state)
+    {
+        int keyIndex = (ushort)key;
+        if (keyIndex >= 256)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), key, "The virtual-key value must fit in the keyboard-state table.");
+        }
+
+        Span<byte> keyboardState = stackalloc byte[256];
+        fixed (byte* keyboardStatePointer = keyboardState)
+        {
+            if (!PInvoke.GetKeyboardState(keyboardStatePointer))
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError());
+            }
+
+            keyboardState[keyIndex] = state;
+            if (!PInvoke.SetKeyboardState(keyboardStatePointer))
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError());
+            }
+        }
+    }
+}

--- a/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/ScenarioArguments.cs
@@ -34,6 +34,8 @@ internal static class ScenarioArguments
             "host-replacement" => EnvironmentScenario.HostReplacement,
             "host-popup-close" => EnvironmentScenario.HostPopupClose,
             "host-shutdown-cleanup" => EnvironmentScenario.HostShutdownCleanup,
+            "focus-traversal" => EnvironmentScenario.FocusTraversal,
+            "input-semantics" => EnvironmentScenario.InputSemantics,
             _ => throw new ArgumentException($"Unknown environment scenario '{arguments[1]}'.")
         };
     }
@@ -59,6 +61,8 @@ internal static class ScenarioArguments
         EnvironmentScenario.HostReplacement => "host-replacement",
         EnvironmentScenario.HostPopupClose => "host-popup-close",
         EnvironmentScenario.HostShutdownCleanup => "host-shutdown-cleanup",
+        EnvironmentScenario.FocusTraversal => "focus-traversal",
+        EnvironmentScenario.InputSemantics => "input-semantics",
         _ => throw new ArgumentOutOfRangeException(nameof(scenario))
     };
 }

--- a/src/thirtytwo/Controls/ButtonCheckState.cs
+++ b/src/thirtytwo/Controls/ButtonCheckState.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>Specifies the check state of a native button control.</summary>
+public enum ButtonCheckState : uint
+{
+    /// <summary>The button is not checked.</summary>
+    Unchecked = 0,
+
+    /// <summary>The button is checked.</summary>
+    Checked = 1,
+
+    /// <summary>The button is indeterminate.</summary>
+    Indeterminate = 2
+}

--- a/src/thirtytwo/Controls/ButtonControl.cs
+++ b/src/thirtytwo/Controls/ButtonControl.cs
@@ -9,6 +9,9 @@ public partial class ButtonControl : RegisteredControl
 {
     private static readonly WindowClass s_buttonClass = new(registeredClassName: "Button");
 
+    /// <summary>Occurs when the user clicks the button.</summary>
+    public event EventHandler? Click;
+
     public ButtonControl(
         Rectangle bounds = default,
         string? text = default,
@@ -26,6 +29,33 @@ public partial class ButtonControl : RegisteredControl
             s_buttonClass,
             parameters,
             (HMENU)buttonId)
+    {
+    }
+
+    /// <summary>Gets or sets the check state of a check box, radio button, or three-state button.</summary>
+    public ButtonCheckState CheckState
+    {
+        get => (ButtonCheckState)(uint)(int)this.SendMessage((MessageType)PInvoke.BM_GETCHECK);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)value, (uint)ButtonCheckState.Indeterminate);
+            this.SendMessage((MessageType)PInvoke.BM_SETCHECK, (WPARAM)(uint)value);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnCommand(int controlId, int notificationCode)
+    {
+        base.OnCommand(controlId, notificationCode);
+        if ((uint)notificationCode == Interop.BN_CLICKED)
+        {
+            OnClick();
+            Click?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Raises the <see cref="Click"/> event.</summary>
+    protected virtual void OnClick()
     {
     }
 }

--- a/src/thirtytwo/Layout/FixedSizeLayout.cs
+++ b/src/thirtytwo/Layout/FixedSizeLayout.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 namespace Windows;
 
 /// <summary>
-///  Uses a fixed size for the layout, aligning within as specified.
+///  Uses a fixed logical size, scaled by the layout scale, and aligns it within the available bounds.
 /// </summary>
 /// <param name="handler">The handler to layout within the specified space.</param>
 /// <param name="size">The fixed size to use.</param>
@@ -20,22 +20,26 @@ public class FixedSizeLayout(
 {
     public void Layout(Rectangle bounds, float scale)
     {
+        Size scaledSize = new(
+            (int)MathF.Round(size.Width * scale),
+            (int)MathF.Round(size.Height * scale));
+
         int x = horizontalAlignment switch
         {
             HorizontalAlignment.Left => bounds.Left,
-            HorizontalAlignment.Right => bounds.Right - size.Width,
-            HorizontalAlignment.Center => (bounds.Width - size.Width) / 2,
+            HorizontalAlignment.Right => bounds.Right - scaledSize.Width,
+            HorizontalAlignment.Center => bounds.X + ((bounds.Width - scaledSize.Width) / 2),
             _ => bounds.Left,
         };
 
         int y = verticalAlignment switch
         {
             VerticalAlignment.Top => bounds.Top,
-            VerticalAlignment.Bottom => bounds.Bottom - size.Height,
-            VerticalAlignment.Center => (bounds.Height - size.Height) / 2,
+            VerticalAlignment.Bottom => bounds.Bottom - scaledSize.Height,
+            VerticalAlignment.Center => bounds.Y + ((bounds.Height - scaledSize.Height) / 2),
             _ => bounds.Top,
         };
 
-        handler.Layout(new Rectangle(new Point(x, y), size), scale);
+        handler.Layout(new Rectangle(new Point(x, y), scaledSize), scale);
     }
 }

--- a/src/thirtytwo/Layout/HorizontalLayout.cs
+++ b/src/thirtytwo/Layout/HorizontalLayout.cs
@@ -19,21 +19,14 @@ public class HorizontalLayout : ILayoutHandler
     ///  An array of tuples containing the percentage of height to allocate and the handler to layout in that space.
     ///  The sum of all percentages must equal 1.0.
     /// </param>
+    /// <exception cref="ArgumentNullException">The handler array or one of its handlers is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    ///  Thrown when the sum of all percentages does not equal 1.0.
+    ///  A percentage is nonfinite or outside 0.0 through 1.0, or the sum does not equal 1.0 within float precision.
     /// </exception>
     public HorizontalLayout(params (float Percent, ILayoutHandler Handler)[] handlers)
     {
-        float totalPercent = 0f;
-        foreach (var (percent, handler) in handlers)
-        {
-            totalPercent += percent;
-        }
-
-        if (totalPercent != 1.0f)
-            throw new ArgumentOutOfRangeException(nameof(handlers), $"Total percentage must be 1.0f.");
-
-        _handlers = handlers;
+        LayoutValidation.ValidateProportionalHandlers(handlers);
+        _handlers = [.. handlers];
     }
 
     /// <summary>
@@ -52,6 +45,6 @@ public class HorizontalLayout : ILayoutHandler
             top += currentHeight;
         }
 
-        _handlers[last].Handler.Layout(new Rectangle(bounds.X, top, bounds.Width, bounds.Height - top), scale);
+        _handlers[last].Handler.Layout(new Rectangle(bounds.X, top, bounds.Width, bounds.Bottom - top), scale);
     }
 }

--- a/src/thirtytwo/Layout/Layout.cs
+++ b/src/thirtytwo/Layout/Layout.cs
@@ -17,7 +17,7 @@ public static class Layout
         ILayoutHandler handler,
         VerticalAlignment verticalAlignment = VerticalAlignment.Center,
         HorizontalAlignment horizontalAlignment = HorizontalAlignment.Center)
-        => new FixedPercentLayout(handler, widthPercent, heightPercent, verticalAlignment, horizontalAlignment);
+        => new FixedPercentLayout(handler, heightPercent, widthPercent, verticalAlignment, horizontalAlignment);
 
     /// <inheritdoc cref="FixedPercentLayout(ILayoutHandler, float, float, VerticalAlignment, HorizontalAlignment)"/>
     /// <param name="percent">The percentage of available width and height to use.</param>

--- a/src/thirtytwo/Layout/LayoutValidation.cs
+++ b/src/thirtytwo/Layout/LayoutValidation.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>Validates shared layout-construction invariants.</summary>
+internal static class LayoutValidation
+{
+    private const double PercentageTolerance = 0.00001;
+
+    internal static void ValidateProportionalHandlers((float Percent, ILayoutHandler Handler)[] handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        double totalPercent = 0;
+        foreach ((float percent, ILayoutHandler handler) in handlers)
+        {
+            if (!float.IsFinite(percent) || percent < 0 || percent > 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(handlers),
+                    percent,
+                    "Each percentage must be finite and between 0.0 and 1.0.");
+            }
+
+            if (handler is null)
+            {
+                throw new ArgumentNullException(nameof(handlers), "A layout handler cannot be null.");
+            }
+
+            totalPercent += percent;
+        }
+
+        if (Math.Abs(totalPercent - 1.0) > PercentageTolerance)
+        {
+            throw new ArgumentOutOfRangeException(nameof(handlers), "Total percentage must be 1.0.");
+        }
+    }
+}

--- a/src/thirtytwo/Layout/PaddedLayout.cs
+++ b/src/thirtytwo/Layout/PaddedLayout.cs
@@ -36,8 +36,8 @@ public class PaddedLayout(
             int left = (int)MathF.Round(leftPadding * scale);
             int right = (int)MathF.Round(rightPadding * scale);
 
-            int marginWidth = left + right;
-            int remainingWidth = bounds.Width - marginWidth;
+            long marginWidth = (long)left + right;
+            long remainingWidth = bounds.Width - marginWidth;
             if (remainingWidth < 0)
             {
                 if (left > 1 || right > 1)
@@ -49,7 +49,7 @@ public class PaddedLayout(
             else
             {
                 bounds.X += left;
-                bounds.Width -= marginWidth;
+                bounds.Width -= (int)marginWidth;
             }
         }
 
@@ -63,8 +63,8 @@ public class PaddedLayout(
 
             int top = (int)MathF.Round(topPadding * scale);
             int bottom = (int)MathF.Round(bottomPadding * scale);
-            int marginHeight = top + bottom;
-            int remainingHeight = bounds.Height - marginHeight;
+            long marginHeight = (long)top + bottom;
+            long remainingHeight = bounds.Height - marginHeight;
 
             if (remainingHeight < 0)
             {
@@ -77,7 +77,7 @@ public class PaddedLayout(
             else
             {
                 bounds.Y += top;
-                bounds.Height -= marginHeight;
+                bounds.Height -= (int)marginHeight;
             }
         }
     }

--- a/src/thirtytwo/Layout/VerticalLayout.cs
+++ b/src/thirtytwo/Layout/VerticalLayout.cs
@@ -19,21 +19,14 @@ public class VerticalLayout : ILayoutHandler
     ///  An array of tuples containing the percentage of width to allocate and the handler to layout in that space.
     ///  The sum of all percentages must equal 1.0.
     /// </param>
+    /// <exception cref="ArgumentNullException">The handler array or one of its handlers is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    ///  Thrown when the sum of all percentages does not equal 1.0.
+    ///  A percentage is nonfinite or outside 0.0 through 1.0, or the sum does not equal 1.0 within float precision.
     /// </exception>
     public VerticalLayout(params (float Percent, ILayoutHandler Handler)[] handlers)
     {
-        float totalPercent = 0f;
-        foreach (var (percent, handler) in handlers)
-        {
-            totalPercent += percent;
-        }
-
-        if (totalPercent != 1.0f)
-            throw new ArgumentOutOfRangeException(nameof(handlers), $"Total percentage must be 1.0f.");
-
-        _handlers = handlers;
+        LayoutValidation.ValidateProportionalHandlers(handlers);
+        _handlers = [.. handlers];
     }
 
     /// <summary>
@@ -52,6 +45,6 @@ public class VerticalLayout : ILayoutHandler
             left += currentWidth;
         }
 
-        _handlers[last].Handler.Layout(new Rectangle(left, bounds.Y, bounds.Width - left, bounds.Height), scale);
+        _handlers[last].Handler.Layout(new Rectangle(left, bounds.Y, bounds.Right - left, bounds.Height), scale);
     }
 }

--- a/src/thirtytwo/NativeMethods.txt
+++ b/src/thirtytwo/NativeMethods.txt
@@ -8,6 +8,8 @@ BeginPaint
 BitBlt
 BITMAP
 BOOLEAN
+BM_*
+BN_*
 BS_*
 CallWindowProc
 CB_*
@@ -158,13 +160,16 @@ GetDlgCtrlID
 GetDlgItem
 GetDpiForWindow
 GetFocus
+GetKeyState
 GetGraphicsMode
 GetIconInfo
 GetIconInfoEx
+GetKeyboardState
 GetLocalTime
 GetMapMode
 GetMessage
 GetModuleHandleEx
+GetNextDlgTabItem
 GetObject
 GetObjectType
 GetOpenClipboardWindow
@@ -278,6 +283,7 @@ LOGFONTW
 LPtoDP
 LsaNtStatusToWinError
 MapDialogRect
+MapVirtualKey
 MapWindowPoints
 MEMBERID_NIL
 MessageBeep
@@ -353,6 +359,7 @@ SetFocus
 SetGraphicsMode
 SetLayeredWindowAttributes
 SetMapMode
+SetKeyboardState
 SetParent
 SetPolyFillMode
 SetROP2

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -328,7 +328,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 {
                     _renderTarget.BeginDraw();
                     _renderTarget.SetTransform(Matrix3x2.Identity);
-                    _renderTarget.Clear(_backgroundColor);
+                    _renderTarget.Clear(GetBackgroundOwner()?._backgroundColor ?? default);
                 }
 
                 break;
@@ -429,15 +429,28 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                     // Direct2D, but pushing that to the paint method is avoids an extra BeginDraw/EndDraw.
                     return (LRESULT)1;
                 }
-                else if (!_backgroundColor.IsEmpty)
+                else if (GetBackgroundOwner() is { } backgroundOwner)
                 {
-                    if (_backgroundBrush.IsNull)
-                    {
-                        _backgroundBrush = HBRUSH.CreateSolid(_backgroundColor);
-                    }
-
-                    ((HDC)wParam).FillRectangle(this.GetClientRectangle(), _backgroundBrush);
+                    ((HDC)wParam).FillRectangle(this.GetClientRectangle(), backgroundOwner.GetBackgroundBrush());
                     return (LRESULT)1;
+                }
+
+                break;
+
+            case MessageType.ControlColorMessageBox:
+            case MessageType.ControlColorEdit:
+            case MessageType.ControlColorListBox:
+            case MessageType.ControlColorButton:
+            case MessageType.ControlColorDialog:
+            case MessageType.ControlColorScrollBar:
+            case MessageType.ControlColorStatic:
+                Window control = lParam == 0
+                    ? this
+                    : FromHandle((HWND)lParam, walkParents: true) ?? this;
+                if (control.GetBackgroundOwner() is { } controlBackgroundOwner)
+                {
+                    ((HDC)wParam).SetBackgroundColor(controlBackgroundOwner._backgroundColor);
+                    return (LRESULT)controlBackgroundOwner.GetBackgroundBrush().Value;
                 }
 
                 break;
@@ -493,6 +506,35 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             // Still creating the window.
             ? (LRESULT)(-1)
             : PInvoke.CallWindowProc(_priorWindowProcedure, window, (uint)message, wParam, lParam);
+    }
+
+    private Window? GetBackgroundOwner()
+    {
+        Window? current = this;
+        while (current._backgroundColor.IsEmpty && !current.Handle.IsNull)
+        {
+            HWND parentHandle = PInvoke.GetParent(current.Handle);
+            Window? parent = parentHandle.IsNull ? null : FromHandle(parentHandle, walkParents: true);
+            if (parent is null || ReferenceEquals(parent, current))
+            {
+                return null;
+            }
+
+            current = parent;
+        }
+
+        return current._backgroundColor.IsEmpty ? null : current;
+    }
+
+    private HBRUSH GetBackgroundBrush()
+    {
+        Debug.Assert(!_backgroundColor.IsEmpty);
+        if (_backgroundBrush.IsNull)
+        {
+            _backgroundBrush = HBRUSH.CreateSolid(_backgroundColor);
+        }
+
+        return _backgroundBrush;
     }
 
     private void HandleDpiChanged(Message.DpiChanged dpiChanged)

--- a/src/thirtytwo_tests/Controls/ButtonControlTests.cs
+++ b/src/thirtytwo_tests/Controls/ButtonControlTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Windows.Controls;
+
+[TestClass]
+public class ButtonControlTests
+{
+    [TestMethod]
+    public void CheckState_RoundTripsSupportedValues()
+    {
+        using MainWindow window = new(Window.DefaultBounds);
+        using ButtonControl button = new(
+            buttonStyle: ButtonControl.Styles.AutoThreeState,
+            parentWindow: window);
+
+        foreach (ButtonCheckState state in Enum.GetValues<ButtonCheckState>())
+        {
+            button.CheckState = state;
+            button.CheckState.Should().Be(state);
+        }
+    }
+
+    [TestMethod]
+    public void CheckState_InvalidValue_Throws()
+    {
+        using MainWindow window = new(Window.DefaultBounds);
+        using ButtonControl button = new(parentWindow: window);
+
+        Action action = () => button.CheckState = (ButtonCheckState)uint.MaxValue;
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void Click_FiresFromCommandMessage()
+    {
+        using MainWindow window = new(Window.DefaultBounds);
+        using ButtonControl button = new(parentWindow: window);
+        int clickCount = 0;
+        button.Click += (sender, eventArgs) => clickCount++;
+
+        window.SendMessage(
+            MessageType.Command,
+            WPARAM.MAKEWPARAM(0, (int)PInvoke.BN_CLICKED),
+            (LPARAM)button.Handle);
+
+        clickCount.Should().Be(1);
+    }
+}

--- a/src/thirtytwo_tests/Layout/LayoutCoverageTests.cs
+++ b/src/thirtytwo_tests/Layout/LayoutCoverageTests.cs
@@ -1,0 +1,417 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+
+namespace Windows;
+
+[TestClass]
+public class LayoutCoverageTests
+{
+    [TestMethod]
+    public void FixedPercentLayout_AllAlignments_UseNonzeroBoundsOrigin()
+    {
+        Rectangle bounds = new(10, 20, 100, 60);
+        (VerticalAlignment Vertical, HorizontalAlignment Horizontal, Point Expected)[] cases =
+        [
+            (VerticalAlignment.Top, HorizontalAlignment.Left, new(10, 20)),
+            (VerticalAlignment.Top, HorizontalAlignment.Center, new(40, 20)),
+            (VerticalAlignment.Top, HorizontalAlignment.Right, new(70, 20)),
+            (VerticalAlignment.Center, HorizontalAlignment.Left, new(10, 35)),
+            (VerticalAlignment.Center, HorizontalAlignment.Center, new(40, 35)),
+            (VerticalAlignment.Center, HorizontalAlignment.Right, new(70, 35)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Left, new(10, 50)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Center, new(40, 50)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Right, new(70, 50))
+        ];
+
+        foreach ((VerticalAlignment vertical, HorizontalAlignment horizontal, Point expected) in cases)
+        {
+            RecordingLayoutHandler handler = new();
+            FixedPercentLayout layout = new(
+                handler,
+                heightPercent: 0.5f,
+                widthPercent: 0.4f,
+                vertical,
+                horizontal);
+
+            layout.Layout(bounds, 1.25f);
+
+            handler.LastBounds.Should().Be(new Rectangle(expected, new Size(40, 30)));
+            handler.LastScale.Should().Be(1.25f);
+        }
+    }
+
+    [TestMethod]
+    public void FixedPercent_UniformPercent_AppliesBothDimensions()
+    {
+        RecordingLayoutHandler handler = new();
+        ILayoutHandler layout = Layout.FixedPercent(0.5f, handler);
+
+        layout.Layout(new Rectangle(10, 20, 100, 60), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(35, 35, 50, 30));
+    }
+
+    [TestMethod]
+    public void FixedPercentLayout_InvalidAlignments_DefaultToTopLeft()
+    {
+        RecordingLayoutHandler handler = new();
+        FixedPercentLayout layout = new(
+            handler,
+            heightPercent: 0.5f,
+            widthPercent: 0.4f,
+            (VerticalAlignment)int.MaxValue,
+            (HorizontalAlignment)int.MaxValue);
+
+        layout.Layout(new Rectangle(10, 20, 100, 60), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(10, 20, 40, 30));
+    }
+
+    [TestMethod]
+    public void FixedSizeLayout_AllAlignments_UseNonzeroBoundsOrigin()
+    {
+        Rectangle bounds = new(10, 20, 100, 60);
+        (VerticalAlignment Vertical, HorizontalAlignment Horizontal, Point Expected)[] cases =
+        [
+            (VerticalAlignment.Top, HorizontalAlignment.Left, new(10, 20)),
+            (VerticalAlignment.Top, HorizontalAlignment.Center, new(40, 20)),
+            (VerticalAlignment.Top, HorizontalAlignment.Right, new(70, 20)),
+            (VerticalAlignment.Center, HorizontalAlignment.Left, new(10, 35)),
+            (VerticalAlignment.Center, HorizontalAlignment.Center, new(40, 35)),
+            (VerticalAlignment.Center, HorizontalAlignment.Right, new(70, 35)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Left, new(10, 50)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Center, new(40, 50)),
+            (VerticalAlignment.Bottom, HorizontalAlignment.Right, new(70, 50))
+        ];
+
+        foreach ((VerticalAlignment vertical, HorizontalAlignment horizontal, Point expected) in cases)
+        {
+            RecordingLayoutHandler handler = new();
+            FixedSizeLayout layout = new(handler, new Size(40, 30), vertical, horizontal);
+
+            layout.Layout(bounds, 1.0f);
+
+            handler.LastBounds.Should().Be(new Rectangle(expected, new Size(40, 30)));
+        }
+    }
+
+    [TestMethod]
+    public void FixedSizeLayout_FractionalScale_RoundsDimensions()
+    {
+        RecordingLayoutHandler handler = new();
+        FixedSizeLayout layout = new(handler, new Size(3, 5));
+
+        layout.Layout(new Rectangle(10, 20, 100, 60), 1.5f);
+
+        handler.LastBounds.Should().Be(new Rectangle(58, 46, 4, 8));
+        handler.LastScale.Should().Be(1.5f);
+    }
+
+    [TestMethod]
+    public void FixedSize_ForwardsSizeAndAlignments()
+    {
+        RecordingLayoutHandler handler = new();
+        ILayoutHandler layout = Layout.FixedSize(
+            new Size(40, 30),
+            handler,
+            VerticalAlignment.Bottom,
+            HorizontalAlignment.Right);
+
+        layout.Layout(new Rectangle(10, 20, 100, 60), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(70, 50, 40, 30));
+    }
+
+    [TestMethod]
+    public void FixedSizeLayout_InvalidAlignments_DefaultToTopLeft()
+    {
+        RecordingLayoutHandler handler = new();
+        FixedSizeLayout layout = new(
+            handler,
+            new Size(40, 30),
+            (VerticalAlignment)int.MaxValue,
+            (HorizontalAlignment)int.MaxValue);
+
+        layout.Layout(new Rectangle(10, 20, 100, 60), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(10, 20, 40, 30));
+    }
+
+    [TestMethod]
+    public void HorizontalLayout_ThreeChildren_AssignsRoundingRemainderToLast()
+    {
+        RecordingLayoutHandler first = new();
+        RecordingLayoutHandler second = new();
+        RecordingLayoutHandler third = new();
+        HorizontalLayout layout = new((0.333f, first), (0.333f, second), (0.334f, third));
+
+        layout.Layout(new Rectangle(10, 20, 101, 101), 1.5f);
+
+        first.LastBounds.Should().Be(new Rectangle(10, 20, 101, 33));
+        second.LastBounds.Should().Be(new Rectangle(10, 53, 101, 33));
+        third.LastBounds.Should().Be(new Rectangle(10, 86, 101, 35));
+        first.LastScale.Should().Be(1.5f);
+        second.LastScale.Should().Be(1.5f);
+        third.LastScale.Should().Be(1.5f);
+    }
+
+    [TestMethod]
+    public void VerticalLayout_ThreeChildren_AssignsRoundingRemainderToLast()
+    {
+        RecordingLayoutHandler first = new();
+        RecordingLayoutHandler second = new();
+        RecordingLayoutHandler third = new();
+        VerticalLayout layout = new((0.333f, first), (0.333f, second), (0.334f, third));
+
+        layout.Layout(new Rectangle(10, 20, 101, 101), 1.5f);
+
+        first.LastBounds.Should().Be(new Rectangle(10, 20, 33, 101));
+        second.LastBounds.Should().Be(new Rectangle(43, 20, 33, 101));
+        third.LastBounds.Should().Be(new Rectangle(76, 20, 35, 101));
+        first.LastScale.Should().Be(1.5f);
+        second.LastScale.Should().Be(1.5f);
+        third.LastScale.Should().Be(1.5f);
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_SingleChild_ReceivesAllBounds()
+    {
+        Rectangle bounds = new(10, 20, 101, 61);
+        RecordingLayoutHandler horizontalHandler = new();
+        RecordingLayoutHandler verticalHandler = new();
+
+        new HorizontalLayout((1.0f, horizontalHandler)).Layout(bounds, 1.25f);
+        new VerticalLayout((1.0f, verticalHandler)).Layout(bounds, 1.25f);
+
+        horizontalHandler.LastBounds.Should().Be(bounds);
+        verticalHandler.LastBounds.Should().Be(bounds);
+        horizontalHandler.LastScale.Should().Be(1.25f);
+        verticalHandler.LastScale.Should().Be(1.25f);
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_CommonDecimalPercentages_AreAccepted()
+    {
+        RecordingLayoutHandler handler = new();
+        (float Percent, ILayoutHandler Handler)[] handlers =
+        [
+            (0.07f, handler),
+            (0.42f, handler),
+            (0.32f, handler),
+            (0.12f, handler),
+            (0.07f, handler)
+        ];
+
+        Action createHorizontal = () => _ = new HorizontalLayout(handlers);
+        Action createVertical = () => _ = new VerticalLayout(handlers);
+
+        createHorizontal.Should().NotThrow();
+        createVertical.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_NegativeOrOversizedIndividualPercentage_Throws()
+    {
+        RecordingLayoutHandler handler = new();
+
+        Action createHorizontal = () => _ = new HorizontalLayout((-0.5f, handler), (1.5f, handler));
+        Action createVertical = () => _ = new VerticalLayout((1.5f, handler), (-0.5f, handler));
+
+        createHorizontal.Should().Throw<ArgumentOutOfRangeException>();
+        createVertical.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_NullHandler_Throws()
+    {
+        Action createHorizontal = () => _ = new HorizontalLayout((1.0f, null!));
+        Action createVertical = () => _ = new VerticalLayout((1.0f, null!));
+
+        createHorizontal.Should().Throw<ArgumentNullException>();
+        createVertical.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_NonfinitePercentage_Throws()
+    {
+        RecordingLayoutHandler handler = new();
+
+        Action createHorizontal = () => _ = new HorizontalLayout((float.NaN, handler), (1.0f, handler));
+        Action createVertical = () => _ = new VerticalLayout((float.PositiveInfinity, handler), (0.0f, handler));
+
+        createHorizontal.Should().Throw<ArgumentOutOfRangeException>();
+        createVertical.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void HorizontalAndVerticalLayout_CopyHandlerDefinitions()
+    {
+        RecordingLayoutHandler original = new();
+        RecordingLayoutHandler replacement = new();
+        (float Percent, ILayoutHandler Handler)[] horizontalDefinitions = [(1.0f, original)];
+        (float Percent, ILayoutHandler Handler)[] verticalDefinitions = [(1.0f, original)];
+        HorizontalLayout horizontal = new(horizontalDefinitions);
+        VerticalLayout vertical = new(verticalDefinitions);
+        horizontalDefinitions[0] = (0.0f, replacement);
+        verticalDefinitions[0] = (0.0f, replacement);
+        Rectangle bounds = new(10, 20, 100, 60);
+
+        horizontal.Layout(bounds, 1.0f);
+        vertical.Layout(bounds, 1.0f);
+
+        original.CallCount.Should().Be(2);
+        replacement.CallCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void HorizontalAndVertical_CreateExpectedLayouts()
+    {
+        RecordingLayoutHandler handler = new();
+
+        Layout.Horizontal((1.0f, handler)).Should().BeOfType<HorizontalLayout>();
+        Layout.Vertical((1.0f, handler)).Should().BeOfType<VerticalLayout>();
+    }
+
+    [TestMethod]
+    public void PaddedLayout_AsymmetricPadding_UsesNonzeroOriginAndForwardsScale()
+    {
+        RecordingLayoutHandler handler = new();
+        PaddedLayout layout = new((3, 5, 7, 11), handler);
+
+        layout.Layout(new Rectangle(10, 20, 100, 80), 2.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(16, 30, 80, 48));
+        handler.LastScale.Should().Be(2.0f);
+    }
+
+    [TestMethod]
+    public void PaddedLayout_MaximumPadding_DoesNotOverflow()
+    {
+        RecordingLayoutHandler handler = new();
+        PaddedLayout layout = new((int.MaxValue, 0, int.MaxValue, 0), handler);
+
+        layout.Layout(new Rectangle(10, 20, 10, 100), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(14, 20, 2, 100));
+    }
+
+    [TestMethod]
+    public void PaddedLayout_TightAsymmetricPadding_ScalesTrailingEdges()
+    {
+        RecordingLayoutHandler handler = new();
+        PaddedLayout layout = new((1, 1, 10, 10), handler);
+
+        layout.Layout(new Rectangle(10, 20, 5, 5), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(10, 20, 0, 0));
+    }
+
+    [TestMethod]
+    public void Padding_ImplicitConversions_SetAllFields()
+    {
+        Padding uniform = 7;
+        Padding asymmetric = (1, 2, 3, 4);
+
+        (uniform.Left, uniform.Top, uniform.Right, uniform.Bottom).Should().Be((7, 7, 7, 7));
+        (asymmetric.Left, asymmetric.Top, asymmetric.Right, asymmetric.Bottom).Should().Be((1, 2, 3, 4));
+    }
+
+    [TestMethod]
+    public void PaddingF_ImplicitConversions_SetAllFields()
+    {
+        PaddingF uniform = 1.5f;
+        PaddingF asymmetric = (1.0f, 2.0f, 3.0f, 4.0f);
+
+        (uniform.Left, uniform.Top, uniform.Right, uniform.Bottom).Should().Be((1.5f, 1.5f, 1.5f, 1.5f));
+        (asymmetric.Left, asymmetric.Top, asymmetric.Right, asymmetric.Bottom).Should().Be((1.0f, 2.0f, 3.0f, 4.0f));
+    }
+
+    [TestMethod]
+    public void FillAndMargin_ForwardBoundsAndScale()
+    {
+        Rectangle bounds = new(10, 20, 100, 80);
+        RecordingLayoutHandler fillHandler = new();
+        RecordingLayoutHandler marginHandler = new();
+
+        Layout.Fill(fillHandler).Layout(bounds, 1.5f);
+        Layout.Margin((1, 2, 3, 4), marginHandler).Layout(bounds, 1.5f);
+
+        fillHandler.LastBounds.Should().Be(bounds);
+        fillHandler.LastScale.Should().Be(1.5f);
+        marginHandler.LastBounds.Should().Be(new Rectangle(12, 23, 94, 71));
+        marginHandler.LastScale.Should().Be(1.5f);
+    }
+
+    [TestMethod]
+    public void Empty_ReturnsSingletonThatAcceptsLayout()
+    {
+        Layout.Empty.Should().BeSameAs(EmptyLayout.Instance);
+
+        Action layout = () => Layout.Empty.Layout(new Rectangle(10, 20, 100, 80), 1.5f);
+
+        layout.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ReplaceableLayout_SetBeforeFirstLayout_UsesDefaults()
+    {
+        RecordingLayoutHandler initial = new();
+        RecordingLayoutHandler replacement = new();
+        ReplaceableLayout layout = new(initial);
+
+        layout.Handler = replacement;
+
+        replacement.LastBounds.Should().Be(Rectangle.Empty);
+        replacement.LastScale.Should().Be(1.0f);
+        replacement.CallCount.Should().Be(1);
+        initial.CallCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void ReplaceableLayout_ForwardsLatestBoundsAndScaleToReplacement()
+    {
+        RecordingLayoutHandler initial = new();
+        RecordingLayoutHandler replacement = new();
+        ReplaceableLayout layout = new(initial);
+        Rectangle bounds = new(10, 20, 100, 80);
+
+        layout.Layout(bounds, 1.75f);
+        layout.Handler = replacement;
+
+        initial.LastBounds.Should().Be(bounds);
+        initial.LastScale.Should().Be(1.75f);
+        replacement.LastBounds.Should().Be(bounds);
+        replacement.LastScale.Should().Be(1.75f);
+    }
+
+    [STATestMethod]
+    public void LayoutBinder_WindowPositionChanged_LaysOutClientBounds()
+    {
+        using Window window = new(new Rectangle(10, 20, 200, 100));
+        RecordingLayoutHandler handler = new();
+        LayoutBinder binder = new(window, handler);
+
+        window.MoveWindow(new Rectangle(20, 30, 300, 150), repaint: false);
+
+        handler.CallCount.Should().BeGreaterThan(0);
+        handler.LastBounds.Should().Be(window.GetClientRectangle());
+        handler.LastScale.Should().Be(window.GetScale());
+        GC.KeepAlive(binder);
+    }
+
+    private sealed class RecordingLayoutHandler : ILayoutHandler
+    {
+        public int CallCount { get; private set; }
+        public Rectangle LastBounds { get; private set; }
+        public float LastScale { get; private set; }
+
+        public void Layout(Rectangle bounds, float scale)
+        {
+            CallCount++;
+            LastBounds = bounds;
+            LastScale = scale;
+        }
+    }
+}

--- a/src/thirtytwo_tests/Layout/LayoutTests.cs
+++ b/src/thirtytwo_tests/Layout/LayoutTests.cs
@@ -34,6 +34,20 @@ public class LayoutTests
     }
 
     [TestMethod]
+    public void FixedPercent_ForwardsWidthAndHeightInDeclaredOrder()
+    {
+        LastLayoutHandler handler = new();
+        ILayoutHandler layout = Layout.FixedPercent(
+            widthPercent: 0.8f,
+            heightPercent: 0.4f,
+            handler);
+
+        layout.Layout(new Rectangle(10, 20, 100, 200), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(20, 80, 80, 80));
+    }
+
+    [TestMethod]
     public void FixedSizeLayout_PositionsCorrectly()
     {
         LastLayoutHandler handler = new();
@@ -45,6 +59,29 @@ public class LayoutTests
         Rectangle bounds = new(0, 0, 200, 100);
         layout.Layout(bounds, 1.0f);
         handler.LastBounds.Should().Be(new Rectangle(150, 70, 50, 30));
+    }
+
+    [TestMethod]
+    public void FixedSizeLayout_CenterAlignment_UsesBoundsOrigin()
+    {
+        LastLayoutHandler handler = new();
+        FixedSizeLayout layout = new(handler, new Size(50, 30));
+
+        layout.Layout(new Rectangle(10, 20, 200, 100), 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(85, 55, 50, 30));
+    }
+
+    [TestMethod]
+    public void FixedSizeLayout_ScalesDimensions()
+    {
+        LastLayoutHandler handler = new();
+        FixedSizeLayout layout = new(handler, new Size(50, 30));
+
+        layout.Layout(new Rectangle(10, 20, 200, 120), 2.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(60, 50, 100, 60));
+        handler.LastScale.Should().Be(2.0f);
     }
 
     [TestMethod]
@@ -63,10 +100,10 @@ public class LayoutTests
         LastLayoutHandler handler1 = new();
         LastLayoutHandler handler2 = new();
         HorizontalLayout layout = new((0.3f, handler1), (0.7f, handler2));
-        Rectangle bounds = new(0, 0, 100, 200);
+        Rectangle bounds = new(10, 20, 100, 200);
         layout.Layout(bounds, 1.0f);
-        handler1.LastBounds.Should().Be(new Rectangle(0, 0, 100, 60));
-        handler2.LastBounds.Should().Be(new Rectangle(0, 60, 100, 140));
+        handler1.LastBounds.Should().Be(new Rectangle(10, 20, 100, 60));
+        handler2.LastBounds.Should().Be(new Rectangle(10, 80, 100, 140));
     }
 
     [TestMethod]
@@ -75,10 +112,10 @@ public class LayoutTests
         LastLayoutHandler handler1 = new();
         LastLayoutHandler handler2 = new();
         VerticalLayout layout = new((0.4f, handler1), (0.6f, handler2));
-        Rectangle bounds = new(0, 0, 100, 200);
+        Rectangle bounds = new(10, 20, 100, 200);
         layout.Layout(bounds, 1.0f);
-        handler1.LastBounds.Should().Be(new Rectangle(0, 0, 40, 200));
-        handler2.LastBounds.Should().Be(new Rectangle(40, 0, 60, 200));
+        handler1.LastBounds.Should().Be(new Rectangle(10, 20, 40, 200));
+        handler2.LastBounds.Should().Be(new Rectangle(50, 20, 60, 200));
     }
 
     [TestMethod]
@@ -275,19 +312,16 @@ public class LayoutTests
     }
 
     [TestMethod]
-    public void PaddedLayout_DeepRecursion()
+    public void PaddedLayout_LargePadding_ConvergesWithinBounds()
     {
         LastLayoutHandler handler = new();
-
-        // Create extremely large padding values
         PaddedLayout layout = new((int.MaxValue / 4, 0, int.MaxValue / 4, 0), handler);
-
-        // Tiny bounds that can't possibly accommodate the padding
         Rectangle bounds = new(0, 0, 10, 100);
 
-        // This will cause infinite recursion in ApplyLeftAndRightPadding
-        // because even at half scale repeatedly, the padding will still be too large
         layout.Layout(bounds, 1.0f);
+
+        handler.LastBounds.Should().Be(new Rectangle(4, 0, 2, 100));
+        handler.LastScale.Should().Be(1.0f);
     }
 
 

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationRunner.cs
@@ -173,6 +173,8 @@ internal sealed class WinUIIntegrationRunner
                         case WinUIIntegrationScenario.HostReplacement:
                         case WinUIIntegrationScenario.HostPopupClose:
                         case WinUIIntegrationScenario.HostShutdownCleanup:
+                        case WinUIIntegrationScenario.FocusTraversal:
+                        case WinUIIntegrationScenario.InputSemantics:
                             break;
                         default:
                             throw new InvalidOperationException($"Unknown WinUI integration scenario '{scenario}'.");
@@ -508,6 +510,8 @@ internal sealed class WinUIIntegrationRunner
         WinUIIntegrationScenario.HostReplacement => "host-replacement",
         WinUIIntegrationScenario.HostPopupClose => "host-popup-close",
         WinUIIntegrationScenario.HostShutdownCleanup => "host-shutdown-cleanup",
+        WinUIIntegrationScenario.FocusTraversal => "focus-traversal",
+        WinUIIntegrationScenario.InputSemantics => "input-semantics",
         _ => throw new ArgumentOutOfRangeException(nameof(scenario))
     };
 

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationScenario.cs
@@ -27,5 +27,7 @@ internal enum WinUIIntegrationScenario
     HostReparent,
     HostReplacement,
     HostPopupClose,
-    HostShutdownCleanup
+    HostShutdownCleanup,
+    FocusTraversal,
+    InputSemantics
 }

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostFocusIntegrationTests.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostFocusIntegrationTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Windows.WinUI.IntegrationHarness;
+
+[TestClass]
+[DoNotParallelize]
+public class XamlHostFocusIntegrationTests
+{
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_FocusTraversal_VisitsNativeAndXamlStopsInBothDirections()
+    {
+        WinUIIntegrationResult result = new WinUIIntegrationRunner()
+            .RunAsync(WinUIIntegrationScenario.FocusTraversal, TimeSpan.FromSeconds(20))
+            .GetAwaiter()
+            .GetResult();
+
+        result.DiagnosticMessage.Should().BeNull();
+        result.TimedOut.Should().BeFalse();
+        result.ExitCode.Should().Be(0);
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(
+            "ready",
+            "focus-native-before",
+            "focus-xaml-first",
+            "focus-xaml-second",
+            "focus-native-after",
+            "focus-forward-wrapped",
+            "focus-backward-wrapped",
+            "focus-backward-xaml-second",
+            "focus-backward-xaml-first",
+            "focus-hidden-host-skipped",
+            "focus-disabled-host-skipped",
+            "focus-reactivation-stable",
+            "focus-traversal-completed",
+            "environment-stopped",
+            "scenario-completed");
+        result.StandardError.Should().BeEmpty();
+        AssertProcessExited(result.ProcessId);
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public void RunAsync_InputSemantics_HandlesKeysOnceAndRetainsXamlFocus()
+    {
+        WinUIIntegrationResult result = new WinUIIntegrationRunner()
+            .RunAsync(WinUIIntegrationScenario.InputSemantics, TimeSpan.FromSeconds(20))
+            .GetAwaiter()
+            .GetResult();
+
+        result.DiagnosticMessage.Should().BeNull();
+        result.TimedOut.Should().BeFalse();
+        result.ExitCode.Should().Be(0);
+        result.Events.Select(entry => entry.Event).Should().ContainInOrder(
+            "ready",
+            "input-space-single-activation",
+            "input-enter-single-delivery",
+            "input-accelerator-single-invocation",
+            "input-arrow-remained-in-xaml",
+            "input-popup-closed-focus-retained",
+            "input-text-page-ready",
+            "environment-stopped",
+            "scenario-completed");
+        result.StandardError.Should().BeEmpty();
+        AssertProcessExited(result.ProcessId);
+    }
+
+    private static void AssertProcessExited(int processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            process.HasExited.Should().BeTrue($"IntegrationHost process {processId} should have exited");
+        }
+        catch (ArgumentException)
+        {
+        }
+    }
+}

--- a/src/thirtytwo_tests/WindowTests.cs
+++ b/src/thirtytwo_tests/WindowTests.cs
@@ -24,4 +24,34 @@ public class WindowTests
         PInvoke.GetWindowThreadProcessId(handle, null).Should().Be(0);
         window.Dispose();
     }
+
+    [STATestMethod]
+    public unsafe void ControlColor_DefaultBackground_InheritsParentColor()
+    {
+        Color backgroundColor = Color.FromArgb(241, 245, 249);
+        using MainWindow window = new(Window.DefaultBounds, backgroundColor: backgroundColor);
+        using CustomControl container = new(parentWindow: window);
+        using StaticControl label = new(text: "Label", parentWindow: container);
+        using ButtonControl checkBox = new(
+            text: "Check box",
+            buttonStyle: ButtonControl.Styles.AutoCheckBox,
+            parentWindow: container);
+        using DeviceContext labelContext = label.GetDeviceContext();
+        using DeviceContext checkBoxContext = checkBox.GetDeviceContext();
+
+        LRESULT labelBrush = container.SendMessage(
+            MessageType.ControlColorStatic,
+            (WPARAM)(nuint)labelContext.Handle.Value,
+            (LPARAM)label.Handle);
+        LRESULT checkBoxBrush = container.SendMessage(
+            MessageType.ControlColorButton,
+            (WPARAM)(nuint)checkBoxContext.Handle.Value,
+            (LPARAM)checkBox.Handle);
+
+        labelContext.GetBackgroundColor().ToArgb().Should().Be(backgroundColor.ToArgb());
+        checkBoxContext.GetBackgroundColor().ToArgb().Should().Be(backgroundColor.ToArgb());
+        labelBrush.Value.Should().NotBe(0);
+        checkBoxBrush.Value.Should().Be(labelBrush.Value);
+    }
+
 }

--- a/thirtytwo.slnx
+++ b/thirtytwo.slnx
@@ -34,6 +34,12 @@
     </Project>
   </Folder>
   <Folder Name="/Samples/WinUI/">
+    <Project Path="src/samples/WinUI/AdvancedUsage/AdvancedUsage.csproj">
+      <Platform Project="x64" />
+    </Project>
+    <Project Path="src/samples/WinUI/BasicUsage/BasicUsage.csproj">
+      <Platform Project="x64" />
+    </Project>
     <Project Path="src/samples/WinUI/ControlHost/ControlHost.csproj">
       <Platform Project="x64" />
     </Project>
@@ -93,6 +99,9 @@
   <Project Path="src/thirtytwo/thirtytwo.csproj">
     <Platform Project="x64" />
   </Project>
+  <Folder Name="/src/" />
+  <Folder Name="/src/samples/" />
+  <Folder Name="/src/samples/WinUI/" />
   <Project Path="src/thirtytwo.winui/thirtytwo.winui.csproj">
     <Platform Project="x64" />
   </Project>


### PR DESCRIPTION
## Summary

Implements the WinUI hosting roadmap's focus and input milestone, including native/XAML focus traversal, Windows App SDK message preprocessing, wrapper-only and custom-XAML samples, and the host-owned context needed by advanced content factories.

## Changes

- register `ContentPreTranslateMessage` for the WinUI environment lifetime and bridge focus through `NavigateFocus`, `GotFocus`, and `TakeFocusRequested`
- add bounded traversal and input scenarios covering Tab/Shift+Tab, wraparound, hidden/disabled hosts, Space, Enter, arrows, Escape, and accelerators
- expand `WinUIColorPicker` with documented feature settings and add non-disposable `XamlHostContext` access through the generic host
- add wrapper-only `BasicUsage` and custom-XAML `AdvancedUsage` samples with automatic environment acquisition
- add native button check/click support and parent-background inheritance for native controls
- harden layout origin, scaling, percentage validation, and overflow behavior with 51 focused tests and 100% line/branch coverage for executable layout types

## Validation

- [x] `dotnet build --configuration Release` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (420 passed, 1 manual skip)
- [x] New or changed behavior has focused tests
- [x] Native ownership, size units, and failure cleanup were reviewed when applicable
- [x] Agent-file validation not required (`.agents` unchanged)
- [x] Debug build and full Debug suite pass (420 passed, 1 manual skip)
- [x] isolated core-only and WinUI package consumers pass
- [x] BasicUsage and AdvancedUsage launch responsively and close normally

## Related issues

None.