### PR TITLE
Add application color mode support

### DIFF
--- a/src/package-tests/CoreOnlyConsumer/Consumer.cs
+++ b/src/package-tests/CoreOnlyConsumer/Consumer.cs
@@ -6,4 +6,24 @@ namespace CoreOnlyConsumer;
 public static class Consumer
 {
     public static Type WindowType => typeof(Windows.Window);
+
+    public static Windows.ApplicationColorMode ColorMode
+    {
+        get => Windows.Application.ColorMode;
+        set => Windows.Application.ColorMode = value;
+    }
+
+    public static Windows.ApplicationColorState ColorState => Windows.Application.CurrentColorState;
+
+    public static Windows.ApplicationColorMode RequestedMode => ColorState.RequestedMode;
+
+    public static bool IsDark => ColorState.IsDark;
+
+    public static bool IsHighContrast => ColorState.IsHighContrast;
+
+    public static bool UseUndocumentedDarkModeApis => ColorState.UseUndocumentedDarkModeApis;
+
+    public static bool UndocumentedDarkModeApisSupported => ColorState.UndocumentedDarkModeApisSupported;
+
+    public static int ColorGeneration => ColorState.Generation;
 }

--- a/src/package-tests/CoreOnlyConsumer/ThemedControl.cs
+++ b/src/package-tests/CoreOnlyConsumer/ThemedControl.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+
+namespace CoreOnlyConsumer;
+
+public sealed class ThemedControl : Windows.CustomControl
+{
+    public ThemedControl()
+    {
+        ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+    }
+
+    public Windows.ApplicationColorPalette Palette => Windows.Application.CurrentColorState.Palette;
+
+    public Color EffectiveWindowBackground => GetEffectiveBackgroundColor();
+
+    public Color EffectiveControlBackground => GetEffectiveBackgroundColor(controlSurface: true);
+
+    public Color EffectiveWindowForeground => GetEffectiveForegroundColor(controlSurface: false);
+
+    public Color EffectiveControlForeground => GetEffectiveForegroundColor();
+
+    public void ApplyNativeTheme(string darkThemeName)
+    {
+        ApplyApplicationDarkModeTheme(darkThemeName);
+        ApplyApplicationDarkModeTheme(Handle, darkThemeName);
+    }
+
+    protected override void OnColorModeChanged()
+    {
+        _ = Windows.Application.CurrentColorState;
+        ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+        base.OnColorModeChanged();
+    }
+}

