### PR TITLE
Add dark scrollbar support

### DIFF
--- a/src/samples/DarkMode/DarkModeWindow.cs
+++ b/src/samples/DarkMode/DarkModeWindow.cs
@@ -64,21 +64,48 @@ internal sealed class DarkModeWindow : MainWindow
                 staticStyle: StaticControl.Styles.Left | StaticControl.Styles.CenterImage,
                 parentWindow: this), ownedControls);
             _edit = Track(new EditControl(
-                text: "Editable text",
-                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.Border,
+                text: string.Join("\r\n",
+                [
+                    "Editable text with a deliberately long first line that keeps the horizontal scrollbar visible.",
+                    "Second line",
+                    "Third line",
+                    "Fourth line"
+                ]),
+                editStyle: EditControl.Styles.Multiline | EditControl.Styles.AutoHorizontalScroll
+                    | EditControl.Styles.AutoVerticalScroll | EditControl.Styles.WantReturn,
+                style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.Border
+                    | WindowStyles.HorizontalScroll | WindowStyles.VerticalScroll,
                 parentWindow: this), ownedControls);
+            _edit.SetSelection(0, 0);
             _comboBox = Track(new ComboBoxControl(
                 comboBoxStyle: ComboBoxControl.Styles.DropDownList,
                 style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop | WindowStyles.VerticalScroll,
                 parentWindow: this), ownedControls);
-            _comboBox.AddItems(["Combo box item", "Second item", "Third item"]);
+            for (int itemNumber = 1; itemNumber <= 40; itemNumber++)
+            {
+                _comboBox.AddItem($"Combo box item {itemNumber}");
+            }
+
             _comboBox.SelectedIndex = 0;
             _richEdit = Track(new RichEditControl(
                 default,
-                text: "Rich edit text\r\nSelection and scrollbars remain part of the compatibility review.",
-                editStyle: RichEditControl.Styles.Multiline | RichEditControl.Styles.AutoVerticalScroll,
+                text: string.Join("\r\n",
+                [
+                    "Rich edit text with a deliberately long first line that keeps the horizontal scrollbar visible.",
+                    "Second line",
+                    "Third line",
+                    "Fourth line",
+                    "Fifth line",
+                    "Sixth line",
+                    "Seventh line",
+                    "Eighth line",
+                    "Ninth line",
+                    "Tenth line"
+                ]),
+                editStyle: RichEditControl.Styles.Multiline | RichEditControl.Styles.AutoHorizontalScroll
+                    | RichEditControl.Styles.AutoVerticalScroll,
                 style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.TabStop
-                    | WindowStyles.Border | WindowStyles.VerticalScroll,
+                    | WindowStyles.Border | WindowStyles.HorizontalScroll | WindowStyles.VerticalScroll,
                 parentWindow: this), ownedControls);
             _disabledEdit = Track(new EditControl(
                 text: "Disabled edit text",
@@ -148,7 +175,7 @@ internal sealed class DarkModeWindow : MainWindow
 
         ILayoutHandler textControls = Layout.Horizontal(
             (.15f, Layout.Margin((20, 8, 10, 8), Layout.Fill(_staticLabel))),
-            (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _edit))),
+            (.15f, Layout.Margin((20, 8, 10, 8), Layout.Fill(_edit))),
             (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _comboBox))),
             (.4f, Layout.Margin((20, 8, 10, 8), Layout.Fill(_richEdit))),
             (.15f, Layout.Margin((20, 8, 10, 8), Layout.FixedPercent(1f, .55f, _disabledEdit))));

