### PR TITLE
Add WinUI mixed-DPI diagnostics

### DIFF
--- a/src/samples/WinUI/DpiTesting/DpiObservingHost.cs
+++ b/src/samples/WinUI/DpiTesting/DpiObservingHost.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows;
+using Windows.WinUI;
+
+namespace DpiTesting;
+
+/// <summary>Exposes the protected host DPI callback to the diagnostic sample.</summary>
+internal sealed class DpiObservingHost : XamlHostControl
+{
+    internal DpiObservingHost(Rectangle bounds, Window parentWindow, Func<DpiTestContent> contentFactory)
+        : base(bounds, parentWindow, () => contentFactory())
+    {
+    }
+
+    internal event Action<uint, uint>? DpiTransition;
+
+    protected override void OnDpiChanged(uint oldDpi, uint newDpi)
+    {
+        base.OnDpiChanged(oldDpi, newDpi);
+        DpiTransition?.Invoke(oldDpi, newDpi);
+    }
+}

--- a/src/samples/WinUI/DpiTesting/DpiTestContent.cs
+++ b/src/samples/WinUI/DpiTesting/DpiTestContent.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace DpiTesting;
+
+/// <summary>Provides XAML-side DPI metrics and a fixed logical-size reference surface.</summary>
+internal sealed class DpiTestContent : Grid, IDisposable
+{
+    internal const double ReferenceWidth = 240;
+    internal const double ReferenceHeight = 120;
+
+    private readonly TextBlock _metrics;
+    private XamlRoot? _subscribedRoot;
+    private bool _disposed;
+
+    internal DpiTestContent()
+    {
+        Padding = new Thickness(16);
+        RowSpacing = 12;
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RowDefinitions.Add(new RowDefinition());
+
+        TextBlock title = new()
+        {
+            Text = "WinUI island",
+            FontSize = 22,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
+        };
+        Children.Add(title);
+
+        _metrics = new TextBlock
+        {
+            Text = "Waiting for XamlRoot...",
+            TextWrapping = TextWrapping.Wrap
+        };
+        SetRow(_metrics, 1);
+        Children.Add(_metrics);
+
+        Border reference = new()
+        {
+            Width = ReferenceWidth,
+            Height = ReferenceHeight,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            BorderBrush = new SolidColorBrush(Colors.DeepSkyBlue),
+            BorderThickness = new Thickness(3),
+            CornerRadius = new CornerRadius(4),
+            Child = new TextBlock
+            {
+                Text = "240 x 120 XAML DIPs",
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            }
+        };
+        SetRow(reference, 2);
+        Children.Add(reference);
+
+        ComboBox popup = new()
+        {
+            Header = "Popup alignment check",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Width = ReferenceWidth,
+            PlaceholderText = "Open while on each monitor"
+        };
+        popup.Items.Add("First popup item");
+        popup.Items.Add("Second popup item");
+        popup.Items.Add("Third popup item");
+        SetRow(popup, 3);
+        Children.Add(popup);
+
+        TextBlock guidance = new()
+        {
+            Text = "Native HWND bounds are physical pixels. XAML dimensions are view pixels and should convert using XamlRoot.RasterizationScale.",
+            TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Bottom
+        };
+        SetRow(guidance, 4);
+        Children.Add(guidance);
+
+        Loaded += ContentLoaded;
+        Unloaded += ContentUnloaded;
+        SizeChanged += ContentSizeChanged;
+    }
+
+    internal event EventHandler? MetricsChanged;
+
+    internal double XamlRootScale => XamlRoot?.RasterizationScale ?? 0;
+
+    internal double LogicalWidth => ActualWidth;
+
+    internal double LogicalHeight => ActualHeight;
+
+    internal string MetricsText => _metrics.Text;
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Loaded -= ContentLoaded;
+        Unloaded -= ContentUnloaded;
+        SizeChanged -= ContentSizeChanged;
+        DetachXamlRoot();
+    }
+
+    private void ContentLoaded(object sender, RoutedEventArgs eventArgs)
+    {
+        AttachXamlRoot();
+        UpdateMetrics();
+    }
+
+    private void ContentUnloaded(object sender, RoutedEventArgs eventArgs) => DetachXamlRoot();
+
+    private void ContentSizeChanged(object sender, SizeChangedEventArgs eventArgs) => UpdateMetrics();
+
+    private void XamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs eventArgs) => UpdateMetrics();
+
+    private void AttachXamlRoot()
+    {
+        XamlRoot? root = XamlRoot;
+        if (ReferenceEquals(root, _subscribedRoot))
+        {
+            return;
+        }
+
+        DetachXamlRoot();
+        _subscribedRoot = root;
+        if (_subscribedRoot is not null)
+        {
+            _subscribedRoot.Changed += XamlRootChanged;
+        }
+    }
+
+    private void DetachXamlRoot()
+    {
+        if (_subscribedRoot is not null)
+        {
+            _subscribedRoot.Changed -= XamlRootChanged;
+            _subscribedRoot = null;
+        }
+    }
+
+    private void UpdateMetrics()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        AttachXamlRoot();
+        double scale = XamlRootScale;
+        string text = scale == 0
+            ? "Waiting for XamlRoot..."
+            : $"XamlRoot scale: {scale:F3} ({scale * 100:F0}%)\nContent: {LogicalWidth:F1} x {LogicalHeight:F1} DIPs -> {LogicalWidth * scale:F0} x {LogicalHeight * scale:F0} pixels\nReference: {ReferenceWidth:F0} x {ReferenceHeight:F0} DIPs -> {ReferenceWidth * scale:F0} x {ReferenceHeight * scale:F0} pixels";
+
+        if (_metrics.Text != text)
+        {
+            _metrics.Text = text;
+        }
+
+        MetricsChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/samples/WinUI/DpiTesting/DpiTestWindow.cs
+++ b/src/samples/WinUI/DpiTesting/DpiTestWindow.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Drawing;
+using Windows;
+using Windows.Win32.Foundation;
+using ThirtyTwoLayout = Windows.Layout;
+
+namespace DpiTesting;
+
+/// <summary>Displays native and XAML DPI metrics while moving between monitors.</summary>
+internal sealed class DpiTestWindow : MainWindow
+{
+    private static readonly Size s_referenceLogicalSize = new(240, 120);
+
+    private readonly TextLabelControl _title;
+    private readonly ButtonControl _refreshButton;
+    private readonly TextLabelControl _nativeMetrics;
+    private readonly TextLabelControl _nativeReference;
+    private readonly DpiObservingHost _host;
+    private readonly DpiTestContent _content;
+    private readonly TextLabelControl _instructions;
+    private readonly Window[] _ownedControls;
+    private int _transitionCount;
+    private string _lastTransition = "none";
+
+    internal DpiTestWindow()
+        : base(
+            bounds: new Rectangle(40, 30, 1100, 760),
+            title: "thirtytwo WinUI Mixed-DPI Test")
+    {
+        List<Window> ownedControls = [];
+        DpiTestContent? content = null;
+
+        try
+        {
+            _title = Track(new TextLabelControl(
+                text: "WinUI mixed-monitor DPI test",
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _title.SetFont("Segoe UI", 20);
+
+            _refreshButton = Track(new ButtonControl(
+                text: "Refresh metrics",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop,
+                parentWindow: this), ownedControls);
+
+            _nativeMetrics = Track(new TextLabelControl(
+                textFormat: DrawTextFormat.Left | DrawTextFormat.Top | DrawTextFormat.WordBreak | DrawTextFormat.NoPrefix,
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _nativeMetrics.SetFont("Consolas", 10);
+
+            _nativeReference = Track(new TextLabelControl(
+                textFormat: DrawTextFormat.Center | DrawTextFormat.VerticallyCenter | DrawTextFormat.SingleLine,
+                text: "240 x 120 logical units",
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.Border,
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _nativeReference.SetFont("Segoe UI", 12);
+
+            _host = Track(new DpiObservingHost(default, this, () => content = new DpiTestContent()), ownedControls);
+            _content = content ?? throw new InvalidOperationException("The DPI test XAML content factory did not run.");
+
+            _instructions = Track(new TextLabelControl(
+                textFormat: DrawTextFormat.Left | DrawTextFormat.Top | DrawTextFormat.WordBreak | DrawTextFormat.NoPrefix,
+                text: "Move the window fully onto each monitor, resize and maximize it, then open the XAML popup. Native DPI and XAML scale should agree; both 240 x 120 rulers should remain the same logical size without clipping or blank frames.",
+                parentWindow: this,
+                features: Features.EnableDirect2d), ownedControls);
+            _instructions.SetFont("Segoe UI", 10);
+
+            _ownedControls = [.. ownedControls];
+            _refreshButton.Click += RefreshButtonClick;
+            _content.MetricsChanged += ContentMetricsChanged;
+            _host.DpiTransition += HostDpiTransition;
+
+            this.AddLayoutHandler(CreateWindowLayout());
+            MessageHandler += WindowMessageHandler;
+            UpdateMetrics();
+        }
+        catch
+        {
+            content?.Dispose();
+            for (int index = ownedControls.Count - 1; index >= 0; index--)
+            {
+                ownedControls[index].Dispose();
+            }
+
+            base.Dispose(disposing: true);
+            throw;
+        }
+    }
+
+    private static TControl Track<TControl>(TControl control, List<Window> ownedControls)
+        where TControl : Window
+    {
+        ownedControls.Add(control);
+        return control;
+    }
+
+    private ILayoutHandler CreateWindowLayout()
+    {
+        ILayoutHandler titleLayout = ThirtyTwoLayout.Vertical(
+            (.8f, ThirtyTwoLayout.Margin((16, 8, 8, 4), ThirtyTwoLayout.Fill(_title))),
+            (.2f, ThirtyTwoLayout.Margin((8, 8, 16, 4), ThirtyTwoLayout.Fill(_refreshButton))));
+
+        ILayoutHandler comparisonLayout = ThirtyTwoLayout.Vertical(
+            (.35f, ThirtyTwoLayout.Margin(
+                (16, 8, 8, 8),
+                ThirtyTwoLayout.FixedSize(s_referenceLogicalSize, _nativeReference))),
+            (.65f, ThirtyTwoLayout.Margin((8, 8, 16, 8), ThirtyTwoLayout.Fill(_host))));
+
+        return ThirtyTwoLayout.Horizontal(
+            (.09f, titleLayout),
+            (.22f, ThirtyTwoLayout.Margin((16, 4, 16, 4), ThirtyTwoLayout.Fill(_nativeMetrics))),
+            (.57f, comparisonLayout),
+            (.12f, ThirtyTwoLayout.Margin((16, 4, 16, 12), ThirtyTwoLayout.Fill(_instructions))));
+    }
+
+    protected override void OnDpiChanged(uint oldDpi, uint newDpi)
+    {
+        base.OnDpiChanged(oldDpi, newDpi);
+        RecordTransition("top-level", oldDpi, newDpi);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            MessageHandler -= WindowMessageHandler;
+            _refreshButton.Click -= RefreshButtonClick;
+            _content.MetricsChanged -= ContentMetricsChanged;
+            _host.DpiTransition -= HostDpiTransition;
+            _content.Dispose();
+            for (int index = _ownedControls.Length - 1; index >= 0; index--)
+            {
+                _ownedControls[index].Dispose();
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private LRESULT? WindowMessageHandler(
+        object sender,
+        HWND window,
+        MessageType message,
+        WPARAM wParam,
+        LPARAM lParam)
+    {
+        if (message == MessageType.WindowPositionChanged)
+        {
+            UpdateMetrics();
+        }
+
+        return null;
+    }
+
+    private void RefreshButtonClick(object? sender, EventArgs eventArgs) => UpdateMetrics();
+
+    private void ContentMetricsChanged(object? sender, EventArgs eventArgs) => UpdateMetrics();
+
+    private void HostDpiTransition(uint oldDpi, uint newDpi) => RecordTransition("host child", oldDpi, newDpi);
+
+    private void RecordTransition(string source, uint oldDpi, uint newDpi)
+    {
+        _transitionCount++;
+        _lastTransition = $"{source}: {oldDpi} -> {newDpi}";
+        UpdateMetrics();
+    }
+
+    private void UpdateMetrics()
+    {
+        if (Handle.IsNull || _host.Handle.IsNull)
+        {
+            return;
+        }
+
+        uint dpi = this.GetDpi();
+        float scale = this.GetScale();
+        Rectangle windowBounds = this.GetWindowRectangle();
+        Size clientSize = this.GetClientRectangle().Size;
+        Size hostSize = _host.GetClientRectangle().Size;
+        Size nativeReferenceSize = _nativeReference.GetWindowRectangle().Size;
+        int expectedNativeWidth = (int)MathF.Round(s_referenceLogicalSize.Width * scale);
+        int expectedNativeHeight = (int)MathF.Round(s_referenceLogicalSize.Height * scale);
+        double xamlScale = _content.XamlRootScale;
+        int expectedXamlWidth = (int)Math.Round(_content.LogicalWidth * xamlScale);
+        int expectedXamlHeight = (int)Math.Round(_content.LogicalHeight * xamlScale);
+        bool nativeMatches = Math.Abs(nativeReferenceSize.Width - expectedNativeWidth) <= 1
+            && Math.Abs(nativeReferenceSize.Height - expectedNativeHeight) <= 1;
+        bool xamlMatches = xamlScale > 0
+            && Math.Abs(hostSize.Width - expectedXamlWidth) <= 1
+            && Math.Abs(hostSize.Height - expectedXamlHeight) <= 1;
+
+        _nativeMetrics.Text = $"Native window DPI: {dpi} ({scale * 100:F0}%)\r\nWindow bounds (virtual-screen px): X={windowBounds.X}, Y={windowBounds.Y}, W={windowBounds.Width}, H={windowBounds.Height}; client={clientSize.Width} x {clientSize.Height} px\r\nHost client: {hostSize.Width} x {hostSize.Height} px; XAML root: {xamlScale:F3} ({xamlScale * 100:F0}%); host/XAML pixels: {(xamlMatches ? "MATCH" : "CHECK")}\r\nNative ruler: {nativeReferenceSize.Width} x {nativeReferenceSize.Height} px; expected {expectedNativeWidth} x {expectedNativeHeight}: {(nativeMatches ? "MATCH" : "CHECK")}\r\nDPI transitions: {_transitionCount}; last: {_lastTransition}";
+    }
+
+}

--- a/src/samples/WinUI/DpiTesting/DpiTesting.csproj
+++ b/src/samples/WinUI/DpiTesting/DpiTesting.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\thirtytwo.winui\thirtytwo.winui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/WinUI/DpiTesting/Program.cs
+++ b/src/samples/WinUI/DpiTesting/Program.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Jeremy W. Kuhne. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows;
+
+namespace DpiTesting;
+
+/// <summary>Starts the mixed-monitor WinUI DPI test application.</summary>
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+        => Application.Run(static () => new DpiTestWindow());
+}

--- a/src/samples/WinUI/DpiTesting/Test-Dpi.ps1
+++ b/src/samples/WinUI/DpiTesting/Test-Dpi.ps1
@@ -1,0 +1,185 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Release',
+
+    [switch] $NoBuild,
+
+    [switch] $MonitorReportOnly
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+$project = Join-Path $PSScriptRoot 'DpiTesting.csproj'
+$executable = Join-Path $repoRoot "artifacts\x64\$Configuration\DpiTesting\net10.0-windows10.0.17763.0\win-x64\DpiTesting.exe"
+$resultsDirectory = Join-Path $repoRoot 'artifacts\test-results\WinUIDpiManual'
+$results = [System.Collections.Generic.List[object]]::new()
+$process = $null
+$inputIdleTimeoutMilliseconds = 10000
+$exitTimeoutMilliseconds = 5000
+
+function Read-ManualResult {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Id,
+
+        [Parameter(Mandatory)]
+        [string] $Prompt
+    )
+
+    do {
+        $answer = (Read-Host "$Prompt [y = pass, n = fail, s = skip]").Trim().ToLowerInvariant()
+    } while ($answer -notin @('y', 'n', 's'))
+
+    $status = switch ($answer) {
+        'y' { 'Pass' }
+        'n' { 'Fail' }
+        default { 'Skipped' }
+    }
+
+    $notes = Read-Host 'Optional notes'
+    return [pscustomobject]@{
+        Id = $Id
+        Status = $status
+        Notes = $notes
+    }
+}
+
+if (-not ('DpiMonitorProbe' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class DpiMonitorProbe
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Point
+    {
+        internal int X;
+        internal int Y;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromPoint(Point point, uint flags);
+
+    [DllImport("shcore.dll")]
+    private static extern int GetScaleFactorForMonitor(IntPtr monitor, out int scale);
+
+    public static int GetScalePercent(int x, int y)
+    {
+        IntPtr monitor = MonitorFromPoint(new Point { X = x, Y = y }, 2);
+        int result = GetScaleFactorForMonitor(monitor, out int scale);
+        if (result < 0)
+        {
+            Marshal.ThrowExceptionForHR(result);
+        }
+
+        return scale;
+    }
+}
+'@
+}
+
+Push-Location $repoRoot
+try {
+    if (-not $NoBuild) {
+        & dotnet build $project --configuration $Configuration
+        if ($LASTEXITCODE -ne 0) {
+            throw "DPI sample build failed with exit code $LASTEXITCODE."
+        }
+    }
+
+    if (-not (Test-Path $executable)) {
+        throw "DPI sample executable was not found at '$executable'."
+    }
+
+    Add-Type -AssemblyName System.Windows.Forms
+    $monitors = [System.Collections.Generic.List[object]]::new()
+    foreach ($screen in [System.Windows.Forms.Screen]::AllScreens) {
+        $centerX = $screen.Bounds.Left + [int]($screen.Bounds.Width / 2)
+        $centerY = $screen.Bounds.Top + [int]($screen.Bounds.Height / 2)
+        $monitors.Add([pscustomobject]@{
+            DeviceName = $screen.DeviceName
+            Primary = $screen.Primary
+            ScalePercent = [DpiMonitorProbe]::GetScalePercent($centerX, $centerY)
+            Bounds = $screen.Bounds.ToString()
+            WorkingArea = $screen.WorkingArea.ToString()
+        })
+    }
+
+    if ($monitors.Count -lt 2) {
+        throw 'This checklist requires at least two monitors.'
+    }
+
+    $scaleCount = @($monitors.ScalePercent | Sort-Object -Unique).Count
+    if ($scaleCount -lt 2) {
+        throw 'This checklist requires monitors configured with at least two different Scale values.'
+    }
+
+    Write-Host ''
+    Write-Host 'Detected monitors:'
+    $monitors | Format-Table -AutoSize
+    Write-Host 'Windows Settings must configure at least two monitors with different Scale values.'
+    Write-Host 'The app reports native DPI, XamlRoot scale, physical bounds, and ruler consistency.'
+    Write-Host ''
+
+    if ($MonitorReportOnly) {
+        return
+    }
+
+    $process = Start-Process -FilePath $executable -PassThru
+    $becameInputIdle = $process.WaitForInputIdle($inputIdleTimeoutMilliseconds)
+    if (-not $becameInputIdle) {
+        throw 'The DPI sample did not become input-idle within 10 seconds.'
+    }
+
+    $results.Add((Read-ManualResult 'initial-monitor' 'With the app fully on the first monitor, do native DPI and XAML scale agree and do both metric lines show MATCH?'))
+    $results.Add((Read-ManualResult 'second-monitor' 'After dragging the app fully onto the second monitor, do DPI, XAML scale, pixel bounds, and transition count update without a blank frame?'))
+    $results.Add((Read-ManualResult 'logical-rulers' 'On both monitors, do the native and XAML 240 x 120 rulers retain comparable logical size with crisp borders and no clipping?'))
+    $results.Add((Read-ManualResult 'resize' 'On the second monitor, do repeated resize, maximize, restore, and snap operations keep host/XAML pixels at MATCH?'))
+    $results.Add((Read-ManualResult 'popup' 'On each monitor, does the XAML combo-box popup open at the control, remain sharp, and accept selection?'))
+    $results.Add((Read-ManualResult 'virtual-origin' 'If a monitor uses negative virtual-screen coordinates, can the app occupy it without clipping or incorrect bounds?'))
+    $results.Add((Read-ManualResult 'transition-stress' 'After moving between monitors at least ten times, is the app responsive with no focus loss, blank island, crash, or growing size drift?'))
+
+    $failed = @($results | Where-Object Status -eq 'Fail').Count
+    $passed = @($results | Where-Object Status -eq 'Pass').Count
+    $skipped = @($results | Where-Object Status -eq 'Skipped').Count
+    $overall = if ($failed -gt 0) { 'Fail' } elseif ($passed -eq 0) { 'Inconclusive' } else { 'Pass' }
+
+    New-Item -ItemType Directory -Force -Path $resultsDirectory | Out-Null
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $reportPath = Join-Path $resultsDirectory "dpi-manual-$timestamp.json"
+    $report = [pscustomobject]@{
+        Timestamp = (Get-Date).ToString('o')
+        Configuration = $Configuration
+        OperatingSystem = [System.Environment]::OSVersion.VersionString
+        ProcessId = $process.Id
+        Monitors = $monitors
+        Overall = $overall
+        Passed = $passed
+        Failed = $failed
+        Skipped = $skipped
+        Steps = $results
+    }
+
+    $report | ConvertTo-Json -Depth 6 | Set-Content -Path $reportPath -Encoding utf8
+    Write-Host ''
+    Write-Host "Overall result: $overall ($passed passed, $failed failed, $skipped skipped)"
+    Write-Host "Report: $reportPath"
+}
+finally {
+    if ($process -is [System.Diagnostics.Process]) {
+        if (-not $process.HasExited) {
+            [void]$process.CloseMainWindow()
+            $exited = $process.WaitForExit($exitTimeoutMilliseconds)
+            if (-not $exited) {
+                Write-Warning 'DPI sample did not exit cleanly; terminating it.'
+                Stop-Process -Id $process.Id -Force
+            }
+        }
+
+        $process.Dispose()
+    }
+
+    Pop-Location
+}

--- a/src/samples/WinUI/DpiTesting/app.manifest
+++ b/src/samples/WinUI/DpiTesting/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <maxversiontested Id="10.0.26100.0" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/thirtytwo.winui/XamlHostControl.cs
+++ b/src/thirtytwo.winui/XamlHostControl.cs
@@ -279,6 +279,32 @@ public unsafe partial class XamlHostControl : CustomControl
     }
 
     /// <inheritdoc/>
+    protected override void OnDpiChanged(uint oldDpi, uint newDpi)
+    {
+        DesktopWindowXamlSource? xamlSource = _xamlSource;
+        if (xamlSource is not null)
+        {
+            try
+            {
+                Size size = this.GetClientRectangle().Size;
+                ResizeSiteBridge(xamlSource, size);
+                XamlHostEventSource.Log.HostDpiChanged(
+                    PInvoke.GetCurrentThreadId(),
+                    oldDpi,
+                    newDpi,
+                    size.Width,
+                    size.Height);
+            }
+            catch (Exception exception)
+            {
+                ReportNativeCallbackFailure("DpiChanged", exception);
+            }
+        }
+
+        base.OnDpiChanged(oldDpi, newDpi);
+    }
+
+    /// <inheritdoc/>
     protected override void OnColorModeChanged()
     {
         ApplyApplicationTheme(_xamlSource?.Content);

--- a/src/thirtytwo.winui/XamlHostEventSource.cs
+++ b/src/thirtytwo.winui/XamlHostEventSource.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.Tracing;
 namespace Windows.WinUI;
 
 /// <summary>
-///  Emits WinUI host lifecycle, lease, initialization failure, and composition collision events.
+///  Emits WinUI host lifecycle, DPI, lease, initialization failure, and composition collision events.
 /// </summary>
 [EventSource(Name = "ThirtyTwo-WinUI")]
 internal sealed class XamlHostEventSource : EventSource
@@ -40,4 +40,8 @@ internal sealed class XamlHostEventSource : EventSource
     [Event(7, Level = EventLevel.Error)]
     public void HostCallbackFailed(uint nativeThreadId, string operation, int hresult, string exceptionType)
         => WriteEvent(7, nativeThreadId, operation, hresult, exceptionType);
+
+    [Event(8, Level = EventLevel.Informational)]
+    public void HostDpiChanged(uint nativeThreadId, uint oldDpi, uint newDpi, int width, int height)
+        => WriteEvent(8, nativeThreadId, oldDpi, newDpi, width, height);
 }

--- a/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
+++ b/src/thirtytwo.winui_tests/IntegrationHost/EnvironmentWindow.cs
@@ -487,7 +487,7 @@ internal sealed class EnvironmentWindow : Window
         _reporter.Write("multiple-host-disposal-completed");
     }
 
-    private void VerifyHostLayout()
+    private unsafe void VerifyHostLayout()
     {
         using XamlHostControl host = new(new Rectangle(0, 0, 1, 1), this, static () => new Grid());
         DesktopWindowXamlSource xamlSource = GetXamlSource(host);
@@ -517,6 +517,23 @@ internal sealed class EnvironmentWindow : Window
         Ensure(siteBridge.GetClientRectangle().Size == expectedSize, "The site bridge did not track the resize storm.");
         Ensure(ReferenceEquals(GetXamlSource(host), xamlSource), "Resizing replaced the XAML source.");
         _reporter.Write("host-resize-storm-completed");
+
+        uint oldDpi = host.GetDpi();
+        ushort newDpi = checked((ushort)(oldDpi + 24));
+        Rectangle dpiBounds = new(15, 20, 360, 240);
+        RECT suggestedBounds = dpiBounds;
+        nuint packedDpi = newDpi | ((nuint)newDpi << 16);
+
+        // SendMessage is synchronous, so the stack RECT remains valid until the window procedure returns.
+        _ = host.SendMessage(
+            MessageType.DpiChanged,
+            (WPARAM)packedDpi,
+            (LPARAM)(nint)(&suggestedBounds));
+
+        Ensure(host.GetClientRectangle().Size == dpiBounds.Size, "The managed host did not accept DPI-adjusted bounds.");
+        Ensure(siteBridge.GetClientRectangle().Size == dpiBounds.Size, "The site bridge did not resynchronize after DPI change.");
+        Ensure(ReferenceEquals(GetXamlSource(host), xamlSource), "DPI change replaced the XAML source.");
+        _reporter.Write("host-dpi-resynchronized");
     }
 
     private void VerifyHostReparent()

--- a/src/thirtytwo/Messages/Message.DpiChanged.cs
+++ b/src/thirtytwo/Messages/Message.DpiChanged.cs
@@ -7,9 +7,21 @@ namespace Windows;
 
 public static partial class Message
 {
-    public unsafe readonly ref struct DpiChanged(WPARAM wParam, LPARAM lParam)
+    public unsafe readonly ref struct DpiChanged
     {
-        public uint Dpi { get; } = wParam.HIWORD;
-        public Rectangle SuggestedBounds { get; } = *(RECT*)lParam;
+        public DpiChanged(WPARAM wParam, LPARAM lParam)
+        {
+            if (lParam == 0)
+            {
+                throw new ArgumentNullException(nameof(lParam));
+            }
+
+            Dpi = wParam.HIWORD;
+            SuggestedBounds = *(RECT*)lParam;
+        }
+
+        public uint Dpi { get; }
+
+        public Rectangle SuggestedBounds { get; }
     }
 }

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -57,6 +57,10 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     protected HwndRenderTarget RenderTarget => _renderTarget ?? throw new InvalidOperationException();
 
     private uint _lastDpi;
+
+    // PMv2 child messages carry no DPI payload. Preserve the old value before the parent transition so the
+    // after-parent notification can report the complete transition even if an ancestor updates this window's font.
+    private uint _dpiBeforeParent;
     private Color _backgroundColor;
     private HBRUSH _backgroundBrush;
     private Color _backgroundBrushColor;
@@ -319,6 +323,20 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     {
     }
 
+    /// <summary>Called after this window has transitioned to a different DPI.</summary>
+    /// <param name="oldDpi">The effective DPI before the transition.</param>
+    /// <param name="newDpi">The effective DPI after the transition.</param>
+    /// <remarks>
+    ///  <para>
+    ///   For a top-level window, the suggested bounds have been applied before this method is called. For a child
+    ///   window under a Per-Monitor V2 top-level window, this method is called while processing
+    ///   <see cref="MessageType.DpiChangedAfterParent"/>. Layout coordinates and HWND bounds are physical pixels.
+    ///  </para>
+    /// </remarks>
+    protected virtual void OnDpiChanged(uint oldDpi, uint newDpi)
+    {
+    }
+
     /// <summary>
     ///  Called whenever a command is sent to the window.
     /// </summary>
@@ -523,9 +541,16 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 break;
 
             case MessageType.DpiChanged:
-                // Resize and reposition for the new DPI
                 HandleDpiChanged(new(wParam, lParam));
-                break;
+                return default;
+
+            case MessageType.DpiChangedBeforeParent:
+                _dpiBeforeParent = _lastDpi;
+                return default;
+
+            case MessageType.DpiChangedAfterParent:
+                HandleDpiChangedAfterParent();
+                return default;
 
             case MessageType.SettingChange:
             case MessageType.SystemColorChange:
@@ -728,14 +753,49 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
     private void HandleDpiChanged(Message.DpiChanged dpiChanged)
     {
-        uint lastDpi = _lastDpi;
-        _lastDpi = dpiChanged.Dpi;
-        UpdateFontsForDpi(lastDpi, _lastDpi);
+        uint oldDpi = _lastDpi;
+        uint newDpi = dpiChanged.Dpi;
+        UpdateFontForDpi(oldDpi, newDpi);
+        UpdateDescendantFontsForDpi();
         this.MoveWindow(dpiChanged.SuggestedBounds, repaint: true);
+        if (oldDpi != 0 && oldDpi != newDpi)
+        {
+            OnDpiChanged(oldDpi, newDpi);
+        }
     }
 
-    private void UpdateFontsForDpi(uint lastDpi, uint newDpi)
+    private void HandleDpiChangedAfterParent()
     {
+        // PMv2 sends this to child HWNDs after the top-level WM_DPICHANGED, but supplies no new DPI or suggested
+        // bounds. Sample the child's effective DPI now that the parent transition is complete.
+        uint oldDpi = _dpiBeforeParent == 0 ? _lastDpi : _dpiBeforeParent;
+        uint newDpi = this.GetDpi();
+        _dpiBeforeParent = 0;
+
+        if (_lastDpi != newDpi)
+        {
+            UpdateFontForDpi(_lastDpi, newDpi);
+        }
+
+        if (oldDpi != 0 && oldDpi != newDpi)
+        {
+            OnDpiChanged(oldDpi, newDpi);
+        }
+    }
+
+    private void UpdateFontForDpi(uint lastDpi, uint newDpi)
+    {
+        if (newDpi == 0 || lastDpi == newDpi)
+        {
+            return;
+        }
+
+        if (lastDpi == 0)
+        {
+            _lastDpi = newDpi;
+            return;
+        }
+
         HFONT currentFont = this.GetFontHandle();
         HFONT lastCreatedFont = _lastCreatedFont;
 
@@ -758,9 +818,20 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
             this.SetFontHandle(GetDefaultFontForDpi((int)newDpi));
         }
 
+        _lastDpi = newDpi;
+    }
+
+    private void UpdateDescendantFontsForDpi()
+    {
+        // EnumChildWindows already walks the entire descendant tree. Update each managed HWND once rather than
+        // recursing from the callback and revisiting grandchildren.
         this.EnumerateChildWindows(child =>
         {
-            FromHandle(child)?.UpdateFontsForDpi(lastDpi, newDpi);
+            if (FromHandle(child) is { } childWindow)
+            {
+                childWindow.UpdateFontForDpi(childWindow._lastDpi, childWindow.GetDpi());
+            }
+
             return true;
         });
     }

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -519,7 +519,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
 
             case MessageType.GetFont:
                 // We only want to handle fonts if we're not an externally registered class.
-                if (!_windowClass.ModuleInstance.IsNull)
+                if (!_windowClass.IsSubclassed)
                 {
                     return (LRESULT)_font.Value;
                 }
@@ -527,7 +527,7 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 break;
 
             case MessageType.SetFont:
-                if (!_windowClass.ModuleInstance.IsNull)
+                if (!_windowClass.IsSubclassed)
                 {
                     _font = (HFONT)(nint)wParam.Value;
                     if ((BOOL)lParam.LOWORD)
@@ -541,16 +541,20 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
                 break;
 
             case MessageType.DpiChanged:
-                HandleDpiChanged(new(wParam, lParam));
-                return default;
+                if (lParam != 0)
+                {
+                    HandleDpiChanged(new(wParam, lParam));
+                }
+
+                return ForwardDpiMessageToRegisteredClass(window, message, wParam, lParam);
 
             case MessageType.DpiChangedBeforeParent:
                 _dpiBeforeParent = _lastDpi;
-                return default;
+                return ForwardDpiMessageToRegisteredClass(window, message, wParam, lParam);
 
             case MessageType.DpiChangedAfterParent:
                 HandleDpiChangedAfterParent();
-                return default;
+                return ForwardDpiMessageToRegisteredClass(window, message, wParam, lParam);
 
             case MessageType.SettingChange:
             case MessageType.SystemColorChange:
@@ -762,6 +766,15 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
         {
             OnDpiChanged(oldDpi, newDpi);
         }
+    }
+
+    private LRESULT ForwardDpiMessageToRegisteredClass(HWND window, MessageType message, WPARAM wParam, LPARAM lParam)
+    {
+        // Wrapped system controls retain DPI-specific behavior in their original class procedure. Framework-owned
+        // classes have fully processed the message here and follow the documented zero-result contract.
+        return _windowClass.IsSubclassed && !_priorWindowProcedure.IsNull
+            ? PInvoke.CallWindowProc(_priorWindowProcedure, window, (uint)message, wParam, lParam)
+            : default;
     }
 
     private void HandleDpiChangedAfterParent()

--- a/src/thirtytwo/WindowClass.cs
+++ b/src/thirtytwo/WindowClass.cs
@@ -14,7 +14,7 @@ public unsafe partial class WindowClass : DisposableBase.Finalizable
     private readonly WindowProcedure _windowProcedure;
     private readonly string _className;
     private readonly WindowClassInfo? _windowClass;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     [ThreadStatic]
     private static WindowProcedure? t_initializeProcedure;
@@ -25,10 +25,13 @@ public unsafe partial class WindowClass : DisposableBase.Finalizable
     public ATOM Atom { get; private set; }
 
     /// <summary>
-    ///  The module instance that this class is registered with. This will be null when this class wraps an
-    ///  existing registered class (such as common control classes).
+    ///  The module instance that this class is registered with. This will be null when <see cref="IsSubclassed"/>
+    ///  is <see langword="true"/>.
     /// </summary>
     public HMODULE ModuleInstance { get; }
+
+    /// <summary>Gets whether this instance subclasses an existing registered window class.</summary>
+    public bool IsSubclassed => !_priorClassProcedure.IsNull;
 
     /// <summary>
     ///  Construct a new <see cref="WindowClass"/>.
@@ -162,7 +165,7 @@ public unsafe partial class WindowClass : DisposableBase.Finalizable
         }
     }
 
-    public bool IsRegistered => Atom.IsValid || ModuleInstance == HMODULE.Null;
+    public bool IsRegistered => Atom.IsValid || IsSubclassed;
 
     /// <summary>
     ///  Registers this <see cref="WindowClass"/> so that instances can be created.

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationHarnessTests.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/WinUIIntegrationHarnessTests.cs
@@ -9,12 +9,15 @@ namespace Windows.WinUI.IntegrationHarness;
 [DoNotParallelize]
 public class WinUIIntegrationHarnessTests
 {
+    // First Windows App SDK activation can be materially slower on a cold hosted runner than on a warm local machine.
+    private static readonly TimeSpan s_startupTimeout = TimeSpan.FromSeconds(30);
+
     [TestMethod]
-    [Timeout(30_000)]
+    [Timeout(45_000)]
     public void RunAsync_Startup_ReturnsStructuredResultAndExits()
     {
         WinUIIntegrationResult result = CreateRunner()
-            .RunAsync(WinUIIntegrationScenario.Startup, TimeSpan.FromSeconds(15))
+            .RunAsync(WinUIIntegrationScenario.Startup, s_startupTimeout)
             .GetAwaiter()
             .GetResult();
 
@@ -108,7 +111,7 @@ public class WinUIIntegrationHarnessTests
     }
 
     [TestMethod]
-    [Timeout(30_000)]
+    [Timeout(120_000)]
     public void RunAsync_RepeatedStartup_LeavesNoChildProcesses()
     {
         WinUIIntegrationRunner runner = CreateRunner();
@@ -116,7 +119,7 @@ public class WinUIIntegrationHarnessTests
         for (int iteration = 0; iteration < 3; iteration++)
         {
             WinUIIntegrationResult result = runner
-                .RunAsync(WinUIIntegrationScenario.Startup, TimeSpan.FromSeconds(15))
+                .RunAsync(WinUIIntegrationScenario.Startup, s_startupTimeout)
                 .GetAwaiter()
                 .GetResult();
 

--- a/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostControlIntegrationTests.cs
+++ b/src/thirtytwo_tests/WinUI/IntegrationHarness/XamlHostControlIntegrationTests.cs
@@ -65,13 +65,14 @@ public class XamlHostControlIntegrationTests
 
     [TestMethod]
     [Timeout(30_000)]
-    public void RunAsync_HostLayout_TracksZeroSizeVisibilityAndResizeStorm()
+    public void RunAsync_HostLayout_TracksSizeVisibilityResizeAndDpi()
         => AssertScenario(WinUIIntegrationScenario.HostLayout)
             .Events.Select(entry => entry.Event).Should().ContainInOrder(
                 "ready",
                 "host-zero-size",
                 "host-visibility-synchronized",
                 "host-resize-storm-completed",
+                "host-dpi-resynchronized",
                 "scenario-completed");
 
     [TestMethod]

--- a/src/thirtytwo_tests/WindowTests.cs
+++ b/src/thirtytwo_tests/WindowTests.cs
@@ -105,6 +105,50 @@ public class WindowTests
         action.Should().Throw<ArgumentNullException>();
     }
 
+    [STATestMethod]
+    public void DpiChanged_NullSuggestedBounds_DoesNotEscapeWindowProcedure()
+    {
+        using DpiTrackingWindow window = new(new Rectangle(40, 50, 320, 240));
+
+        LRESULT result = window.SendMessage(MessageType.DpiChanged);
+
+        result.Value.Should().Be(0);
+        window.DpiChangeCount.Should().Be(0);
+    }
+
+    [STATestMethod]
+    public void DpiChanged_RegisteredControl_ForwardsWithoutEscapingWindowProcedure()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using ButtonControl button = new(parentWindow: window);
+
+        Action action = () =>
+        {
+            _ = button.SendMessage(MessageType.DpiChangedBeforeParent);
+            _ = button.SendMessage(MessageType.DpiChanged);
+            _ = button.SendMessage(MessageType.DpiChangedAfterParent);
+        };
+
+        action.Should().NotThrow();
+    }
+
+    [STATestMethod]
+    public void IsSubclassed_FrameworkOwnedWindow_ReturnsFalse()
+    {
+        using WindowClassTrackingWindow window = new();
+
+        window.IsWindowClassSubclassed.Should().BeFalse();
+    }
+
+    [STATestMethod]
+    public void IsSubclassed_RegisteredControl_ReturnsTrue()
+    {
+        using Window window = new(Window.DefaultBounds);
+        using WindowClassTrackingButton button = new(window);
+
+        button.IsWindowClassSubclassed.Should().BeTrue();
+    }
+
     private sealed class DpiTrackingWindow(Rectangle bounds) : Window(bounds)
     {
         internal uint OldDpi { get; private set; }
@@ -120,6 +164,16 @@ public class WindowTests
             DpiChangeCount++;
             base.OnDpiChanged(oldDpi, newDpi);
         }
+    }
+
+    private sealed class WindowClassTrackingWindow : Window
+    {
+        internal bool IsWindowClassSubclassed => _windowClass.IsSubclassed;
+    }
+
+    private sealed class WindowClassTrackingButton(Window parentWindow) : ButtonControl(parentWindow: parentWindow)
+    {
+        internal bool IsWindowClassSubclassed => _windowClass.IsSubclassed;
     }
 
 }

--- a/src/thirtytwo_tests/WindowTests.cs
+++ b/src/thirtytwo_tests/WindowTests.cs
@@ -54,4 +54,72 @@ public class WindowTests
         checkBoxBrush.Value.Should().Be(labelBrush.Value);
     }
 