--- a/src/samples/DarkMode/DarkMode.csproj
+++ b/src/samples/DarkMode/DarkMode.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\thirtytwo\thirtytwo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/DarkMode/DarkModeWindow.cs
+++ b/src/samples/DarkMode/DarkModeWindow.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows;
+
+namespace DarkModeSample;
+
+/// <summary>Demonstrates application color modes across current native control wrappers.</summary>
+internal sealed class DarkModeWindow : MainWindow
+{
+    private readonly TextLabelControl _title;
+    private readonly StaticControl _modeLabel;
+    private readonly ComboBoxControl _modeSelector;
+    private readonly ButtonControl _cycleButton;
+    private readonly StaticControl _staticLabel;
+    private readonly EditControl _edit;
+    private readonly ComboBoxControl _comboBox;
+    private readonly RichEditControl _richEdit;
+    private readonly EditControl _disabledEdit;
+    private readonly ButtonControl _pushButton;
+    private readonly ButtonControl _checkBox;
+    private readonly ButtonControl _radioButton;
+    private readonly ButtonControl _disabledButton;
+    private readonly TextLabelControl _direct2dLabel;
+    private readonly TextLabelControl _status;
+    private readonly Window[] _ownedControls;
+
+    internal DarkModeWindow()
+        : base(
+            bounds: new Rectangle(40, 30, 900, 680),
+            title: "Dark Mode",
+            backgroundColor: default)
+    {
+        List<Window> ownedControls = [];
+        try
+        {
+            _title = Track(new TextLabelControl(
+                text: "Application color mode",
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _title.SetFont("Segoe UI", 22);
+
+            _modeLabel = Track(new StaticControl(
+                text: "Requested mode",
+                staticStyle: StaticControl.Styles.Left | StaticControl.Styles.CenterImage,
+                parentWindow: this), ownedControls);
+            _modeSelector = Track(new ComboBoxControl(
+                comboBoxStyle: ComboBoxControl.Styles.DropDownList,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.VerticalScroll,
+                parentWindow: this), ownedControls);
+            _modeSelector.AddItems(["System", "Dark", "Light"]);
+            _modeSelector.SelectedIndex = (int)Application.ColorMode;
+            _modeSelector.SelectionChanged += ModeSelectorSelectionChanged;
+
+            _cycleButton = Track(new ButtonControl(
+                text: "Cycle mode",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
+            _cycleButton.Click += CycleButtonClick;
+
+            _staticLabel = Track(new StaticControl(
+                text: "Static text follows the application foreground",
+                staticStyle: StaticControl.Styles.Left | StaticControl.Styles.CenterImage,
+                parentWindow: this), ownedControls);
+            _edit = Track(new EditControl(
+                text: "Editable text",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.Border,
+                parentWindow: this), ownedControls);
+            _comboBox = Track(new ComboBoxControl(
+                comboBoxStyle: ComboBoxControl.Styles.DropDownList,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.VerticalScroll,
+                parentWindow: this), ownedControls);
+            _comboBox.AddItems(["Combo box item", "Second item", "Third item"]);
+            _comboBox.SelectedIndex = 0;
+            _richEdit = Track(new RichEditControl(
+                default,
+                text: "Rich edit text\r\nSelection and scrollbars remain part of the compatibility review.",
+                editStyle: RichEditControl.Styles.Multiline | RichEditControl.Styles.AutoVerticalScroll,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop
+                    | WindowStyles.Border | WindowStyles.VerticalScroll,
+                parentWindow: this), ownedControls);
+            _disabledEdit = Track(new EditControl(
+                text: "Disabled edit text",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.Border | WindowStyles.Disabled,
+                parentWindow: this), ownedControls);
+
+            _pushButton = Track(new ButtonControl(
+                text: "Push button",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
+            _checkBox = Track(new ButtonControl(
+                text: "Check box",
+                buttonStyle: ButtonControl.Styles.AutoCheckBox | ButtonControl.Styles.Left,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
+            _checkBox.CheckState = ButtonCheckState.Checked;
+            _radioButton = Track(new ButtonControl(
+                text: "Radio button",
+                buttonStyle: ButtonControl.Styles.AutoRadioButton | ButtonControl.Styles.Left,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
+            _radioButton.CheckState = ButtonCheckState.Checked;
+            _disabledButton = Track(new ButtonControl(
+                text: "Disabled button",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.Disabled,
+                parentWindow: this), ownedControls);
+            _direct2dLabel = Track(new TextLabelControl(
+                text: "Direct2D text and background",
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+
+            _status = Track(new TextLabelControl(
+                text: string.Empty,
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _status.SetFont("Consolas", 11);
+
+            _ownedControls = [.. ownedControls];
+            this.AddLayoutHandler(CreateLayout());
+            UpdateStatus();
+        }
+        catch
+        {
+            for (int index = ownedControls.Count - 1; index >= 0; index--)
+            {
+                ownedControls[index].Dispose();
+            }
+
+            base.Dispose(disposing: true);
+            throw;
+        }
+    }
+
+    private static TControl Track<TControl>(TControl control, List<Window> ownedControls)
+        where TControl : Window
+    {
+        ownedControls.Add(control);
+        return control;
+    }
+
+    private ILayoutHandler CreateLayout()
+    {
+        ILayoutHandler modeRow = Layout.Vertical(
+            (.25f, Layout.Margin((20, 8, 8, 8), Layout.Fill(_modeLabel))),
+            (.5f, Layout.Margin((8, 8, 8, 8), Layout.FixedPercent(1f, .55f, _modeSelector))),
+            (.25f, Layout.Margin((8, 8, 20, 8), Layout.FixedPercent(.8f, .55f, _cycleButton))));
+
+        ILayoutHandler textControls = Layout.Horizontal(
+            (.15f, Layout.Margin((20, 8, 10, 8), Layout.Fill(_staticLabel))),
+            (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _edit))),
+            (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _comboBox))),
+            (.4f, Layout.Margin((20, 8, 10, 8), Layout.Fill(_richEdit))),
+            (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _disabledEdit))));
+
+        ILayoutHandler buttonControls = Layout.Horizontal(
+            (.16f, Layout.Margin((10, 8, 20, 8), Layout.FixedPercent(.7f, .6f, _pushButton))),
+            (.16f, Layout.Margin((10, 8, 20, 8), Layout.Fill(_checkBox))),
+            (.16f, Layout.Margin((10, 8, 20, 8), Layout.Fill(_radioButton))),
+            (.16f, Layout.Margin((10, 8, 20, 8), Layout.FixedPercent(.7f, .6f, _disabledButton))),
+            (.36f, Layout.Margin((10, 8, 20, 8), Layout.Fill(_direct2dLabel))));
+
+        return Layout.Horizontal(
+            (.12f, Layout.Margin((20, 12, 20, 4), Layout.Fill(_title))),
+            (.12f, modeRow),
+            (.64f, Layout.Vertical((.55f, textControls), (.45f, buttonControls))),
+            (.12f, Layout.Margin((20, 8, 20, 12), Layout.Fill(_status))));
+    }
+
+    private void ModeSelectorSelectionChanged(object? sender, EventArgs eventArgs)
+    {
+        if (_modeSelector.SelectedIndex >= 0)
+        {
+            Application.ColorMode = (ApplicationColorMode)_modeSelector.SelectedIndex;
+        }
+    }
+
+    private void CycleButtonClick(object? sender, EventArgs eventArgs)
+    {
+        ApplicationColorMode mode = Application.ColorMode switch
+        {
+            ApplicationColorMode.System => ApplicationColorMode.Dark,
+            ApplicationColorMode.Dark => ApplicationColorMode.Light,
+            _ => ApplicationColorMode.System
+        };
+
+        _modeSelector.SelectedIndex = (int)mode;
+        Application.ColorMode = mode;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        UpdateStatus();
+        base.OnColorModeChanged();
+    }
+
+    private void UpdateStatus()
+        => _status.Text = $"Requested: {Application.ColorMode}    Change the mode while controls are focused or dropped down.";
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _modeSelector.SelectionChanged -= ModeSelectorSelectionChanged;
+            _cycleButton.Click -= CycleButtonClick;
+            for (int index = _ownedControls.Length - 1; index >= 0; index--)
+            {
+                _ownedControls[index].Dispose();
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/samples/DarkMode/Program.cs
+++ b/src/samples/DarkMode/Program.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows;
+
+namespace DarkModeSample;
+
+/// <summary>Starts the native dark mode sample.</summary>
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+        => Application.Run(static () => new DarkModeWindow());
+}

--- a/src/samples/WinUI/BasicUsage/BasicUsageWindow.cs
+++ b/src/samples/WinUI/BasicUsage/BasicUsageWindow.cs
@@ -44,6 +44,7 @@ internal sealed class BasicUsageWindow : MainWindow
 
     private readonly Dictionary<ButtonControl, Action<bool>> _featureBindings = [];
     private readonly TextLabelControl _titleLabel;
+    private readonly ButtonControl _themeButton;
     private readonly WinUIColorPicker _colorPicker;
     private readonly TextLabelControl _statusLabel;
     private readonly StaticControl[] _selectorLabels;
@@ -57,8 +58,7 @@ internal sealed class BasicUsageWindow : MainWindow
     internal BasicUsageWindow()
         : base(
             bounds: new Rectangle(24, 4, 960, 720),
-            title: "thirtytwo WinUI Basic Usage",
-            backgroundColor: Color.White)
+            title: "thirtytwo WinUI Basic Usage")
     {
         List<Window> ownedControls = [];
 
@@ -66,23 +66,23 @@ internal sealed class BasicUsageWindow : MainWindow
         {
             _titleLabel = Track(new TextLabelControl(
                 text: "WinUI ColorPicker",
-                textColor: Color.FromArgb(17, 24, 39),
                 parentWindow: this,
-                backgroundColor: Color.White,
                 features: Features.EnableDirect2d), ownedControls);
             _titleLabel.SetFont("Segoe UI", 20);
+
+            _themeButton = Track(new ButtonControl(
+                text: GetThemeButtonText(),
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
 
             _colorPicker = Track(new WinUIColorPicker(default, this)
             {
                 Color = Color.CornflowerBlue,
-                IsAlphaEnabled = true,
-                RequestedTheme = WinUIElementTheme.Light
+                IsAlphaEnabled = true
             }, ownedControls);
 
             _statusLabel = Track(new TextLabelControl(
-                textColor: Color.FromArgb(31, 41, 55),
                 parentWindow: this,
-                backgroundColor: Color.FromArgb(243, 244, 246),
                 features: Features.EnableDirect2d), ownedControls);
             _statusLabel.SetFont("Consolas", 12);
 
@@ -136,6 +136,7 @@ internal sealed class BasicUsageWindow : MainWindow
 
             _ownedControls = [.. ownedControls];
             _colorPicker.ColorChanged += ColorPickerColorChanged;
+            _themeButton.Click += ThemeButtonClick;
             _colorPresetSelector.SelectionChanged += ColorPresetSelectionChanged;
             _spectrumShapeSelector.SelectionChanged += SpectrumShapeSelectionChanged;
             _spectrumComponentsSelector.SelectionChanged += SpectrumComponentsSelectionChanged;
@@ -217,6 +218,10 @@ internal sealed class BasicUsageWindow : MainWindow
 
     private ILayoutHandler CreateWindowLayout()
     {
+        ILayoutHandler titleLayout = Layout.Vertical(
+            (.75f, Layout.Margin((16, 4, 8, 0), Layout.Fill(_titleLabel))),
+            (.25f, Layout.Margin((8, 4, 16, 0), Layout.Fill(_themeButton))));
+
         ILayoutHandler selectorLayout = Layout.Horizontal(
             (.25f, CreateSelectorRow(_selectorLabels[0], _colorPresetSelector)),
             (.25f, CreateSelectorRow(_selectorLabels[1], _spectrumShapeSelector)),
@@ -238,7 +243,7 @@ internal sealed class BasicUsageWindow : MainWindow
             (.625f, Layout.Margin((8, 0, 16, 0), Layout.Fill(_colorPicker))));
 
         return Layout.Horizontal(
-            (.0625f, Layout.Margin((16, 4, 16, 0), Layout.Fill(_titleLabel))),
+            (.0625f, titleLayout),
             (.875f, contentLayout),
             (.0625f, Layout.Margin((16, 4, 16, 8), Layout.Fill(_statusLabel))));
     }
@@ -297,6 +302,20 @@ internal sealed class BasicUsageWindow : MainWindow
         }
     }
 
+    private void ThemeButtonClick(object? sender, EventArgs eventArgs)
+    {
+        Application.ColorMode = Application.ColorMode switch
+        {
+            ApplicationColorMode.System => ApplicationColorMode.Dark,
+            ApplicationColorMode.Dark => ApplicationColorMode.Light,
+            _ => ApplicationColorMode.System
+        };
+
+        _themeButton.Text = GetThemeButtonText();
+    }
+
+    private static string GetThemeButtonText() => $"Theme: {Application.ColorMode}";
+
     private void ColorPickerColorChanged(object? sender, WinUIColorChangedEventArgs eventArgs)
         => SynchronizeSelectedColor(eventArgs.NewColor);
 
@@ -321,6 +340,7 @@ internal sealed class BasicUsageWindow : MainWindow
         if (disposing)
         {
             _colorPicker.ColorChanged -= ColorPickerColorChanged;
+            _themeButton.Click -= ThemeButtonClick;
             _colorPresetSelector.SelectionChanged -= ColorPresetSelectionChanged;
             _spectrumShapeSelector.SelectionChanged -= SpectrumShapeSelectionChanged;
             _spectrumComponentsSelector.SelectionChanged -= SpectrumComponentsSelectionChanged;

--- a/src/thirtytwo.winui/XamlHostControl.cs
+++ b/src/thirtytwo.winui/XamlHostControl.cs
@@ -45,6 +45,7 @@ public unsafe partial class XamlHostControl : CustomControl
     private XamlHostEnvironment? _environment;
     private DesktopWindowXamlSource? _xamlSource;
     private ShutdownRegistration _shutdownRegistration;
+    private ElementTheme? _applicationRequestedTheme;
     private Guid _reportedFocusRequestId;
     private bool _xamlStateDisposed;
 
@@ -149,7 +150,13 @@ public unsafe partial class XamlHostControl : CustomControl
         set
         {
             DesktopWindowXamlSource xamlSource = GetXamlSource();
+            if (!ReferenceEquals(xamlSource.Content, value))
+            {
+                _applicationRequestedTheme = null;
+            }
+
             xamlSource.Content = value;
+            ApplyApplicationTheme(value);
         }
     }
 
@@ -269,6 +276,13 @@ public unsafe partial class XamlHostControl : CustomControl
         }
 
         base.OnSize(size);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        ApplyApplicationTheme(_xamlSource?.Content);
+        base.OnColorModeChanged();
     }
 
     /// <inheritdoc/>
@@ -518,6 +532,35 @@ public unsafe partial class XamlHostControl : CustomControl
         {
             ReportNativeCallbackFailure("NavigateFocus", exception);
         }
+    }
+
+    private void ApplyApplicationTheme(UIElement? content)
+    {
+        if (content is not FrameworkElement element)
+        {
+            _applicationRequestedTheme = null;
+            return;
+        }
+
+        if (_applicationRequestedTheme is null && element.RequestedTheme != ElementTheme.Default)
+        {
+            return;
+        }
+
+        if (_applicationRequestedTheme is { } previousTheme && element.RequestedTheme != previousTheme)
+        {
+            _applicationRequestedTheme = null;
+            return;
+        }
+
+        ElementTheme theme = Application.ColorMode switch
+        {
+            ApplicationColorMode.Dark => ElementTheme.Dark,
+            ApplicationColorMode.Light => ElementTheme.Light,
+            _ => ElementTheme.Default
+        };
+        element.RequestedTheme = theme;
+        _applicationRequestedTheme = theme;
     }
 
     private void XamlSourceGotFocus(

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -265,6 +265,17 @@ internal sealed class EnvironmentWindow : Window
         _xamlHost.Content = replacement;
         Ensure(ReferenceEquals(Window.FromHandle(_xamlHost), _xamlHost), "The managed host HWND was not registered.");
 
+        Application.ColorMode = ApplicationColorMode.Dark;
+        Ensure(replacement.RequestedTheme == Microsoft.UI.Xaml.ElementTheme.Dark, "Dark mode did not reach hosted XAML content.");
+        Application.ColorMode = ApplicationColorMode.Light;
+        Ensure(replacement.RequestedTheme == Microsoft.UI.Xaml.ElementTheme.Light, "Light mode did not reach hosted XAML content.");
+        Application.ColorMode = ApplicationColorMode.System;
+        Ensure(replacement.RequestedTheme == Microsoft.UI.Xaml.ElementTheme.Default, "System mode did not restore the default XAML theme.");
+        replacement.RequestedTheme = Microsoft.UI.Xaml.ElementTheme.Light;
+        Application.ColorMode = ApplicationColorMode.Dark;
+        Ensure(replacement.RequestedTheme == Microsoft.UI.Xaml.ElementTheme.Light, "An explicit XAML theme override was replaced.");
+        Application.ColorMode = ApplicationColorMode.System;
+
         XamlHostContext? disposedContext = null;
         using (XamlHostControl temporaryHost = new(
             new Rectangle(0, 0, 10, 10),

--- a/src/thirtytwo/Application.ColorMode.cs
+++ b/src/thirtytwo/Application.ColorMode.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32.UI.Accessibility;
+
+namespace Windows;
+
+public static unsafe partial class Application
+{
+    private static readonly Lock s_colorModeLock = new();
+    private static ApplicationColorMode s_colorMode;
+    private static ApplicationColorState? s_colorState;
+    private static bool s_colorStateInitialized;
+    private static bool s_useUndocumentedDarkModeApis = true;
+    private static int s_colorGeneration;
+
+    /// <summary>Gets or sets how the application chooses its light or dark color palette.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   The default is <see cref="ApplicationColorMode.System"/>. Changing this property updates existing managed
+    ///   windows on their owning UI threads and applies to subsequently created windows.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is not defined.</exception>
+    public static ApplicationColorMode ColorMode
+    {
+        get
+        {
+            lock (s_colorModeLock)
+            {
+                return s_colorMode;
+            }
+        }
+        set
+        {
+            if (value is not (ApplicationColorMode.System or ApplicationColorMode.Dark or ApplicationColorMode.Light))
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown application color mode.");
+            }
+
+            bool changed;
+            lock (s_colorModeLock)
+            {
+                EnsureColorStateLocked();
+                if (s_colorMode == value)
+                {
+                    return;
+                }
+
+                s_colorMode = value;
+                changed = RefreshColorStateLocked(forceGeneration: true);
+            }
+
+            if (changed)
+            {
+                Window.ApplyApplicationColorModeToWindows();
+            }
+        }
+    }
+
+    /// <summary>Gets or sets whether undocumented Windows dark mode APIs are used for native controls.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   The default is <see langword="true"/>. These APIs are not part of the supported Windows SDK contract and
+    ///   can change between Windows releases. Set this property to <see langword="false"/> to use only documented
+    ///   color and theme APIs.
+    ///  </para>
+    /// </remarks>
+    public static bool UseUndocumentedDarkModeApis
+    {
+        get
+        {
+            lock (s_colorModeLock)
+            {
+                return s_useUndocumentedDarkModeApis;
+            }
+        }
+        set
+        {
+            lock (s_colorModeLock)
+            {
+                EnsureColorStateLocked();
+                if (s_useUndocumentedDarkModeApis == value)
+                {
+                    return;
+                }
+
+                s_useUndocumentedDarkModeApis = value;
+                _ = RefreshColorStateLocked(forceGeneration: true);
+            }
+
+            Window.ApplyApplicationColorModeToWindows();
+        }
+    }
+
+    /// <summary>Gets a snapshot of the application's resolved color state and semantic palette.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   The snapshot reflects the requested mode, resolved Light or Dark preference, High Contrast precedence,
+    ///   native compatibility policy, and current semantic colors. Derived controls can read this property from
+    ///   <see cref="Window.OnColorModeChanged"/> to recreate mode-dependent resources.
+    ///  </para>
+    ///  <para>
+    ///   This property can be read before any window is created. Each returned value remains unchanged; a later
+    ///   application or system color update produces a new snapshot with a different generation token.
+    ///  </para>
+    /// </remarks>
+    public static ApplicationColorState CurrentColorState
+    {
+        get
+        {
+            lock (s_colorModeLock)
+            {
+                EnsureColorStateLocked();
+                return s_colorState!;
+            }
+        }
+    }
+
+    internal static void RefreshSystemColorMode()
+    {
+        bool changed;
+        lock (s_colorModeLock)
+        {
+            EnsureColorStateLocked();
+            changed = RefreshColorStateLocked(forceGeneration: false);
+        }
+
+        if (changed)
+        {
+            Window.ApplyApplicationColorModeToWindows();
+        }
+    }
+
+    private static void EnsureColorStateLocked()
+    {
+        if (s_colorStateInitialized)
+        {
+            return;
+        }
+
+        s_colorStateInitialized = true;
+        _ = RefreshColorStateLocked(forceGeneration: true);
+    }
+
+    private static bool RefreshColorStateLocked(bool forceGeneration)
+    {
+        bool highContrast = IsHighContrastEnabled();
+        bool dark = s_colorMode switch
+        {
+            ApplicationColorMode.Dark => true,
+            ApplicationColorMode.Light => false,
+            _ => IsSystemDark()
+        };
+
+        ApplicationColorPalette palette = ApplicationColorPalette.Create(dark, highContrast);
+        if (!forceGeneration
+            && s_colorState is { } state
+            && state.IsDark == dark
+            && state.IsHighContrast == highContrast
+            && state.Palette == palette)
+        {
+            return false;
+        }
+
+        s_colorState = new(
+            s_colorMode,
+            dark,
+            highContrast,
+            s_useUndocumentedDarkModeApis,
+            UndocumentedDarkMode.IsSupported,
+            ++s_colorGeneration,
+            palette);
+        return true;
+    }
+
+    private static bool IsSystemDark()
+    {
+        return SystemColorModeProvider.TryGetIsDark(out bool dark) && dark;
+    }
+
+    private static bool IsHighContrastEnabled()
+    {
+        HIGHCONTRASTW highContrast = new() { cbSize = (uint)sizeof(HIGHCONTRASTW) };
+        return PInvoke.SystemParametersInfo(
+            SYSTEM_PARAMETERS_INFO_ACTION.SPI_GETHIGHCONTRAST,
+            highContrast.cbSize,
+            &highContrast,
+            default)
+            && highContrast.dwFlags.HasFlag(HIGHCONTRASTW_FLAGS.HCF_HIGHCONTRASTON);
+    }
+}

--- a/src/thirtytwo/Application.cs
+++ b/src/thirtytwo/Application.cs
@@ -14,7 +14,7 @@ namespace Windows;
 /// <summary>
 ///  Main application class.
 /// </summary>
-public static unsafe class Application
+public static unsafe partial class Application
 {
     // Keep all framework-owned WM_APP identifiers together so new allocations cannot silently overlap.
 

--- a/src/thirtytwo/ApplicationColorMode.cs
+++ b/src/thirtytwo/ApplicationColorMode.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>Specifies how an application chooses its light or dark color palette.</summary>
+public enum ApplicationColorMode
+{
+    /// <summary>
+    ///  Follows the current Windows application color preference and High Contrast changes.
+    /// </summary>
+    System,
+
+    /// <summary>Uses the dark application palette.</summary>
+    Dark,
+
+    /// <summary>Uses the light application palette.</summary>
+    Light
+}

--- a/src/thirtytwo/ApplicationColorPalette.cs
+++ b/src/thirtytwo/ApplicationColorPalette.cs
@@ -1,0 +1,265 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows.Win32.UI.ViewManagement;
+
+namespace Windows;
+
+/// <summary>Contains immutable opaque semantic colors used by native windows and controls.</summary>
+public sealed record ApplicationColorPalette
+{
+    // ------------------------------
+    // Palette sources and derivation
+    // ------------------------------
+    //
+    // Normative source:
+    // -----------------
+    //
+    // The non-contrast palette follows the immutable theme resources shipped by Microsoft.WindowsAppSDK.WinUI
+    // 2.3.0. This repository references Microsoft.WindowsAppSDK 2.3.1, whose resolved dependency graph selects
+    // that WinUI component version. The source values are in lib/native/Microsoft.UI/Themes/generic.xaml. The
+    // Default dictionary is the Dark theme and the Light dictionary is the Light theme.
+    //
+    // Sources:
+    // https://learn.microsoft.com/windows/apps/develop/platform/xaml/xaml-theme-resources
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/main/src/controls/dev/CommonStyles/Common_themeresources_any.xaml
+    //
+    // Compositing:
+    // ------------
+    //
+    // WinUI stores many colors as translucent ARGB tokens. GDI and DWM consumers need opaque colors, so each token
+    // is composited over the surface on which this framework uses it. For each channel:
+    //
+    //     round((source * alpha + destination * (255 - alpha)) / 255)
+    //
+    // Text and disabled text are composited over their matching window or control fill. Border is composited over
+    // the window surface because its current consumer is the top-level DWM frame. A control border would instead
+    // composite the same raw token over ControlBackground.
+    //
+    // Raw WinUI 2.3.0 tokens (ARGB):
+    // ------------------------------
+    //
+    // Dark:
+    //
+    // - SolidBackgroundFillColorBase=#FF202020
+    // - TextFillColorPrimary=#FFFFFFFF
+    // - TextFillColorDisabled=#5DFFFFFF
+    // - ControlFillColorDefault=#0FFFFFFF
+    // - ControlStrokeColorDefault=#12FFFFFF
+    // - TextOnAccentFillColorSelectedText=#FFFFFFFF
+    //
+    // Light:
+    //
+    // - SolidBackgroundFillColorBase=#FFF3F3F3
+    // - TextFillColorPrimary=#E4000000
+    // - TextFillColorDisabled=#5C000000
+    // - ControlFillColorDefault=#B3FFFFFF
+    // - ControlStrokeColorDefault=#0F000000
+    // - TextOnAccentFillColorSelectedText=#FFFFFFFF
+    //
+    // Related WinUI tokens reserved for future state-specific drawing:
+    //
+    // These are recorded so custom drawing does not invent another ramp. Dark ControlFillColorSecondary=#15FFFFFF,
+    // ControlFillColorTertiary=#08FFFFFF, and ControlFillColorDisabled=#0BFFFFFF composite over #202020 to #323232,
+    // #272727, and #2A2A2A. Light ControlFillColorSecondary=#80F9F9F9, ControlFillColorTertiary=#4DF9F9F9, and
+    // ControlFillColorDisabled=#4DF9F9F9 composite over #F3F3F3 to #F6F6F6, #F5F5F5, and #F5F5F5. WinUI maps
+    // these to normal pointer-over, pressed, and disabled control backgrounds respectively.
+    //
+    // Dark focus tokens are FocusStrokeColorOuter=#FFFFFFFF and FocusStrokeColorInner=#B3000000; over #2D2D2D they
+    // are #FFFFFF and #0D0D0D. Light focus tokens are FocusStrokeColorOuter=#E4000000 and
+    // FocusStrokeColorInner=#B3FFFFFF; over #FBFBFB they are #1B1B1B and #FEFEFE. WinUI tooltip resources use
+    // background #2B2B2B with foreground #FFFFFF in Dark, and background #F2F2F2 with effective foreground #1A1A1A
+    // in Light. This type does not expose these roles until a native focus or tooltip adapter consumes them.
+    //
+    // Opaque values produced for this type:
+    // -------------------------------------
+    //
+    // Dark:
+    //
+    // - WindowBackground=#202020; WindowForeground=#FFFFFF
+    // - ControlBackground=#2D2D2D; ControlForeground=#FFFFFF
+    // - DisabledForeground=#7A7A7A; Border=#303030; SelectionForeground=#FFFFFF
+    // - The disabled token over the window surface would be #717171.
+    // - The border token over the control surface would be #3C3C3C.
+    //
+    // Light:
+    //
+    // - WindowBackground=#F3F3F3; WindowForeground=#1A1A1A
+    // - ControlBackground=#FBFBFB; ControlForeground=#1B1B1B
+    // - DisabledForeground=#A0A0A0; Border=#E5E5E5; SelectionForeground=#FFFFFF
+    // - The disabled token over the window surface would be #9B9B9B.
+    // - The border token over the control surface would be #ECECEC.
+    //
+    // WCAG relative-luminance checks:
+    //
+    // - Dark window text: 16.29:1
+    // - Dark control text: 13.77:1
+    // - Dark disabled control text: 3.21:1
+    // - Light window text: 15.68:1
+    // - Light control text: 16.65:1
+    // - Light disabled control text: 2.53:1
+    //
+    // Disabled text is exempt from the WCAG text contrast requirement but remains recorded so changes are deliberate.
+    //
+    // Dynamic accent:
+    // ---------------
+    //
+    // WinUI defines AccentFillColorSelectedTextBackgroundBrush with SystemAccentColor. SelectionBackground therefore
+    // comes from the documented Windows.UI.ViewManagement.UISettings.GetColorValue(UIColorType.Accent) WinRT API.
+    // If activation or the call fails, the documented GetSysColor(COLOR_HIGHLIGHT) value is used. SelectionForeground
+    // follows TextOnAccentFillColorSelectedText.
+    //
+    // Sources:
+    // https://learn.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.getcolorvalue
+    // https://learn.microsoft.com/uwp/api/windows.ui.viewmanagement.uicolortype
+    //
+    // For emphasized controls, WinUI's AccentFillColorDefaultBrush uses SystemAccentColorLight2 in Dark and
+    // SystemAccentColorDark1 in Light. Its pointer-over and pressed variants apply brush opacities 0.9 and 0.8.
+    // Those accent-control roles are not currently represented by this type.
+    //
+    // High Contrast:
+    // --------------
+    // High Contrast does not use the WinUI Light or Dark ramp. Values come from the documented system color pairs
+    // COLOR_WINDOW/COLOR_WINDOWTEXT, COLOR_3DFACE/COLOR_BTNTEXT, COLOR_GRAYTEXT, and
+    // COLOR_HIGHLIGHT/COLOR_HIGHLIGHTTEXT. The frame uses COLOR_WINDOWTEXT, which Microsoft documents for app and
+    // window borders on Windows 10 and 11.
+    //
+    // Source:
+    // https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-getsyscolor
+    //
+    // Research probes (observations, not palette contracts):
+    // ------------------------------------------------------
+    //
+    // - On Windows build 10.0.26200.0, UISettings.GetColorValue returned Background=#FF000000,
+    //   Foreground=#FFFFFFFF, AccentDark3=#FF001A68, AccentDark2=#FF003E92, AccentDark1=#FF0067C0,
+    //   Accent=#FF0078D4, AccentLight1=#FF0091F8, AccentLight2=#FF4CC2FF, and AccentLight3=#FF99EBFF. White over
+    //   the measured Accent had 4.53:1 contrast.
+    //
+    // - On the same build, UISettings.UIElementColor returned classic Light values rather than modern dark colors:
+    //   ActiveCaption=#99B4D1, Background=#4A5459, ButtonFace=#F0F0F0, ButtonText=#000000, CaptionText=#000000,
+    //   GrayText=#6D6D6D, Highlight=#0078D7, HighlightText=#FFFFFF, Hotlight=#0066CC,
+    //   InactiveCaption=#BFCDDB, InactiveCaptionText=#000000, Window=#FFFFFF, and WindowText=#000000. AccentColor,
+    //   TextHigh, TextMedium, TextLow, TextContrastWithHigh, NonTextHigh, NonTextMediumHigh, NonTextMedium,
+    //   NonTextMediumLow, NonTextLow, PageBackground, PopupBackground, and OverlayOutsidePopup all returned
+    //   transparent #00000000. It is therefore not a modern Light/Dark palette provider.
+    //
+    // - DwmGetColorizationColor returned #E3006FC4 with opaque blending enabled while UISettings Accent was
+    //   #FF0078D4. DWM colorization is a chrome composition color, not the WinUI accent resource.
+    //
+    // - With the undocumented native dark-mode compatibility option enabled, captured common controls used dominant
+    //   Button and ComboBox fill #333333, borders #9B9B9B/#8B8B8B, and checked glyph #60CDFF. On build 26200,
+    //   DarkMode_Explorer drew the selected radio label #000000 even though WM_CTLCOLORBTN set the semantic control
+    //   foreground; DarkMode_DarkTheme rendered it #FFFFFF. These are build- and state-specific pixels.
+    //
+    // - Documented GetThemeColor returned HRESULT 0x80070490 for most fill and border properties of those
+    //   bitmap-backed dark parts. Push-button text reported #000000 for normal/hot/pressed/defaulted and #838383 for
+    //   disabled. Checkbox/radio normal text was absent and disabled text was #6D6D6D. ComboBox borders reported
+    //   #ABADB3 and disabled text #6D6D6D; these are inherited Light values. Documented DrawThemeBackground rendered
+    //   a Light Button with dominant fill #FDFDFD and borders #D0D0D0/#BABABA, and a Light ComboBox with fill #FDFDFD
+    //   and borders #D2D2D2/#BCBCBC, even for HWNDs visibly using the private dark association. Explicit
+    //   DarkMode_Explorer::Button failed to open; CFD::ComboBox still rendered Light. Rendered sampling is retained
+    //   only as compatibility-test evidence, not as a production color provider.
+    //
+    // - WinUI's XamlControlsResources exposes runtime resource dictionaries but requires Windows App SDK and XAML
+    //   initialization, so it is suitable for the optional WinUI package rather than the Windows-App-SDK-independent
+    //   core. ColorPaletteResources is an override dictionary, not a system palette reader.
+    //   Microsoft.UI.System.ThemeSettings reports High Contrast state and scheme only; it exposes no colors.
+
+    internal ApplicationColorPalette(
+        Color windowBackground,
+        Color windowForeground,
+        Color controlBackground,
+        Color controlForeground,
+        Color disabledForeground,
+        Color border,
+        Color selectionBackground,
+        Color selectionForeground)
+    {
+        WindowBackground = windowBackground;
+        WindowForeground = windowForeground;
+        ControlBackground = controlBackground;
+        ControlForeground = controlForeground;
+        DisabledForeground = disabledForeground;
+        Border = border;
+        SelectionBackground = selectionBackground;
+        SelectionForeground = selectionForeground;
+    }
+
+    /// <summary>Gets the default top-level window and inherited custom-control background.</summary>
+    public Color WindowBackground { get; }
+
+    /// <summary>Gets the default foreground for text drawn directly on <see cref="WindowBackground"/>.</summary>
+    public Color WindowForeground { get; }
+
+    /// <summary>Gets the default background for interactive native control surfaces.</summary>
+    public Color ControlBackground { get; }
+
+    /// <summary>Gets the default foreground for text drawn on <see cref="ControlBackground"/>.</summary>
+    public Color ControlForeground { get; }
+
+    /// <summary>Gets the default disabled foreground for text drawn on <see cref="ControlBackground"/>.</summary>
+    public Color DisabledForeground { get; }
+
+    /// <summary>Gets the default top-level window border color.</summary>
+    public Color Border { get; }
+
+    /// <summary>Gets the default selected-text background.</summary>
+    public Color SelectionBackground { get; }
+
+    /// <summary>Gets the default selected-text foreground.</summary>
+    public Color SelectionForeground { get; }
+
+    internal static ApplicationColorPalette Create(bool dark, bool highContrast)
+    {
+        if (highContrast)
+        {
+            return new(
+                GetSystemColor(SystemColor.Window),
+                GetSystemColor(SystemColor.WindowText),
+                GetSystemColor(SystemColor.ButtonFace),
+                GetSystemColor(SystemColor.ButtonText),
+                GetSystemColor(SystemColor.GrayText),
+                GetSystemColor(SystemColor.WindowText),
+                GetSystemColor(SystemColor.Highlight),
+                GetSystemColor(SystemColor.HightlightText));
+        }
+
+        Color windowBackground = dark ? Color.FromArgb(32, 32, 32) : Color.FromArgb(243, 243, 243);
+        Color textFillPrimary = dark ? Color.White : Color.FromArgb(228, 0, 0, 0);
+        Color textFillDisabled = dark ? Color.FromArgb(93, 255, 255, 255) : Color.FromArgb(92, 0, 0, 0);
+        Color controlFillDefault = dark ? Color.FromArgb(15, 255, 255, 255) : Color.FromArgb(179, 255, 255, 255);
+        Color controlStrokeDefault = dark ? Color.FromArgb(18, 255, 255, 255) : Color.FromArgb(15, 0, 0, 0);
+        Color controlBackground = Composite(controlFillDefault, windowBackground);
+
+        return new(
+            windowBackground,
+            Composite(textFillPrimary, windowBackground),
+            controlBackground,
+            Composite(textFillPrimary, controlBackground),
+            Composite(textFillDisabled, controlBackground),
+            Composite(controlStrokeDefault, windowBackground),
+            GetSelectionBackground(),
+            Color.White);
+    }
+
+    private static Color Composite(Color source, Color destination)
+    {
+        int inverseAlpha = byte.MaxValue - source.A;
+        return Color.FromArgb(
+            CompositeChannel(source.R, source.A, destination.R, inverseAlpha),
+            CompositeChannel(source.G, source.A, destination.G, inverseAlpha),
+            CompositeChannel(source.B, source.A, destination.B, inverseAlpha));
+    }
+
+    private static int CompositeChannel(int source, int alpha, int destination, int inverseAlpha)
+        => ((source * alpha) + (destination * inverseAlpha) + 127) / byte.MaxValue;
+
+    private static Color GetSelectionBackground()
+        => SystemColorModeProvider.TryGetColor(UISettingsColorType.Accent, out UISettingsColor accent)
+            ? Color.FromArgb(accent.A, accent.R, accent.G, accent.B)
+            : GetSystemColor(SystemColor.Highlight);
+
+    private static Color GetSystemColor(SystemColor color)
+        => new COLORREF(PInvoke.GetSysColor((SYS_COLOR_INDEX)color));
+}

--- a/src/thirtytwo/ApplicationColorState.cs
+++ b/src/thirtytwo/ApplicationColorState.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>Represents an immutable snapshot of the application's resolved color state.</summary>
+public sealed record ApplicationColorState
+{
+    internal ApplicationColorState(
+        ApplicationColorMode requestedMode,
+        bool isDark,
+        bool isHighContrast,
+        bool useUndocumentedDarkModeApis,
+        bool undocumentedDarkModeApisSupported,
+        int generation,
+        ApplicationColorPalette palette)
+    {
+        RequestedMode = requestedMode;
+        IsDark = isDark;
+        IsHighContrast = isHighContrast;
+        UseUndocumentedDarkModeApis = useUndocumentedDarkModeApis;
+        UndocumentedDarkModeApisSupported = undocumentedDarkModeApisSupported;
+        Generation = generation;
+        Palette = palette;
+    }
+
+    /// <summary>Gets the mode requested through <see cref="Application.ColorMode"/>.</summary>
+    public ApplicationColorMode RequestedMode { get; }
+
+    /// <summary>Gets whether the resolved Windows application preference is Dark.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   When <see cref="IsHighContrast"/> is <see langword="true"/>, the palette contains system High Contrast
+    ///   colors regardless of this value.
+    ///  </para>
+    /// </remarks>
+    public bool IsDark { get; }
+
+    /// <summary>Gets whether Windows High Contrast is active.</summary>
+    public bool IsHighContrast { get; }
+
+    /// <summary>Gets whether private Windows dark-mode APIs are enabled for native control compatibility.</summary>
+    public bool UseUndocumentedDarkModeApis { get; }
+
+    /// <summary>Gets whether the required private Windows dark-mode exports are available.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   A native wrapper can use this with <see cref="UseUndocumentedDarkModeApis"/> to decide whether it needs a
+    ///   documented rendering fallback. Availability does not indicate that a private theme was applied successfully
+    ///   to any particular HWND.
+    ///  </para>
+    /// </remarks>
+    public bool UndocumentedDarkModeApisSupported { get; }
+
+    /// <summary>Gets the generation token for this application color state.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   Controls can compare this value for equality to invalidate resources cached from another snapshot. The
+    ///   numeric value can wrap and does not provide an ordering contract.
+    ///  </para>
+    /// </remarks>
+    public int Generation { get; }
+
+    /// <summary>Gets the resolved semantic colors for native window and control rendering.</summary>
+    public ApplicationColorPalette Palette { get; }
+}

--- a/src/thirtytwo/Controls/ButtonControl.cs
+++ b/src/thirtytwo/Controls/ButtonControl.cs
@@ -30,6 +30,7 @@ public partial class ButtonControl : RegisteredControl
             parameters,
             (HMENU)buttonId)
     {
+        ApplyApplicationTheme();
     }
 
     /// <summary>Gets or sets the check state of a check box, radio button, or three-state button.</summary>
@@ -53,6 +54,19 @@ public partial class ButtonControl : RegisteredControl
             Click?.Invoke(this, EventArgs.Empty);
         }
     }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        ApplyApplicationTheme();
+        base.OnColorModeChanged();
+    }
+
+    private void ApplyApplicationTheme()
+        => ApplyApplicationDarkModeTheme(
+            OperatingSystem.IsWindowsVersionAtLeast(10, 0, 26200)
+                ? "DarkMode_DarkTheme"
+                : "DarkMode_Explorer");
 
     /// <summary>Raises the <see cref="Click"/> event.</summary>
     protected virtual void OnClick()

--- a/src/thirtytwo/Controls/ComboBoxControl.cs
+++ b/src/thirtytwo/Controls/ComboBoxControl.cs
@@ -106,6 +106,7 @@ public unsafe partial class ComboBoxControl : RegisteredControl
             s_comboBoxClass,
             parameters)
     {
+        ApplyApplicationTheme();
     }
 
     /// <summary>
@@ -314,6 +315,24 @@ public unsafe partial class ComboBoxControl : RegisteredControl
                 OnSelectionCanceled();
                 SelectionCanceled?.Invoke(this, EventArgs.Empty);
                 break;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        ApplyApplicationTheme();
+        base.OnColorModeChanged();
+    }
+
+    private void ApplyApplicationTheme()
+    {
+        ApplyApplicationDarkModeTheme("CFD");
+
+        COMBOBOXINFO comboBoxInfo = new() { cbSize = (uint)sizeof(COMBOBOXINFO) };
+        if (PInvoke.GetComboBoxInfo(Handle, &comboBoxInfo) && !comboBoxInfo.hwndList.IsNull)
+        {
+            ApplyApplicationDarkModeTheme(comboBoxInfo.hwndList, "DarkMode_Explorer");
         }
     }
 

--- a/src/thirtytwo/Controls/RichEditControl.cs
+++ b/src/thirtytwo/Controls/RichEditControl.cs
@@ -3,6 +3,7 @@
 
 using System.Drawing;
 using Windows.Support;
+using Windows.Win32.UI.Controls.RichEdit;
 
 namespace Windows;
 
@@ -40,5 +41,40 @@ public partial class RichEditControl : EditBase
             parentWindow,
             parameters)
     {
+        ApplyApplicationColors();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        ApplyApplicationColors();
+        base.OnColorModeChanged();
+    }
+
+    private unsafe void ApplyApplicationColors()
+    {
+        ApplicationColorState state = Application.CurrentColorState;
+        ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+
+        Color background = state.Palette.ControlBackground;
+        this.SendMessage(
+            (MessageType)PInvoke.EM_SETBKGNDCOLOR,
+            (WPARAM)(BOOL)state.IsHighContrast,
+            (LPARAM)(nint)((COLORREF)background).Value);
+
+        CHARFORMAT2W characterFormat = new();
+        characterFormat.Base.cbSize = (uint)sizeof(CHARFORMAT2W);
+        characterFormat.Base.dwMask = CFM_MASK.CFM_COLOR;
+        characterFormat.Base.dwEffects = state.IsHighContrast ? CFE_EFFECTS.CFE_AUTOCOLOR : default;
+        characterFormat.Base.crTextColor = (COLORREF)state.Palette.ControlForeground;
+
+        this.SendMessage(
+            (MessageType)PInvoke.EM_SETCHARFORMAT,
+            default,
+            (LPARAM)(nint)(&characterFormat));
+        this.SendMessage(
+            (MessageType)PInvoke.EM_SETCHARFORMAT,
+            (WPARAM)PInvoke.SCF_ALL,
+            (LPARAM)(nint)(&characterFormat));
     }
 }

--- a/src/thirtytwo/Controls/TextLabelControl.cs
+++ b/src/thirtytwo/Controls/TextLabelControl.cs
@@ -43,14 +43,9 @@ public class TextLabelControl : CustomControl
 
     public Color TextColor
     {
-        get => _textColor;
+        get => _textColor.IsEmpty ? Application.CurrentColorState.Palette.WindowForeground : _textColor;
         set
         {
-            if (value.IsEmpty)
-            {
-                value = Color.Black;
-            }
-
             if (value == _textColor)
             {
                 return;
@@ -101,6 +96,18 @@ public class TextLabelControl : CustomControl
         }
 
         base.OnPaint();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        if (_textBrush is { } brush)
+        {
+            brush.Color = TextColor;
+        }
+
+        this.Invalidate();
+        base.OnColorModeChanged();
     }
 
     protected override LRESULT WindowProcedure(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)

--- a/src/thirtytwo/DeviceContextExtensions.cs
+++ b/src/thirtytwo/DeviceContextExtensions.cs
@@ -535,4 +535,12 @@ public static unsafe partial class DeviceContextExtensions
         GC.KeepAlive(context.Wrapper);
         return color;
     }
+
+    /// <inheritdoc cref="PInvoke.SetTextColor(HDC, COLORREF)"/>
+    public static Color SetTextColor<T>(this T context, Color color) where T : IHandle<HDC>
+    {
+        COLORREF result = PInvoke.SetTextColor(context.Handle, (COLORREF)color);
+        GC.KeepAlive(context.Wrapper);
+        return result;
+    }
 }

--- a/src/thirtytwo/NativeMethods.txt
+++ b/src/thirtytwo/NativeMethods.txt
@@ -15,6 +15,9 @@ CallWindowProc
 CB_*
 CBN_*
 CBS_*
+CFE_EFFECTS
+CFM_MASK
+CHARFORMAT2W
 CHILDID_SELF
 CLASS_E_NOTLICENSED
 CLEARTYPE_NATURAL_QUALITY
@@ -71,6 +74,7 @@ DrawFocusRect
 DrawIconEx
 DRAWITEMSTRUCT
 DrawTextEx
+DwmSetWindowAttribute
 DWriteCreateFactory
 E_ACCESSDENIED
 E_FAIL
@@ -147,6 +151,7 @@ GetClipboardData
 GetClipboardFormatName
 GetClipboardOwner
 GetClipRgn
+GetComboBoxInfo
 GetCurrentThread
 GetCurrentThreadId
 GetCursorPos
@@ -179,6 +184,7 @@ GetProcessDpiAwareness
 GetRgnBox
 GetROP2
 GetStockObject
+GetSysColor
 GetSysColorBrush
 GetTextColor
 GetThreadDpiAwarenessContext
@@ -205,6 +211,8 @@ GlobalSize
 GlobalUnlock
 GUID_WICPixelFormat32bppPBGRA
 HFONT
+HIGHCONTRASTW
+HIGHCONTRASTW_FLAGS
 HKEY_*
 HRESULT
 HWND_MESSAGE
@@ -331,6 +339,9 @@ ReleaseDC
 RemoveClipboardFormatListener
 RestoreDC
 ROLE_SYSTEM_*
+RoActivateInstance
+RoInitialize
+RoUninitialize
 RoundRect
 S_FALSE
 S_OK
@@ -340,6 +351,9 @@ SafeArrayGetVartype
 SafeArrayLock
 SafeArrayUnlock
 SaveDC
+SCF_ALL
+SCF_DEFAULT
+SCF_SELECTION
 ScreenToClient
 SelectClipRgn
 SelectObject
@@ -372,6 +386,7 @@ SetWindowLong
 SetWindowLongPtr
 SetWindowRgn
 SetWindowText
+SetWindowTheme
 SetWorldTransform
 SHCreateShellItem
 SHDefExtractIcon
@@ -383,6 +398,7 @@ STATE_SYSTEM_*
 STATIC_STYLES
 STATUS_BUFFER_OVERFLOW
 STATUS_BUFFER_TOO_SMALL
+SystemParametersInfo
 STATUS_INFO_LENGTH_MISMATCH
 STATUS_SUCCESS
 SubtractRect
@@ -412,5 +428,7 @@ VIRTUAL_KEY
 WICComponentEnumerateOptions
 WIN32_ERROR
 WINDOWPOS
+WindowsCreateString
+WindowsDeleteString
 WM_*
 XFORMCOORDS

--- a/src/thirtytwo/Support/PreferredAppMode.cs
+++ b/src/thirtytwo/Support/PreferredAppMode.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows;
+
+/// <summary>Defines the known mode values for the private UxTheme <c>SetPreferredAppMode</c> export.</summary>
+internal enum PreferredAppMode
+{
+    /// <summary>Requests the export's default application mode.</summary>
+    Default,
+
+    /// <summary>Requests that the export permit Dark mode without forcing it.</summary>
+    AllowDark,
+
+    /// <summary>Requests that the export force Dark mode.</summary>
+    ForceDark,
+
+    /// <summary>Requests that the export force Light mode.</summary>
+    ForceLight
+}

--- a/src/thirtytwo/Support/UndocumentedDarkMode.cs
+++ b/src/thirtytwo/Support/UndocumentedDarkMode.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32.System.LibraryLoader;
+
+namespace Windows;
+
+/// <summary>Applies private UxTheme dark-mode preferences when explicitly enabled by the application.</summary>
+/// <devdoc>
+///  <para>
+///   These exports are undocumented and can change between Windows releases. On Windows 10 build 17763, ordinal
+///   133 is <c>AllowDarkModeForWindow(HWND, bool)</c> and ordinal 135 is <c>AllowDarkModeForApp(bool)</c>. Starting
+///   with build 18362, ordinal 135 retains its number but changes to
+///   <c>SetPreferredAppMode(PreferredAppMode)</c>. Keep the signatures separated by the build check below.
+///  </para>
+///  <para>
+///   Export lookup failure disables the private path. The containing module remains loaded for the process lifetime
+///   because the cached function pointers are valid only while UxTheme is loaded. Documented palette rendering and
+///   <c>SetWindowTheme</c> reset behavior remain available when this adapter is unsupported or disabled.
+///  </para>
+/// </devdoc>
+internal static unsafe class UndocumentedDarkMode
+{
+    private const ushort AllowDarkModeForWindowOrdinal = 133;
+    private const ushort SetPreferredAppModeOrdinal = 135;
+
+    private static readonly Lock s_lock = new();
+
+    // Cached exports require UxTheme to remain loaded for the process lifetime.
+    private static readonly HMODULE s_uxTheme = LoadUxTheme();
+    private static readonly FARPROC s_allowDarkModeForWindow = GetExport(AllowDarkModeForWindowOrdinal);
+    private static readonly FARPROC s_setPreferredAppMode = GetExport(SetPreferredAppModeOrdinal);
+    private static int s_configuredGeneration = -1;
+
+    /// <summary>Gets whether the required private UxTheme exports are available on this Windows version.</summary>
+    /// <value>
+    ///  <see langword="true"/> when Windows is build 17763 or later and both required exports resolved;
+    ///  otherwise, <see langword="false"/>.
+    /// </value>
+    internal static bool IsSupported
+        => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763)
+            && !s_allowDarkModeForWindow.IsNull
+            && !s_setPreferredAppMode.IsNull;
+
+    /// <summary>Configures the process-wide private preferred application mode for the current color generation.</summary>
+    /// <param name="state">The resolved application color state to apply.</param>
+    /// <remarks>
+    ///  <para>
+    ///   This method does nothing when the private exports are unavailable or the generation has already been
+    ///   configured. High Contrast and an application opt-out restore the default private application mode.
+    ///  </para>
+    /// </remarks>
+    internal static void ConfigureApplication(ApplicationColorState state)
+    {
+        if (!IsSupported)
+        {
+            return;
+        }
+
+        lock (s_lock)
+        {
+            if (s_configuredGeneration == state.Generation)
+            {
+                return;
+            }
+
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 18362))
+            {
+                PreferredAppMode mode = !state.UseUndocumentedDarkModeApis || state.IsHighContrast
+                    ? PreferredAppMode.Default
+                    : state.IsDark
+                        ? PreferredAppMode.ForceDark
+                        : PreferredAppMode.ForceLight;
+
+                _ = ((delegate* unmanaged[Stdcall]<PreferredAppMode, PreferredAppMode>)(void*)s_setPreferredAppMode.Value)(mode);
+            }
+            else
+            {
+                byte allowDark = state.UseUndocumentedDarkModeApis && state.IsDark && !state.IsHighContrast
+                    ? (byte)1
+                    : (byte)0;
+
+                _ = ((delegate* unmanaged[Stdcall]<byte, byte>)(void*)s_setPreferredAppMode.Value)(allowDark);
+            }
+
+            s_configuredGeneration = state.Generation;
+        }
+    }
+
+    /// <summary>Applies or removes a private dark visual-style association for a window.</summary>
+    /// <param name="window">The window whose visual-style association is updated.</param>
+    /// <param name="state">The resolved application color state to apply.</param>
+    /// <param name="darkThemeName">The private visual-style class name used when dark mode is active.</param>
+    /// <remarks>
+    ///  <para>
+    ///   The private per-window opt-in is enabled only when the exports are supported, the application has not opted
+    ///   out, Dark mode is effective, and High Contrast is inactive. Otherwise, <c>SetWindowTheme</c> receives null
+    ///   theme names to remove the prior association.
+    ///  </para>
+    /// </remarks>
+    internal static void ApplyWindowTheme(HWND window, ApplicationColorState state, string darkThemeName)
+    {
+        ConfigureApplication(state);
+
+        bool useDarkTheme = ShouldUseDarkTheme(state);
+
+        if (!s_allowDarkModeForWindow.IsNull)
+        {
+            _ = ((delegate* unmanaged[Stdcall]<HWND, byte, byte>)(void*)s_allowDarkModeForWindow.Value)(
+                window,
+                useDarkTheme ? (byte)1 : (byte)0);
+        }
+
+        _ = PInvoke.SetWindowTheme(window, useDarkTheme ? darkThemeName : null, null);
+    }
+
+    private static bool ShouldUseDarkTheme(ApplicationColorState state)
+        => IsSupported
+            && state.UseUndocumentedDarkModeApis
+            && state.IsDark
+            && !state.IsHighContrast;
+
+    private static FARPROC GetExport(ushort ordinal)
+        => s_uxTheme.IsNull
+            ? default
+            : PInvoke.GetProcAddress(s_uxTheme, new PCSTR((byte*)(nuint)ordinal));
+
+    private static HMODULE LoadUxTheme()
+    {
+        fixed (char* moduleName = "uxtheme.dll")
+        {
+            return PInvoke.LoadLibraryEx(
+                moduleName,
+                default,
+                LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_SEARCH_SYSTEM32);
+        }
+    }
+}