--- a/src/thirtytwo/Controls/EditControl.cs
+++ b/src/thirtytwo/Controls/EditControl.cs
@@ -11,6 +11,7 @@ namespace Windows;
 public partial class EditControl : EditBase
 {
     private static readonly WindowClass s_editClass = new("Edit");
+    private readonly bool _usesApplicationScrollBarTheme;
 
     public EditControl(
         Rectangle bounds = default,
@@ -28,5 +29,23 @@ public partial class EditControl : EditBase
             parentWindow,
             parameters)
     {
+        _usesApplicationScrollBarTheme = (style
+            & (WindowStyles.HorizontalScroll | WindowStyles.VerticalScroll)) != 0;
+        ApplyApplicationTheme();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnColorModeChanged()
+    {
+        ApplyApplicationTheme();
+        base.OnColorModeChanged();
+    }
+
+    private void ApplyApplicationTheme()
+    {
+        if (_usesApplicationScrollBarTheme)
+        {
+            ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+        }
     }
 }

--- a/src/thirtytwo/Controls/RichEditControl.cs
+++ b/src/thirtytwo/Controls/RichEditControl.cs
@@ -54,7 +54,9 @@ public partial class RichEditControl : EditBase
     private unsafe void ApplyApplicationColors()
     {
         ApplicationColorState state = Application.CurrentColorState;
-        ApplyApplicationDarkModeTheme("DarkMode_Explorer");
+        ApplyApplicationDarkModeTheme(
+            darkSubAppName: null,
+            darkSubIdList: "DarkMode_Explorer::ScrollBar");
 
         Color background = state.Palette.ControlBackground;
         this.SendMessage(

--- a/src/thirtytwo/Support/UndocumentedDarkMode.cs
+++ b/src/thirtytwo/Support/UndocumentedDarkMode.cs
@@ -90,8 +90,14 @@ internal static unsafe class UndocumentedDarkMode
     /// <summary>Applies or removes a private dark visual-style association for a window.</summary>
     /// <param name="window">The window whose visual-style association is updated.</param>
     /// <param name="state">The resolved application color state to apply.</param>
-    /// <param name="darkSubAppName">The private visual-style sub-app name used when dark mode is active.</param>
-    /// <param name="darkSubIdList">The private visual-style sub-ID list used when dark mode is active.</param>
+    /// <param name="darkSubAppName">
+    ///  The private visual-style sub-app name used when dark mode is active, or <see langword="null"/> when no
+    ///  sub-app override is required.
+    /// </param>
+    /// <param name="darkSubIdList">
+    ///  The private visual-style sub-ID list used when dark mode is active, or <see langword="null"/> when no sub-ID
+    ///  override is required.
+    /// </param>
     /// <remarks>
     ///  <para>
     ///   The private per-window opt-in is enabled only when the exports are supported, the application has not opted

--- a/src/thirtytwo/Support/UndocumentedDarkMode.cs
+++ b/src/thirtytwo/Support/UndocumentedDarkMode.cs
@@ -90,7 +90,8 @@ internal static unsafe class UndocumentedDarkMode
     /// <summary>Applies or removes a private dark visual-style association for a window.</summary>
     /// <param name="window">The window whose visual-style association is updated.</param>
     /// <param name="state">The resolved application color state to apply.</param>
-    /// <param name="darkThemeName">The private visual-style class name used when dark mode is active.</param>
+    /// <param name="darkSubAppName">The private visual-style sub-app name used when dark mode is active.</param>
+    /// <param name="darkSubIdList">The private visual-style sub-ID list used when dark mode is active.</param>
     /// <remarks>
     ///  <para>
     ///   The private per-window opt-in is enabled only when the exports are supported, the application has not opted
@@ -98,7 +99,11 @@ internal static unsafe class UndocumentedDarkMode
     ///   theme names to remove the prior association.
     ///  </para>
     /// </remarks>
-    internal static void ApplyWindowTheme(HWND window, ApplicationColorState state, string darkThemeName)
+    internal static void ApplyWindowTheme(
+        HWND window,
+        ApplicationColorState state,
+        string? darkSubAppName,
+        string? darkSubIdList)
     {
         ConfigureApplication(state);
 
@@ -111,7 +116,10 @@ internal static unsafe class UndocumentedDarkMode
                 useDarkTheme ? (byte)1 : (byte)0);
         }
 
-        _ = PInvoke.SetWindowTheme(window, useDarkTheme ? darkThemeName : null, null);
+        _ = PInvoke.SetWindowTheme(
+            window,
+            useDarkTheme ? darkSubAppName : null,
+            useDarkTheme ? darkSubIdList : null);
     }
 
     private static bool ShouldUseDarkTheme(ApplicationColorState state)

--- a/src/thirtytwo/Window.cs
+++ b/src/thirtytwo/Window.cs
@@ -612,6 +612,18 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     protected void ApplyApplicationDarkModeTheme(string darkThemeName)
         => ApplyApplicationDarkModeTheme(Handle, darkThemeName);
 
+    /// <summary>Applies the current application color state using private dark visual-style identifiers.</summary>
+    /// <param name="darkSubAppName">The private sub-app name used when dark mode is active, or <see langword="null"/>.</param>
+    /// <param name="darkSubIdList">The private sub-ID list used when dark mode is active, or <see langword="null"/>.</param>
+    /// <remarks>
+    ///  <para>
+    ///   Call this after the window handle is created and again from <see cref="OnColorModeChanged"/>. At least one
+    ///   identifier must be supplied. The framework removes both identifiers when private dark theming is inactive.
+    ///  </para>
+    /// </remarks>
+    protected void ApplyApplicationDarkModeTheme(string? darkSubAppName, string? darkSubIdList)
+        => ApplyApplicationDarkModeTheme(Handle, darkSubAppName, darkSubIdList);
+
     /// <summary>Applies the current application color state to an owned native window using a private dark theme class.</summary>
     /// <param name="window">The owned native window whose visual-style association is updated.</param>
     /// <param name="darkThemeName">The private visual-style class name used when dark mode is active.</param>
@@ -624,7 +636,41 @@ public unsafe partial class Window : ComponentBase, IHandle<HWND>, ILayoutHandle
     protected void ApplyApplicationDarkModeTheme(HWND window, string darkThemeName)
     {
         ArgumentException.ThrowIfNullOrEmpty(darkThemeName);
-        UndocumentedDarkMode.ApplyWindowTheme(window, Application.CurrentColorState, darkThemeName);
+        ApplyApplicationDarkModeTheme(window, darkThemeName, darkSubIdList: null);
+    }
+
+    /// <summary>Applies private dark visual-style identifiers to an owned native window.</summary>
+    /// <param name="window">The owned native window whose visual-style association is updated.</param>
+    /// <param name="darkSubAppName">The private sub-app name used when dark mode is active, or <see langword="null"/>.</param>
+    /// <param name="darkSubIdList">The private sub-ID list used when dark mode is active, or <see langword="null"/>.</param>
+    /// <remarks>
+    ///  <para>
+    ///   This overload supports controls that select a private theme through the sub-ID list and unwrapped child or
+    ///   popup windows owned by a derived control. The supplied handle must remain valid for the duration of the call.
+    ///  </para>
+    /// </remarks>
+    protected void ApplyApplicationDarkModeTheme(HWND window, string? darkSubAppName, string? darkSubIdList)
+    {
+        if (darkSubAppName is not null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(darkSubAppName);
+        }
+
+        if (darkSubIdList is not null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(darkSubIdList);
+        }
+
+        if (darkSubAppName is null && darkSubIdList is null)
+        {
+            throw new ArgumentException("A dark theme sub-app name or sub-ID list is required.");
+        }
+
+        UndocumentedDarkMode.ApplyWindowTheme(
+            window,
+            Application.CurrentColorState,
+            darkSubAppName,
+            darkSubIdList);
     }
 
     private Window GetBackgroundOwner()

--- a/src/thirtytwo_tests/ApplicationColorModeTests.cs
+++ b/src/thirtytwo_tests/ApplicationColorModeTests.cs
@@ -247,6 +247,46 @@ public class ApplicationColorModeTests
     }
 
     [STATestMethod]