+    [STATestMethod]
+    public unsafe void OnDpiChanged_Message_UpdatesBoundsCachesAndCallback()
+    {
+        using DpiTrackingWindow window = new(new Rectangle(40, 50, 320, 240));
+        uint oldDpi = window.GetDpi();
+        ushort newDpi = checked((ushort)(oldDpi + 24));
+        Rectangle suggestedBounds = new(40, 50, 400, 300);
+        RECT suggestedRectangle = suggestedBounds;
+        nuint packedDpi = newDpi | ((nuint)newDpi << 16);
+
+        // SendMessage is synchronous, so the stack RECT remains valid until the window procedure returns.
+        LRESULT result = window.SendMessage(
+            MessageType.DpiChanged,
+            (WPARAM)packedDpi,
+            (LPARAM)(nint)(&suggestedRectangle));
+
+        result.Value.Should().Be(0);
+        window.GetWindowRectangle().Should().Be(suggestedBounds);
+        window.OldDpi.Should().Be(oldDpi);
+        window.NewDpi.Should().Be(newDpi);
+        window.DpiChangeCount.Should().Be(1);
+        window.PixelToHiMetric((int)newDpi).Should().Be(2540);
+    }
+
+    [STATestMethod]
+    public void OnDpiChanged_AfterParent_UsesCapturedDpiAndInvokesCallback()
+    {
+        using DpiTrackingWindow window = new(new Rectangle(40, 50, 320, 240));
+        uint newDpi = window.GetDpi();
+        uint oldDpi = newDpi == 96 ? 120u : newDpi - 24;
+        dynamic accessor = ((Window)window).TestAccessor.Dynamic;
+        accessor._lastDpi = oldDpi;
+
+        _ = window.SendMessage(MessageType.DpiChangedBeforeParent);
+        accessor._lastDpi = newDpi;
+        _ = window.SendMessage(MessageType.DpiChangedAfterParent);
+
+        window.OldDpi.Should().Be(oldDpi);
+        window.NewDpi.Should().Be(newDpi);
+        window.DpiChangeCount.Should().Be(1);
+        window.PixelToHiMetric((int)newDpi).Should().Be(2540);
+    }
+
+    [TestMethod]
+    public void DpiChanged_NullSuggestedBounds_Throws()
+    {
+        Action action = static () => _ = new Message.DpiChanged(default, default);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    private sealed class DpiTrackingWindow(Rectangle bounds) : Window(bounds)
+    {
+        internal uint OldDpi { get; private set; }
+
+        internal uint NewDpi { get; private set; }
+
+        internal int DpiChangeCount { get; private set; }
+
+        protected override void OnDpiChanged(uint oldDpi, uint newDpi)
+        {
+            OldDpi = oldDpi;
+            NewDpi = newDpi;
+            DpiChangeCount++;
+            base.OnDpiChanged(oldDpi, newDpi);
+        }
+    }
+
 }