--- a/src/thirtytwo/SystemColorModeProvider.cs
+++ b/src/thirtytwo/SystemColorModeProvider.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32.System.Com;
+using Windows.Win32.System.WinRT;
+using Windows.Win32.UI.ViewManagement;
+
+namespace Windows;
+
+/// <summary>Reads the supported Windows application color preference through UISettings.</summary>
+internal static unsafe class SystemColorModeProvider
+{
+    // https://learn.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings
+    private const string UISettingsRuntimeClass = "Windows.UI.ViewManagement.UISettings";
+
+    internal static bool TryGetIsDark(out bool dark)
+    {
+        dark = false;
+        if (!TryGetColor(UISettingsColorType.Foreground, out UISettingsColor foreground))
+        {
+            return false;
+        }
+
+        dark = IsLight(foreground);
+        return true;
+    }
+
+    internal static bool TryGetColor(UISettingsColorType colorType, out UISettingsColor color)
+    {
+        color = default;
+        RO_INIT_TYPE initializationType = Thread.CurrentThread.GetApartmentState() == ApartmentState.STA
+            ? RO_INIT_TYPE.RO_INIT_SINGLETHREADED
+            : RO_INIT_TYPE.RO_INIT_MULTITHREADED;
+        HRESULT initializationResult = PInvoke.RoInitialize(initializationType);
+        bool uninitialize = initializationResult.Succeeded;
+        if (initializationResult.Failed)
+        {
+            return false;
+        }
+
+        HSTRING runtimeClass = default;
+        try
+        {
+            fixed (char* runtimeClassPointer = UISettingsRuntimeClass)
+            {
+                HRESULT stringResult = PInvoke.WindowsCreateString(
+                    runtimeClassPointer,
+                    (uint)UISettingsRuntimeClass.Length,
+                    &runtimeClass);
+
+                if (stringResult.Failed)
+                {
+                    return false;
+                }
+            }
+
+            using ComScope<IInspectable> inspectable = new(null);
+            if (PInvoke.RoActivateInstance(runtimeClass, inspectable).Failed)
+            {
+                return false;
+            }
+
+            using ComScope<IUISettings3> settings = new(((IUnknown*)inspectable.Pointer)->TryQueryInterface<IUISettings3>());
+            if (settings.IsNull)
+            {
+                return false;
+            }
+
+            UISettingsColor result = default;
+            if (settings.Pointer->GetColorValue(colorType, &result).Failed)
+            {
+                return false;
+            }
+
+            color = result;
+            return true;
+        }
+        finally
+        {
+            if (!runtimeClass.IsNull)
+            {
+                _ = PInvoke.WindowsDeleteString(runtimeClass);
+            }
+
+            if (uninitialize)
+            {
+                PInvoke.RoUninitialize();
+            }
+        }
+    }
+
+    /// <summary>Classifies a color with Microsoft's documented weighted-brightness heuristic.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   A light application foreground indicates Dark mode. This is a quick classifier, not a general luminance
+    ///   model. See <see href="https://learn.microsoft.com/windows/apps/desktop/modernize/ui/apply-windows-themes#know-when-dark-mode-is-enabled">Support Dark and Light themes in Win32 apps</see>.
+    ///  </para>
+    /// </remarks>
+    internal static bool IsLight(UISettingsColor color)
+        => ((5 * color.G) + (2 * color.R) + color.B) > (8 * 128);
+}