+    public void ColorMode_EditScrollBarTheme_TracksEligibleStyles()
+    {
+        using MainWindow window = new(Window.DefaultBounds);
+        using EditControl plainEdit = new(parentWindow: window);
+        using EditControl verticalEdit = new(
+            style: WindowStyles.Child | WindowStyles.VerticalScroll,
+            parentWindow: window);
+        using EditControl horizontalEdit = new(
+            style: WindowStyles.Child | WindowStyles.HorizontalScroll,
+            parentWindow: window);
+
+        ((bool)plainEdit.TestAccessor.Dynamic._usesApplicationScrollBarTheme).Should().BeFalse();
+        ((bool)verticalEdit.TestAccessor.Dynamic._usesApplicationScrollBarTheme).Should().BeTrue();
+        ((bool)horizontalEdit.TestAccessor.Dynamic._usesApplicationScrollBarTheme).Should().BeTrue();
+    }
+
+    [STATestMethod]
+    public void ColorMode_EditScrollBarTheme_PreservesScrollPosition()
+    {
+        Application.ColorMode = ApplicationColorMode.Light;
+        using MainWindow window = new(Window.DefaultBounds);
+        using EditControl edit = new(
+            bounds: new(0, 0, 200, 60),
+            text: string.Join("\r\n", Enumerable.Range(1, 20).Select(lineNumber => $"Line {lineNumber}")),
+            editStyle: EditControl.Styles.Multiline | EditControl.Styles.AutoVerticalScroll,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.VerticalScroll,
+            parentWindow: window);
+
+        edit.SendMessage((MessageType)PInvoke.EM_LINESCROLL, default, (LPARAM)5);
+        int firstVisibleLine = (int)edit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE);
+        firstVisibleLine.Should().BeGreaterThan(0);
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+        ((int)edit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE)).Should().Be(firstVisibleLine);
+
+        Application.UseUndocumentedDarkModeApis = false;
+        ((int)edit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE)).Should().Be(firstVisibleLine);
+    }
+
+    [STATestMethod]
     public void ColorMode_Change_NotifiesRadioButton()
     {
         Application.ColorMode = ApplicationColorMode.Light;
@@ -310,11 +350,40 @@ public class ApplicationColorModeTests
     }
 
     [STATestMethod]