--- a/thirtytwo.slnx
+++ b/thirtytwo.slnx
@@ -46,6 +46,9 @@
     <Project Path="src/samples/WinUI/ControlHost/ControlHost.csproj">
       <Platform Project="x64" />
     </Project>
+    <Project Path="src/samples/WinUI/DpiTesting/DpiTesting.csproj">
+      <Platform Project="x64" />
+    </Project>
     <Project Path="src/samples/WinUI/SampleWinUIClassLibraryA/SampleWinUIClassLibraryA.csproj">
       <Platform Project="x64" />
     </Project>


### PR DESCRIPTION
## Summary

Add the first WinUI layout/DPI milestone slice: explicit PMv2 transition hooks, XAML site-bridge resynchronization, focused integration evidence, and a dedicated two-monitor diagnostic sample.

## Changes

- Add `Window.OnDpiChanged` with top-level `WM_DPICHANGED` and PMv2 child before/after-parent handling.
- Keep per-HWND DPI/font caches current without recursively revisiting descendants.
- Forward DPI messages to subclassed registered controls while framework-owned classes retain zero-result handling.
- Resynchronize `DesktopChildSiteBridge` physical-pixel bounds after DPI transitions and emit host DPI telemetry.
- Add focused native and out-of-process tests for suggested bounds, pointer validation, child transition ordering, native forwarding, and bridge preservation/resizing.
- Add the `DpiTesting` WinUI sample with native/XAML logical-size rulers, live DPI/scale/bounds metrics, popup checks, and transition history.
- Add `Test-Dpi.ps1` to validate mixed-scale monitor prerequisites, guide the manual checklist, and retain JSON results.
- Keep startup scenarios bounded while allowing a slower first Windows App SDK activation on cold hosted runners.

## Validation

- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (450 passed, 1 manual test skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (450 passed, 1 manual test skipped)
- [x] Exact and repeated WinUI startup scenarios pass with the adjusted bounded watchdog
- [x] New and changed behavior has focused native and out-of-process tests
- [x] Native pointer lifetime, DPI packing, HWND ownership, and failure cleanup were reviewed
- [x] `./eng/verify-winui-package-isolation.ps1 -Configuration Release` passes
- [x] `Test-Dpi.ps1` parses and its monitor preflight detects `DISPLAY1` at 100% and `DISPLAY2` at 150%
- [x] Local 96-to-144 DPI movement remained responsive; XAML reported 1.500 scale and both pixel checks reported `MATCH`
- [x] Agent-file validation is not applicable because this commit does not change `.agents/`

## Related issues

None.