--- a/src/thirtytwo/Win32/UI/ViewManagement/IUISettings3.cs
+++ b/src/thirtytwo/Win32/UI/ViewManagement/IUISettings3.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Windows.Win32.UI.ViewManagement;
+
+/// <summary>Raw Windows Runtime interface used to read application color preferences.</summary>
+/// <remarks>
+///  <para>
+///   See <see href="https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uisettings.getcolorvalue">UISettings.GetColorValue</see>
+///   for the projected API. The IID and ABI layout are defined by the Windows SDK's
+///   <see href="https://github.com/microsoft/win32metadata/blob/5ced95101b7458c83e3bed4e92c369ff27753648/generation/WinSDK/RecompiledIdlHeaders/winrt/windows.ui.viewmanagement.h#L3999-L4029">IUISettings3 declaration</see>.
+///  </para>
+/// </remarks>
+internal unsafe struct IUISettings3 : IComIID
+{
+    private readonly void** _vtable;
+
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xe4, 0x1b, 0x02, 0x03,
+                0x54, 0x52,
+                0x81, 0x47,
+                0x81, 0x94, 0x51, 0x68, 0xf7, 0xd0, 0x6d, 0x7b
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+
+    /// <summary>
+    ///  Invokes the raw ABI form of
+    ///  <see href="https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uisettings.getcolorvalue">UISettings.GetColorValue</see>.
+    /// </summary>
+    internal HRESULT GetColorValue(UISettingsColorType desiredColor, UISettingsColor* value)
+    {
+        fixed (IUISettings3* settings = &this)
+        {
+            return ((delegate* unmanaged[Stdcall]<IUISettings3*, UISettingsColorType, UISettingsColor*, HRESULT>)_vtable[6])(
+                settings,
+                desiredColor,
+                value);
+        }
+    }
+}