+    public void ApplyApplicationDarkModeTheme_RequiresAThemeIdentifier()
+    {
+        Application.ColorMode = ApplicationColorMode.Light;
+        using MainWindow window = new(Window.DefaultBounds);
+        using PublicColorControl control = new(window);
+
+        Action missingIdentifiers = () => control.ApplyNativeTheme(null, null);
+        Action emptySubAppName = () => control.ApplyNativeTheme(string.Empty, null);
+        Action emptySubIdList = () => control.ApplyNativeTheme(null, string.Empty);
+        Action subAppName = () => control.ApplyNativeTheme("DarkMode_Explorer", null);
+        Action subIdList = () => control.ApplyNativeTheme(null, "DarkMode_Explorer::ScrollBar");
+        Action bothIdentifiers = () => control.ApplyNativeTheme(
+            "DarkMode_Explorer",
+            "DarkMode_Explorer::ScrollBar");
+
+        missingIdentifiers.Should().Throw<ArgumentException>();
+        emptySubAppName.Should().Throw<ArgumentException>();
+        emptySubIdList.Should().Throw<ArgumentException>();
+        subAppName.Should().NotThrow();
+        subIdList.Should().NotThrow();
+        bothIdentifiers.Should().NotThrow();
+    }
+
+    [STATestMethod]
     public unsafe void ColorMode_RichEdit_UpdatesBackgroundAndTextColors()
     {
         Application.ColorMode = ApplicationColorMode.Dark;
         using MainWindow window = new(Window.DefaultBounds);
-        using RichEditControl richEdit = new(new(0, 0, 200, 100), text: "Rich text", parentWindow: window);
+        using RichEditControl richEdit = new(
+            new(0, 0, 200, 60),
+            text: string.Join("\r\n", Enumerable.Range(1, 20).Select(lineNumber => $"Line {lineNumber}")),
+            editStyle: RichEditControl.Styles.Multiline | RichEditControl.Styles.AutoVerticalScroll,
+            style: WindowStyles.Child | WindowStyles.Visible | WindowStyles.VerticalScroll,
+            parentWindow: window);
 
         ApplicationColorPalette palette = Application.CurrentColorState.Palette;
         COLORREF expectedBackground = (COLORREF)palette.ControlBackground;
@@ -330,6 +399,19 @@ public class ApplicationColorModeTests
         richEdit.SetSelection(0, -1);
         GetCharacterFormat(richEdit, PInvoke.SCF_SELECTION).Base.crTextColor
             .Should().Be((COLORREF)palette.ControlForeground);
+
+        richEdit.SendMessage((MessageType)PInvoke.EM_LINESCROLL, default, (LPARAM)5);
+        int firstVisibleLine = (int)richEdit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE);
+        firstVisibleLine.Should().BeGreaterThan(0);
+
+        Application.ColorMode = ApplicationColorMode.Light;
+        ((int)richEdit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE)).Should().Be(firstVisibleLine);
+
+        Application.ColorMode = ApplicationColorMode.Dark;
+        ((int)richEdit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE)).Should().Be(firstVisibleLine);
+
+        Application.UseUndocumentedDarkModeApis = false;
+        ((int)richEdit.SendMessage((MessageType)PInvoke.EM_GETFIRSTVISIBLELINE)).Should().Be(firstVisibleLine);
 
         static CHARFORMAT2W GetCharacterFormat(RichEditControl richEdit, uint scope)
         {
@@ -401,6 +483,9 @@ public class ApplicationColorModeTests
             ApplyApplicationDarkModeTheme("DarkMode_Explorer");
             ApplyApplicationDarkModeTheme(Handle, "DarkMode_Explorer");
         }