--- a/src/thirtytwo/Win32/UI/ViewManagement/UISettingsColor.cs
+++ b/src/thirtytwo/Win32/UI/ViewManagement/UISettingsColor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Win32.UI.ViewManagement;
+
+/// <summary>Represents the ABI layout of <c>Windows.UI.Color</c>.</summary>
+internal struct UISettingsColor
+{
+    internal byte A;
+    internal byte R;
+    internal byte G;
+    internal byte B;
+}

--- a/src/thirtytwo/Win32/UI/ViewManagement/UISettingsColorType.cs
+++ b/src/thirtytwo/Win32/UI/ViewManagement/UISettingsColorType.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Windows.Win32.UI.ViewManagement;
+
+/// <summary>Identifies a semantic color exposed by UISettings.</summary>
+internal enum UISettingsColorType
+{
+    Background,
+    Foreground,
+    AccentDark3,
+    AccentDark2,
+    AccentDark1,
+    Accent,
+    AccentLight1,
+    AccentLight2,
+    AccentLight3,
+    Complement
+}

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -496,7 +496,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                     or MessageType.ControlColorScrollBar;
                 DeviceContext controlContext = (DeviceContext)wParam;
                 controlContext.SetBackgroundColor(controlBackgroundOwner.GetEffectiveBackgroundColor(controlSurface));
-                controlContext.SetTextColor(control.GetEffectiveForegroundColor());
+                controlContext.SetTextColor(control.GetEffectiveForegroundColor(controlSurface));
                 return (LRESULT)controlBackgroundOwner.GetBackgroundBrush(controlSurface).Value;
 
             case MessageType.GetFont:

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Drawing;
 using System.Numerics;
+using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.Graphics.Direct2D;
 
 namespace Windows;
@@ -58,6 +59,10 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     private uint _lastDpi;
     private Color _backgroundColor;
     private HBRUSH _backgroundBrush;
+    private Color _backgroundBrushColor;
+    private HBRUSH _controlBackgroundBrush;
+    private Color _controlBackgroundBrushColor;
+    private int _colorModeGeneration = -1;
 
     private readonly Features _features;
 
@@ -133,6 +138,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
         _features = features;
         _backgroundColor = backgroundColor;
+        UndocumentedDarkMode.ConfigureApplication(Application.CurrentColorState);
 
         try
         {
@@ -166,6 +172,8 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             // Default system font is applied, use a nicer (ClearType) font
             this.SetFontHandle(GetDefaultFontForDpi((int)_lastDpi));
         }
+
+        ApplyApplicationColorMode(invokeCallback: false);
     }
 
     /// <summary>
@@ -207,6 +215,40 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             if (reference.TryGetTarget(out Window? window) && ReferenceEquals(window._thread, Thread.CurrentThread))
             {
                 window.AttachDispatcher(dispatcher);
+            }
+        }
+    }
+
+    internal static void ApplyApplicationColorModeToWindows()
+    {
+        HashSet<Threading.Dispatcher> postedDispatchers = [];
+        foreach (WeakReference<Window> reference in s_windows.Values)
+        {
+            if (!reference.TryGetTarget(out Window? window) || window.Handle.IsNull)
+            {
+                continue;
+            }
+
+            if (ReferenceEquals(window._thread, Thread.CurrentThread))
+            {
+                window.ApplyApplicationColorMode(invokeCallback: true);
+            }
+            else if (window._dispatcher is { } dispatcher && postedDispatchers.Add(dispatcher))
+            {
+                _ = dispatcher.TryPost(ApplyApplicationColorModeToCurrentThread);
+            }
+        }
+    }
+
+    private static void ApplyApplicationColorModeToCurrentThread()
+    {
+        foreach (WeakReference<Window> reference in s_windows.Values)
+        {
+            if (reference.TryGetTarget(out Window? window)
+                && !window.Handle.IsNull
+                && ReferenceEquals(window._thread, Thread.CurrentThread))
+            {
+                window.ApplyApplicationColorMode(invokeCallback: true);
             }
         }
     }
@@ -328,7 +370,8 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 {
                     _renderTarget.BeginDraw();
                     _renderTarget.SetTransform(Matrix3x2.Identity);
-                    _renderTarget.Clear(GetBackgroundOwner()?._backgroundColor ?? default);
+                    Window backgroundOwner = GetBackgroundOwner();
+                    _renderTarget.Clear(backgroundOwner.GetEffectiveBackgroundColor(controlSurface: false));
                 }
 
                 break;
@@ -447,13 +490,14 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 Window control = lParam == 0
                     ? this
                     : FromHandle((HWND)lParam, walkParents: true) ?? this;
-                if (control.GetBackgroundOwner() is { } controlBackgroundOwner)
-                {
-                    ((HDC)wParam).SetBackgroundColor(controlBackgroundOwner._backgroundColor);
-                    return (LRESULT)controlBackgroundOwner.GetBackgroundBrush().Value;
-                }
-
-                break;
+                Window controlBackgroundOwner = control.GetBackgroundOwner();
+                bool controlSurface = message is MessageType.ControlColorEdit
+                    or MessageType.ControlColorListBox
+                    or MessageType.ControlColorScrollBar;
+                DeviceContext controlContext = (DeviceContext)wParam;
+                controlContext.SetBackgroundColor(controlBackgroundOwner.GetEffectiveBackgroundColor(controlSurface));
+                controlContext.SetTextColor(control.GetEffectiveForegroundColor());
+                return (LRESULT)controlBackgroundOwner.GetBackgroundBrush(controlSurface).Value;
 
             case MessageType.GetFont:
                 // We only want to handle fonts if we're not an externally registered class.
@@ -483,6 +527,12 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 HandleDpiChanged(new(wParam, lParam));
                 break;
 
+            case MessageType.SettingChange:
+            case MessageType.SystemColorChange:
+            case MessageType.ThemeChanged:
+                Application.RefreshSystemColorMode();
+                break;
+
             case MessageType.Command:
                 if (lParam != 0 && FromHandle((HWND)lParam, walkParents: false) is Window child)
                 {
@@ -508,33 +558,172 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             : PInvoke.CallWindowProc(_priorWindowProcedure, window, (uint)message, wParam, lParam);
     }
 
-    private Window? GetBackgroundOwner()
+    /// <summary>Called after the effective application color state changes.</summary>
+    /// <remarks>
+    ///  <para>
+    ///   This method is called on the window's owning UI thread after <see cref="Application.CurrentColorState"/> is
+    ///   updated. Derived controls should recreate palette-dependent resources here and then call the base method.
+    ///   Initial construction does not invoke this virtual method; initialize those resources in the derived
+    ///   constructor or the relevant creation hook as well.
+    ///  </para>
+    /// </remarks>
+    protected virtual void OnColorModeChanged()
     {
-        Window? current = this;
+    }
+
+    /// <summary>Applies the current application color state to this window using a private dark theme class.</summary>
+    /// <param name="darkThemeName">The private visual-style class name used when dark mode is active.</param>
+    /// <remarks>
+    ///  <para>
+    ///   Call this after the window handle is created and again from <see cref="OnColorModeChanged"/>. The framework
+    ///   applies the private theme only when <see cref="Application.UseUndocumentedDarkModeApis"/> is enabled, Dark
+    ///   mode is resolved, and High Contrast is inactive. Otherwise, it removes the prior private association.
+    ///  </para>
+    /// </remarks>
+    protected void ApplyApplicationDarkModeTheme(string darkThemeName)
+        => ApplyApplicationDarkModeTheme(Handle, darkThemeName);
+
+    /// <summary>Applies the current application color state to an owned native window using a private dark theme class.</summary>
+    /// <param name="window">The owned native window whose visual-style association is updated.</param>
+    /// <param name="darkThemeName">The private visual-style class name used when dark mode is active.</param>
+    /// <remarks>
+    ///  <para>
+    ///   This overload supports unwrapped child or popup windows owned by a derived control. The supplied handle must
+    ///   remain valid for the duration of the call.
+    ///  </para>
+    /// </remarks>
+    protected void ApplyApplicationDarkModeTheme(HWND window, string darkThemeName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(darkThemeName);
+        UndocumentedDarkMode.ApplyWindowTheme(window, Application.CurrentColorState, darkThemeName);
+    }
+
+    private Window GetBackgroundOwner()
+    {
+        Window current = this;
         while (current._backgroundColor.IsEmpty && !current.Handle.IsNull)
         {
             HWND parentHandle = PInvoke.GetParent(current.Handle);
             Window? parent = parentHandle.IsNull ? null : FromHandle(parentHandle, walkParents: true);
             if (parent is null || ReferenceEquals(parent, current))
             {
-                return null;
+                break;
             }
 
             current = parent;
         }
 
-        return current._backgroundColor.IsEmpty ? null : current;
+        return current;
     }
 