+
+        internal void ApplyNativeTheme(string? darkSubAppName, string? darkSubIdList)
+            => ApplyApplicationDarkModeTheme(darkSubAppName, darkSubIdList);
 
         protected override void OnColorModeChanged()
         {


### PR DESCRIPTION
## Summary

Add dark scrollbar theming for the current native control wrappers while preserving Light, High Contrast, and undocumented-API opt-out behavior.

## Changes

- Extend the guarded UxTheme helper to accept independent sub-app and sub-ID values and reset both when private dark theming is inactive.
- Apply `DarkMode_Explorer` to scrolled `EditControl` instances and the `DarkMode_Explorer::ScrollBar` sub-ID to `RichEditControl`.
- Expand the DarkMode sample with forced Edit, RichEdit, and ComboBox overflow for visual compatibility checks.
- Add focused coverage for identifier validation, Edit scrollbar-style eligibility, and Edit/RichEdit scroll-position preservation across mode and opt-out changes.

## Validation

- [x] `dotnet restore` passes
- [x] `dotnet build --configuration Debug --no-restore` passes
- [x] `dotnet test --configuration Debug --no-build --report-trx` passes (467 passed, 1 manual test skipped)
- [x] `dotnet build --configuration Release --no-restore` passes
- [x] `dotnet test --configuration Release --no-build --report-trx` passes (467 passed, 1 manual test skipped)
- [x] New and changed behavior has focused tests
- [x] Native ownership, ABI arguments, failure behavior, and handle lifetime were reviewed
- [x] `./eng/verify-winui-package-isolation.ps1 -Configuration Release` passes
- [x] Dark and Light Edit, RichEdit, and ComboBox popup scrollbar captures verified on Windows 11 build 26200
- [x] Agent-file validation is not applicable because `.agents/` did not change

Windows 10 and High Contrast visual compatibility remain platform-matrix checks; the implementation resets private theme identifiers whenever High Contrast is active.

## Related issues

None.