-    private HBRUSH GetBackgroundBrush()
+    /// <summary>Gets the effective inherited background color for this window.</summary>
+    /// <param name="controlSurface">
+    ///  <see langword="true"/> to use the semantic interactive-control background when no explicit background is
+    ///  inherited; <see langword="false"/> to use the semantic window background.
+    /// </param>
+    /// <returns>The nearest explicit ancestor background or the current semantic default.</returns>
+    protected Color GetEffectiveBackgroundColor(bool controlSurface = false)
     {
-        Debug.Assert(!_backgroundColor.IsEmpty);
-        if (_backgroundBrush.IsNull)
+        Window backgroundOwner = GetBackgroundOwner();
+        if (!backgroundOwner._backgroundColor.IsEmpty)
         {
-            _backgroundBrush = HBRUSH.CreateSolid(_backgroundColor);
+            return backgroundOwner._backgroundColor;
         }
 
-        return _backgroundBrush;
+        ApplicationColorPalette palette = Application.CurrentColorState.Palette;
+        return controlSurface ? palette.ControlBackground : palette.WindowBackground;
+    }
+
+    /// <summary>Gets the effective enabled or disabled semantic foreground color for this window.</summary>
+    /// <param name="controlSurface">
+    ///  <see langword="true"/> to use the semantic interactive-control foreground; <see langword="false"/> to use
+    ///  the semantic window foreground.
+    /// </param>
+    /// <returns>The current enabled foreground, or the disabled foreground when this window is disabled.</returns>
+    protected Color GetEffectiveForegroundColor(bool controlSurface = true)
+    {
+        ApplicationColorPalette palette = Application.CurrentColorState.Palette;
+        if (!PInvoke.IsWindowEnabled(Handle))
+        {
+            return palette.DisabledForeground;
+        }
+
+        return controlSurface ? palette.ControlForeground : palette.WindowForeground;
+    }
+
+    private HBRUSH GetBackgroundBrush(bool controlSurface = false)
+    {
+        Color color = GetEffectiveBackgroundColor(controlSurface);
+        ref HBRUSH brush = ref controlSurface ? ref _controlBackgroundBrush : ref _backgroundBrush;
+        ref Color brushColor = ref controlSurface ? ref _controlBackgroundBrushColor : ref _backgroundBrushColor;
+        if (brush.IsNull || brushColor != color)
+        {
+            brush.Dispose();
+            brush = HBRUSH.CreateSolid(color);
+            brushColor = color;
+        }
+
+        return brush;
+    }
+
+    private void ApplyApplicationColorMode(bool invokeCallback)
+    {
+        if (Handle.IsNull)
+        {
+            return;
+        }
+
+        ApplicationColorState state = Application.CurrentColorState;
+        if (_colorModeGeneration == state.Generation)
+        {
+            return;
+        }
+
+        _colorModeGeneration = state.Generation;
+        _backgroundBrush.Dispose();
+        _backgroundBrush = default;
+        _backgroundBrushColor = default;
+        _controlBackgroundBrush.Dispose();
+        _controlBackgroundBrush = default;
+        _controlBackgroundBrushColor = default;
+        UndocumentedDarkMode.ConfigureApplication(state);
+        ApplyTitleBarColorMode(state);
+        if (invokeCallback)
+        {
+            OnColorModeChanged();
+        }
+
+        this.Invalidate(erase: true);
+    }
+
+    private void ApplyTitleBarColorMode(ApplicationColorState state)
+    {
+        if (PInvoke.GetAncestor(Handle, GET_ANCESTOR_FLAGS.GA_ROOT) != Handle)
+        {
+            return;
+        }
+
+        BOOL dark = state.IsDark && !state.IsHighContrast;
+        // These attributes are unavailable on older Windows versions. Client-area theming remains functional when
+        // DWM rejects an attribute, so compatibility failures are intentionally nonfatal.
+        _ = PInvoke.DwmSetWindowAttribute(
+            Handle,
+            DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &dark,
+            (uint)sizeof(BOOL));
+
+        uint caption = state.IsHighContrast
+            ? uint.MaxValue
+            : ((COLORREF)state.Palette.WindowBackground).Value;
+        uint text = state.IsHighContrast
+            ? uint.MaxValue
+            : ((COLORREF)state.Palette.WindowForeground).Value;
+        uint border = state.IsHighContrast
+            ? uint.MaxValue
+            : ((COLORREF)state.Palette.Border).Value;
+        _ = PInvoke.DwmSetWindowAttribute(Handle, DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR, &caption, sizeof(uint));
+        _ = PInvoke.DwmSetWindowAttribute(Handle, DWMWINDOWATTRIBUTE.DWMWA_TEXT_COLOR, &text, sizeof(uint));
+        _ = PInvoke.DwmSetWindowAttribute(Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, &border, sizeof(uint));
     }
 
     private void HandleDpiChanged(Message.DpiChanged dpiChanged)
@@ -653,6 +842,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
         if (disposing)
         {
             _backgroundBrush.Dispose();
+            _controlBackgroundBrush.Dispose();
             _lastCreatedFont.Dispose();
             _font.Dispose();
             _renderTarget?.Dispose();

--- a/src/thirtytwo_tests/ApplicationColorModeTests.cs
+++ b/src/thirtytwo_tests/ApplicationColorModeTests.cs
@@ -208,9 +208,9 @@ public class ApplicationColorModeTests
     }
 
     [STATestMethod]
-    public unsafe void ColorMode_RadioButton_UsesDarkControlForeground()
+    public unsafe void ColorMode_RadioButton_UsesWindowSurfaceColors()
     {
-        Application.ColorMode = ApplicationColorMode.Dark;
+        Application.ColorMode = ApplicationColorMode.Light;
         using MainWindow window = new(Window.DefaultBounds);
         using ButtonControl radioButton = new(
             text: "Radio button",
@@ -223,6 +223,25 @@ public class ApplicationColorModeTests
             (WPARAM)(nuint)context.Handle.Value,
             (LPARAM)radioButton.Handle);
 
+        context.GetBackgroundColor().Should().Be(Application.CurrentColorState.Palette.WindowBackground);
+        context.GetTextColor().ToArgb().Should().Be(
+            Application.CurrentColorState.Palette.WindowForeground.ToArgb());
+    }
+
+    [STATestMethod]
+    public unsafe void ColorMode_Edit_UsesControlSurfaceColors()
+    {
+        Application.ColorMode = ApplicationColorMode.Light;
+        using MainWindow window = new(Window.DefaultBounds);
+        using EditControl edit = new(text: "Edit", parentWindow: window);
+        using DeviceContext context = edit.GetDeviceContext();
+
+        _ = window.SendMessage(
+            MessageType.ControlColorEdit,
+            (WPARAM)(nuint)context.Handle.Value,
+            (LPARAM)edit.Handle);
+
+        context.GetBackgroundColor().Should().Be(Application.CurrentColorState.Palette.ControlBackground);
         context.GetTextColor().ToArgb().Should().Be(
             Application.CurrentColorState.Palette.ControlForeground.ToArgb());
     }

--- a/src/thirtytwo_tests/ApplicationColorModeTests.cs
+++ b/src/thirtytwo_tests/ApplicationColorModeTests.cs
@@ -1,0 +1,394 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.Controls.RichEdit;
+using Windows.Win32.UI.ViewManagement;
+
+namespace Windows;
+
+[TestClass]
+[DoNotParallelize]
+public class ApplicationColorModeTests
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Application.ColorMode = ApplicationColorMode.System;
+        Application.UseUndocumentedDarkModeApis = true;
+    }
+
+    [TestMethod]
+    public void ColorMode_Default_IsSystem()
+    {
+        Application.ColorMode.Should().Be(ApplicationColorMode.System);
+    }
+
+    [TestMethod]
+    public void UseUndocumentedDarkModeApis_Default_IsEnabled()
+    {
+        Application.UseUndocumentedDarkModeApis.Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void UseUndocumentedDarkModeApis_Change_UpdatesExistingWindow()
+    {
+        Application.UseUndocumentedDarkModeApis = true;
+        using ColorModeWindow window = new();
+
+        Application.UseUndocumentedDarkModeApis = false;
+
+        window.ColorModeChangeCount.Should().Be(1);
+    }
+
+    [TestMethod]
+    public void IsLight_DarkAndLightColors_ClassifiesPerDocumentedFormula()
+    {
+        SystemColorModeProvider.IsLight(new UISettingsColor { A = 255, R = 0, G = 0, B = 0 }).Should().BeFalse();
+        SystemColorModeProvider.IsLight(new UISettingsColor { A = 255, R = 255, G = 255, B = 255 }).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TryGetIsDark_CurrentInteractiveSession_Succeeds()
+    {
+        if (!OperatingSystem.IsWindowsVersionAtLeast(10))
+        {
+            return;
+        }
+
+        SystemColorModeProvider.TryGetIsDark(out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public unsafe void IUISettings3_Iid_IsExpected()
+    {
+        (*IID.Get<IUISettings3>()).Should().Be(new Guid("03021be4-5254-4781-8194-5168f7d06d7b"));
+    }
+
+    [TestMethod]
+    public void ColorPalette_Dark_UsesWinUI23ThemeTokens()
+    {
+        ApplicationColorPalette palette = ApplicationColorPalette.Create(dark: true, highContrast: false);
+
+        palette.WindowBackground.ToArgb().Should().Be(Color.FromArgb(32, 32, 32).ToArgb());
+        palette.WindowForeground.ToArgb().Should().Be(Color.White.ToArgb());
+        palette.ControlBackground.ToArgb().Should().Be(Color.FromArgb(45, 45, 45).ToArgb());
+        palette.ControlForeground.ToArgb().Should().Be(Color.White.ToArgb());
+        palette.DisabledForeground.ToArgb().Should().Be(Color.FromArgb(122, 122, 122).ToArgb());
+        palette.Border.ToArgb().Should().Be(Color.FromArgb(48, 48, 48).ToArgb());
+        palette.SelectionForeground.ToArgb().Should().Be(Color.White.ToArgb());
+    }
+
+    [TestMethod]
+    public void ColorPalette_Light_UsesWinUI23ThemeTokens()
+    {
+        ApplicationColorPalette palette = ApplicationColorPalette.Create(dark: false, highContrast: false);
+
+        palette.WindowBackground.ToArgb().Should().Be(Color.FromArgb(243, 243, 243).ToArgb());
+        palette.WindowForeground.ToArgb().Should().Be(Color.FromArgb(26, 26, 26).ToArgb());
+        palette.ControlBackground.ToArgb().Should().Be(Color.FromArgb(251, 251, 251).ToArgb());
+        palette.ControlForeground.ToArgb().Should().Be(Color.FromArgb(27, 27, 27).ToArgb());
+        palette.DisabledForeground.ToArgb().Should().Be(Color.FromArgb(160, 160, 160).ToArgb());
+        palette.Border.ToArgb().Should().Be(Color.FromArgb(229, 229, 229).ToArgb());
+        palette.SelectionForeground.ToArgb().Should().Be(Color.White.ToArgb());
+    }
+
+    [TestMethod]
+    public void ColorPalette_EquivalentInstances_AreValueEqual()
+    {
+        ApplicationColorPalette first = ApplicationColorPalette.Create(dark: true, highContrast: false);
+        ApplicationColorPalette second = ApplicationColorPalette.Create(dark: true, highContrast: false);
+
+        first.Should().NotBeSameAs(second);
+        first.Should().Be(second);
+    }
+
+    [TestMethod]
+    public void ColorPalette_HighContrast_UsesDocumentedSystemColors()
+    {
+        ApplicationColorPalette palette = ApplicationColorPalette.Create(dark: true, highContrast: true);
+
+        palette.WindowBackground.ToArgb().Should().Be(GetSystemColor(SystemColor.Window).ToArgb());
+        palette.WindowForeground.ToArgb().Should().Be(GetSystemColor(SystemColor.WindowText).ToArgb());
+        palette.ControlBackground.ToArgb().Should().Be(GetSystemColor(SystemColor.ButtonFace).ToArgb());
+        palette.ControlForeground.ToArgb().Should().Be(GetSystemColor(SystemColor.ButtonText).ToArgb());
+        palette.DisabledForeground.ToArgb().Should().Be(GetSystemColor(SystemColor.GrayText).ToArgb());
+        palette.Border.ToArgb().Should().Be(GetSystemColor(SystemColor.WindowText).ToArgb());
+        palette.SelectionBackground.ToArgb().Should().Be(GetSystemColor(SystemColor.Highlight).ToArgb());
+        palette.SelectionForeground.ToArgb().Should().Be(GetSystemColor(SystemColor.HightlightText).ToArgb());
+
+        static Color GetSystemColor(SystemColor color)
+            => new COLORREF(PInvoke.GetSysColor((SYS_COLOR_INDEX)color));
+    }
+
+    [TestMethod]
+    public void ColorPalette_SelectionBackground_UsesUISettingsAccent()
+    {
+        if (!SystemColorModeProvider.TryGetColor(UISettingsColorType.Accent, out UISettingsColor accent))
+        {
+            return;
+        }
+
+        ApplicationColorPalette palette = ApplicationColorPalette.Create(dark: true, highContrast: false);
+
+        palette.SelectionBackground.Should().Be(Color.FromArgb(accent.A, accent.R, accent.G, accent.B));
+    }
+
+    [TestMethod]
+    public void ColorMode_InvalidValue_ThrowsWithoutChangingMode()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+
+        Action action = () => Application.ColorMode = (ApplicationColorMode)int.MaxValue;
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+        Application.ColorMode.Should().Be(ApplicationColorMode.Dark);
+    }
+
+    [STATestMethod]
+    public unsafe void ColorMode_Change_UpdatesExistingWindowAndInheritedControlColors()
+    {
+        Application.ColorMode = ApplicationColorMode.Light;
+        using ColorModeWindow window = new();
+        using StaticControl label = new(text: "Label", parentWindow: window);
+        using DeviceContext context = label.GetDeviceContext();
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+        _ = window.SendMessage(
+            MessageType.ControlColorStatic,
+            (WPARAM)(nuint)context.Handle.Value,
+            (LPARAM)label.Handle);
+
+        window.ColorModeChangeCount.Should().Be(1);
+        context.GetBackgroundColor().Should().Be(Color.FromArgb(32, 32, 32));
+        context.GetTextColor().ToArgb().Should().Be(Color.White.ToArgb());
+    }
+
+    [STATestMethod]
+    public void ColorMode_SameValue_DoesNotNotifyExistingWindow()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+        using ColorModeWindow window = new();
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+
+        window.ColorModeChangeCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void CurrentColorState_RepeatedRead_ReturnsSameInstance()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+
+        ApplicationColorState first = Application.CurrentColorState;
+        ApplicationColorState second = Application.CurrentColorState;
+
+        second.Should().BeSameAs(first);
+        second.Palette.Should().BeSameAs(first.Palette);
+    }
+
+    [STATestMethod]
+    public unsafe void ColorMode_WindowCreatedAfterChange_UsesSelectedPalette()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+        using MainWindow window = new(Window.DefaultBounds);
+        using StaticControl label = new(text: "Label", parentWindow: window);
+        using DeviceContext context = label.GetDeviceContext();
+
+        _ = window.SendMessage(
+            MessageType.ControlColorStatic,
+            (WPARAM)(nuint)context.Handle.Value,
+            (LPARAM)label.Handle);
+
+        context.GetBackgroundColor().Should().Be(Color.FromArgb(32, 32, 32));
+        context.GetTextColor().ToArgb().Should().Be(Color.White.ToArgb());
+    }
+
+    [STATestMethod]
+    public unsafe void ColorMode_RadioButton_UsesDarkControlForeground()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+        using MainWindow window = new(Window.DefaultBounds);
+        using ButtonControl radioButton = new(
+            text: "Radio button",
+            buttonStyle: ButtonControl.Styles.AutoRadioButton,
+            parentWindow: window);
+        using DeviceContext context = radioButton.GetDeviceContext();
+
+        _ = window.SendMessage(
+            MessageType.ControlColorButton,
+            (WPARAM)(nuint)context.Handle.Value,
+            (LPARAM)radioButton.Handle);
+
+        context.GetTextColor().ToArgb().Should().Be(
+            Application.CurrentColorState.Palette.ControlForeground.ToArgb());
+    }
+
+    [STATestMethod]
+    public void ColorMode_Change_NotifiesRadioButton()
+    {
+        Application.ColorMode = ApplicationColorMode.Light;
+        using MainWindow window = new(Window.DefaultBounds);
+        using TrackingRadioButton radioButton = new(window);
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+
+        radioButton.ColorModeChangeCount.Should().Be(1);
+    }
+
+    [STATestMethod]
+    public void ColorMode_ExplicitBackground_RemainsUnchanged()
+    {
+        Color explicitColor = Color.Crimson;
+        using MainWindow window = new(Window.DefaultBounds, backgroundColor: explicitColor);
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+        Color actual = window.TestAccessor.Dynamic._backgroundColor;
+
+        actual.Should().Be(explicitColor);
+    }
+
+    [STATestMethod]
+    public void CurrentColorState_DerivedControl_ExposesResolvedRenderingContract()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+        using MainWindow window = new(Window.DefaultBounds);
+        using PublicColorControl control = new(window);
+
+        ApplicationColorState state = Application.CurrentColorState;
+        control.ApplyNativeTheme();
+
+        state.RequestedMode.Should().Be(ApplicationColorMode.Dark);
+        state.IsDark.Should().BeTrue();
+        state.UseUndocumentedDarkModeApis.Should().Be(Application.UseUndocumentedDarkModeApis);
+        state.UndocumentedDarkModeApisSupported.Should().Be(UndocumentedDarkMode.IsSupported);
+        state.Generation.Should().BeGreaterThan(0);
+        state.Palette.Should().Be(Application.CurrentColorState.Palette);
+        control.EffectiveWindowBackground.ToArgb().Should().Be(state.Palette.WindowBackground.ToArgb());
+        control.EffectiveControlBackground.ToArgb().Should().Be(state.Palette.ControlBackground.ToArgb());
+        control.EffectiveWindowForeground.ToArgb().Should().Be(state.Palette.WindowForeground.ToArgb());
+        control.EffectiveControlForeground.ToArgb().Should().Be(state.Palette.ControlForeground.ToArgb());
+
+        Application.ColorMode = ApplicationColorMode.Light;
+
+        control.ColorModeChangeCount.Should().Be(1);
+        control.LastColorState.RequestedMode.Should().Be(ApplicationColorMode.Light);
+        control.LastColorState.Generation.Should().NotBe(state.Generation);
+    }
+
+    [STATestMethod]
+    public void GetEffectiveBackgroundColor_ExplicitParent_InheritsColor()
+    {
+        Color explicitColor = Color.Crimson;
+        using MainWindow window = new(Window.DefaultBounds, backgroundColor: explicitColor);
+        using PublicColorControl control = new(window);
+
+        control.EffectiveWindowBackground.Should().Be(explicitColor);
+        control.EffectiveControlBackground.Should().Be(explicitColor);
+    }
+
+    [STATestMethod]
+    public unsafe void ColorMode_RichEdit_UpdatesBackgroundAndTextColors()
+    {
+        Application.ColorMode = ApplicationColorMode.Dark;
+        using MainWindow window = new(Window.DefaultBounds);
+        using RichEditControl richEdit = new(new(0, 0, 200, 100), text: "Rich text", parentWindow: window);
+
+        ApplicationColorPalette palette = Application.CurrentColorState.Palette;
+        COLORREF expectedBackground = (COLORREF)palette.ControlBackground;
+        LRESULT previousBackground = richEdit.SendMessage(
+            (MessageType)PInvoke.EM_SETBKGNDCOLOR,
+            default,
+            (LPARAM)(nint)expectedBackground.Value);
+
+        ((uint)previousBackground.Value).Should().Be(expectedBackground.Value);
+        GetCharacterFormat(richEdit, PInvoke.SCF_DEFAULT).Base.crTextColor
+            .Should().Be((COLORREF)palette.ControlForeground);
+
+        richEdit.SetSelection(0, -1);
+        GetCharacterFormat(richEdit, PInvoke.SCF_SELECTION).Base.crTextColor
+            .Should().Be((COLORREF)palette.ControlForeground);
+
+        static CHARFORMAT2W GetCharacterFormat(RichEditControl richEdit, uint scope)
+        {
+            CHARFORMAT2W characterFormat = new();
+            characterFormat.Base.cbSize = (uint)sizeof(CHARFORMAT2W);
+            richEdit.SendMessage(
+                (MessageType)PInvoke.EM_GETCHARFORMAT,
+                (WPARAM)scope,
+                (LPARAM)(nint)(&characterFormat));
+            characterFormat.Base.dwMask.HasFlag(CFM_MASK.CFM_COLOR).Should().BeTrue();
+            return characterFormat;
+        }
+    }
+
+    private sealed class ColorModeWindow : MainWindow
+    {
+        internal ColorModeWindow()
+            : base(Window.DefaultBounds)
+        {
+        }
+
+        internal int ColorModeChangeCount { get; private set; }
+
+        protected override void OnColorModeChanged()
+        {
+            ColorModeChangeCount++;
+            base.OnColorModeChanged();
+        }
+    }
+
+    private sealed class TrackingRadioButton : ButtonControl
+    {
+        internal TrackingRadioButton(Window parentWindow)
+            : base(buttonStyle: Styles.AutoRadioButton, parentWindow: parentWindow)
+        {
+        }
+
+        internal int ColorModeChangeCount { get; private set; }
+
+        protected override void OnColorModeChanged()
+        {
+            ColorModeChangeCount++;
+            base.OnColorModeChanged();
+        }
+    }
+
+    private sealed class PublicColorControl : CustomControl
+    {
+        internal PublicColorControl(Window parentWindow)
+            : base(parentWindow: parentWindow)
+        {
+            LastColorState = Application.CurrentColorState;
+        }
+
+        internal int ColorModeChangeCount { get; private set; }
+
+        internal ApplicationColorState LastColorState { get; private set; }
+
+        internal Color EffectiveWindowBackground => GetEffectiveBackgroundColor();
+
+        internal Color EffectiveControlBackground => GetEffectiveBackgroundColor(controlSurface: true);
+
+        internal Color EffectiveWindowForeground => GetEffectiveForegroundColor(controlSurface: false);
+
+        internal Color EffectiveControlForeground => GetEffectiveForegroundColor();
+
+        internal void ApplyNativeTheme()
+        {
+            ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+            ApplyApplicationDarkModeTheme(Handle, "DarkMode_Explorer");
+        }
+
+        protected override void OnColorModeChanged()
+        {
+            ColorModeChangeCount++;
+            LastColorState = Application.CurrentColorState;
+            ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+            base.OnColorModeChanged();
+        }
+    }
+}

--- a/thirtytwo.slnx
+++ b/thirtytwo.slnx
@@ -9,6 +9,9 @@
     <Project Path="src/samples/ClipboardViewer/ClipboardViewer.csproj">
       <Platform Project="x64" />
     </Project>
+    <Project Path="src/samples/DarkMode/DarkMode.csproj">
+      <Platform Project="x64" />
+    </Project>
     <Project Path="src/samples/KeyWatch/KeyWatch.csproj">
       <Platform Project="x64" />
     </Project>


### PR DESCRIPTION
## Summary

Add application-wide System, Dark, and Light color modes for native windows, controls, and hosted WinUI content. The implementation uses a semantic palette, respects High Contrast, and preserves explicit XAML theme overrides.

## Changes

- Add `Application.ColorMode`, immutable color-state snapshots, and semantic native palettes sourced from WinUI theme resources.
- Propagate mode changes across managed HWNDs, native controls, DWM title bars, and hosted WinUI content.
- Add WinRT `UISettings` color detection plus guarded compatibility support for native dark themes, including `DarkMode_DarkTheme` on Windows build 26200 and later.
- Add focused color-mode tests, package-consumer coverage, a native DarkMode sample, and a three-state retheming control in the BasicUsage sample.

## Validation

- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (443 passed, 1 manual test skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (443 passed, 1 manual test skipped)
- [x] New and changed behavior has focused tests
- [x] Native ownership, ABI signatures, size units, and failure cleanup were reviewed
- [x] `./eng/verify-winui-package-isolation.ps1 -Configuration Release` passes
- [x] Agent-file validation is not applicable because this commit does not change `.agents/`

## Related issues

None.